### PR TITLE
Add support for Steam TOTP

### DIFF
--- a/src/services/totp.service.ts
+++ b/src/services/totp.service.ts
@@ -48,6 +48,8 @@ export class TotpService implements TotpServiceAbstraction {
                     alg = algParam;
                 }
             }
+        } else if(key.toLowerCase().indexOf('steam://') === 0) {
+            keyB32 = key.substr('steam://'.length);
         }
 
         const epoch = Math.round(new Date().getTime() / 1000.0);
@@ -71,6 +73,20 @@ export class TotpService implements TotpServiceAbstraction {
         /* tslint:enable */
         let otp = (binary % Math.pow(10, digits)).toString();
         otp = this.leftpad(otp, digits, '0');
+
+        if(key.toLowerCase().indexOf('steam://') === 0) {
+            const steamchars = [
+                '2', '3', '4', '5', '6', '7', '8', '9', 'B', 'C',
+                'D', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q',
+                'R', 'T', 'V', 'W', 'X', 'Y'];
+             otp = "";
+            let fullcode = binary & 0x7fffffff;
+            for (var i = 0; i < 5; i++) {
+                otp += steamchars[fullcode % steamchars.length];
+                fullcode = Math.trunc(fullcode / steamchars.length);
+            }
+        }
+
         return otp;
     }
 


### PR DESCRIPTION
Steam uses a different format for printing their TOTP codes.
This pr allows to use this format by prefixing the OTP key with steam://