### PR TITLE
Add multiple build targets, for umd and es5.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-tsconfig.json
-src

--- a/package.json
+++ b/package.json
@@ -1,10 +1,35 @@
 {
   "name": "@bitwarden/jslib",
   "version": "0.0.5",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "description": "",
+  "keywords": [],
+  "main": "dist/index.umd.js",
+  "module": "dist/index.es5.js",
+  "typings": "dist/types/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "license": "GPL-3.0",
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "scripts": {
+    "lint": "tslint 'src/**/*.ts'",
+    "prebuild": "rimraf dist",
+    "build": "tsc && tsc --module commonjs --outDir dist/lib && rollup -c rollup.config.ts && typedoc --out dist/docs --target es6 --theme minimal --mode file src",
+    "start": "concurrently \"tsc -w\" \"rollup -c rollup.config.ts -w\""
+  },
   "devDependencies": {
+    "@types/node": "^8.0.0",
+    "concurrently": "^3.5.1",
+    "lodash.camelcase": "^4.3.0",
+    "rimraf": "^2.6.2",
+    "rollup": "^0.53.0",
+    "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
     "tslint": "^5.8.0",
-    "typescript": "^2.5.3"
+    "typedoc": "^0.9.0",
+    "typescript": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@types/node": "^8.0.0",
     "concurrently": "^3.5.1",
-    "lodash.camelcase": "^4.3.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.53.0",
     "rollup-plugin-commonjs": "^8.2.6",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,35 @@
+// Based upon https://github.com/alexjoverm/typescript-library-starter/blob/master/rollup.config.ts
+
+import camelCase from 'lodash.camelcase';
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+import sourceMaps from 'rollup-plugin-sourcemaps';
+
+const pkg = require('./package.json');
+
+const libraryName = 'index';
+
+export default {
+  input: `dist/es/${libraryName}.js`,
+  output: [
+    { file: pkg.main, name: camelCase(libraryName), format: 'umd' },
+    { file: pkg.module, format: 'es' },
+  ],
+  sourcemap: true,
+  // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
+  external: [],
+  watch: {
+    include: 'dist/es/**',
+  },
+  plugins: [
+    // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
+    commonjs(),
+    // Allow node_modules resolution, so you can use 'external' to control
+    // which external modules to include in the bundle
+    // https://github.com/rollup/rollup-plugin-node-resolve#usage
+    resolve(),
+
+    // Resolve source maps to the original source
+    sourceMaps(),
+  ],
+};

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,6 +1,5 @@
 // Based upon https://github.com/alexjoverm/typescript-library-starter/blob/master/rollup.config.ts
 
-import camelCase from 'lodash.camelcase';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 import sourceMaps from 'rollup-plugin-sourcemaps';
@@ -12,7 +11,7 @@ const libraryName = 'index';
 export default {
   input: `dist/es/${libraryName}.js`,
   output: [
-    { file: pkg.main, name: camelCase(libraryName), format: 'umd' },
+    { file: pkg.main, name: libraryName, format: 'umd' },
     { file: pkg.module, format: 'es' },
   ],
   sourcemap: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,22 @@
 {
   "compilerOptions": {
-    "noImplicitAny": true,
-    "module": "es6",
-    "target": "ES2016",
+    "moduleResolution": "node",
+    "target": "es5",
+    "module":"es2015",
+    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "strict": true,
+    "sourceMap": true,
     "declaration": true,
-    "outDir": "./dist"
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "declarationDir": "dist/types",
+    "outDir": "dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   },
   "include": [
-    "src/**/*"
+    "src"
   ]
 }


### PR DESCRIPTION
Based upon https://github.com/alexjoverm/typescript-library-starter

VS Code and Visual Studio uses the commonjs library for their IntelliSense, while webpack prefers the es5 version.

As an added bonus, documentation gets generated using typedoc.