### PR TITLE
update cipher getLastUsedForUrl to prioritize exact domain match

### DIFF
--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -45,6 +45,7 @@ import { UserService } from '../abstractions/user.service';
 
 import { sequentialize } from '../misc/sequentialize';
 import { Utils } from '../misc/utils';
+import { LoginUriView } from '../models/view';
 
 const Keys = {
     ciphersPrefix: 'ciphers_',
@@ -393,7 +394,19 @@ export class CipherService implements CipherServiceAbstraction {
             return null;
         }
 
-        const sortedCiphers = ciphers.sort(this.sortCiphersByLastUsed);
+        const hostnameParts = url.split(/(http|https):\/\//i);
+        const hostname = hostnameParts[hostnameParts.length - 1].split('/')[0];
+        const uriMatch = (uri: LoginUriView) =>  uri.hostname === hostname;
+
+        const sortedCiphers = ciphers.sort((a, b) => {
+            const aIsExact = a.login.hasUris && a.login.uris.some(uriMatch);
+            const bIsExact = b.login.hasUris && b.login.uris.some(uriMatch);
+
+            if (aIsExact === bIsExact) {
+                return this.sortCiphersByLastUsed(a, b);
+            }
+            return aIsExact ? -1 : 1;
+        });
         return sortedCiphers[0];
     }
 


### PR DESCRIPTION
Currently, when using autofill and having multiple logins for different subdomains for the same base domain it defaults to the last used instead of the one that matches the current subdomain.

For example, if you have two logins app.domain.com and mail.domain.com and you last used mail.domain.com then visit app.domain.com it will autofill mail.domain.com's login details instead of app.domain.com's

This just adds a small check to see if there is an exact match and prioritizes it over the last used one. By the way, super awesome service it works great!