### PR TITLE
Mix entropy with RNG for making floor on entropy.

### DIFF
--- a/src/abstractions/crypto.service.ts
+++ b/src/abstractions/crypto.service.ts
@@ -24,9 +24,9 @@ export abstract class CryptoService {
     toggleKey: () => Promise<any>;
     makeKey: (password: string, salt: string) => SymmetricCryptoKey;
     hashPassword: (password: string, key: SymmetricCryptoKey) => Promise<string>;
-    makeEncKey: (key: SymmetricCryptoKey) => Promise<CipherString>;
+    makeEncKey: (key: SymmetricCryptoKey, mixin?: Uint8Array) => Promise<CipherString>;
     encrypt: (plainValue: string | Uint8Array, key?: SymmetricCryptoKey,
-        plainValueEncoding?: string) => Promise<CipherString>;
+        plainValueEncoding?: string, mixin?: Uint8Array) => Promise<CipherString>;
     encryptToBytes: (plainValue: ArrayBuffer, key?: SymmetricCryptoKey) => Promise<ArrayBuffer>;
     decrypt: (cipherString: CipherString, key?: SymmetricCryptoKey, outputEncoding?: string) => Promise<string>;
     decryptFromBytes: (encBuf: ArrayBuffer, key: SymmetricCryptoKey) => Promise<ArrayBuffer>;

--- a/src/angular/components/register.component.ts
+++ b/src/angular/components/register.component.ts
@@ -1,4 +1,5 @@
 import { Router } from '@angular/router';
+import * as crypto from 'crypto';
 
 import { ToasterService } from 'angular2-toaster';
 import { Angulartics2 } from 'angulartics2';
@@ -70,7 +71,8 @@ export class RegisterComponent {
     private async register() {
         this.email = this.email.toLowerCase();
         const key = this.cryptoService.makeKey(this.masterPassword, this.email);
-        const encKey = await this.cryptoService.makeEncKey(key);
+        const mixin = crypto.createHmac('sha512', this.email).update(this.masterPassword).digest();
+        const encKey = await this.cryptoService.makeEncKey(key, mixin);
         const hashedPassword = await this.cryptoService.hashPassword(this.masterPassword, key);
         const request = new RegisterRequest(this.email, hashedPassword, this.hint, encKey.encryptedString);
         await this.apiService.postRegister(request);


### PR DESCRIPTION
https://www.reddit.com/r/Bitwarden/comments/8caa9d/whitepaper/dxe07m8/

/u/kinoshitajona has a good idea.

## Scenario 1: CSPRNG is bad (like Android bug in 2013) but Master Password is good
* Master Password and email are XOR so entropy is at least as good as master password on initial registration.

## Scenario 2: Master Password is bad
* Nothing changes, as XOR weak entropy with strong entropy will keep the strongest entropy.
* Many more problems outside this PR.

Notes: Perhaps quietly doing this is less good. Maybe saying "your initial registration master password will help protect the RNG in case of bug"... is better?

Also, Maybe Instead of This we should make the user move mouse / tap screen / etc. instead to create the mixin.

I'm sorry this is my first Typescript edit. Thanks.