### PR TITLE
Remove artificial limit on name length

### DIFF
--- a/src/importers/passmanJsonImporter.ts
+++ b/src/importers/passmanJsonImporter.ts
@@ -20,9 +20,6 @@ export class PassmanJsonImporter extends BaseImporter implements Importer {
 
             const cipher = this.initLoginCipher();
             cipher.name = credential.label;
-            if (cipher.name != null && cipher.name.length > 30) {
-                cipher.name = cipher.name.substring(0, 30);
-            }
 
             cipher.login.username = this.getValueOrDefault(credential.username);
             if (this.isNullOrWhitespace(cipher.login.username)) {


### PR DESCRIPTION
When importing my real data I noticed some names being cut off. The limit was copied from `gnomeJsonImporter.ts` assuming it's some internal limit.

After testing with a 200 character name that still was imported fine I think this limit on the name should be removed.