### PR TITLE
Close to tray

### DIFF
--- a/src/electron/baseMenu.ts
+++ b/src/electron/baseMenu.ts
@@ -93,7 +93,7 @@ export class BaseMenu {
                 },
                 {
                     label: this.i18nService.t('close'),
-                    role: 'close',
+                    role: 'quit',
                 },
             ],
         };

--- a/src/electron/electronConstants.ts
+++ b/src/electron/electronConstants.ts
@@ -1,4 +1,5 @@
 export class ElectronConstants {
     static readonly enableMinimizeToTrayKey: string = 'enableMinimizeToTray';
+    static readonly enableCloseToTrayKey: string = 'enableCloseToTray';
     static readonly enableTrayKey: string = 'enableTray';
 }

--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -68,6 +68,17 @@ export class TrayMain {
             });
         }
 
+        if (process.platform === 'win32') {
+            this.windowMain.win.on('close', async (e: Event) => {
+                if (await this.storageService.get<boolean>(ElectronConstants.enableCloseToTrayKey)) {
+                    if(!this.windowMain.isQuitting){
+                        e.preventDefault();
+                        this.hideToTray();
+                    }
+                }
+            });
+        }
+
         this.windowMain.win.on('show', async (e: Event) => {
             const enableTray = await this.storageService.get<boolean>(ElectronConstants.enableTrayKey);
             if (!enableTray) {
@@ -124,6 +135,7 @@ export class TrayMain {
     }
 
     private closeWindow() {
+        this.windowMain.quit();
         if (this.windowMain.win != null) {
             this.windowMain.win.close();
         }

--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -135,7 +135,7 @@ export class TrayMain {
     }
 
     private closeWindow() {
-        this.windowMain.quit();
+        this.windowMain.isQuitting = true;
         if (this.windowMain.win != null) {
             this.windowMain.win.close();
         }

--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -59,7 +59,7 @@ export class TrayMain {
             this.showTray();
         }
 
-        if (process.platform === 'win32') {
+        if (process.platform === 'win32' || process.platform === 'linux') {
             this.windowMain.win.on('minimize', async (e: Event) => {
                 if (await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey)) {
                     e.preventDefault();
@@ -68,7 +68,7 @@ export class TrayMain {
             });
         }
 
-        if (process.platform === 'win32') {
+        if (process.platform === 'win32' || process.platform === 'linux') {
             this.windowMain.win.on('close', async (e: Event) => {
                 if (await this.storageService.get<boolean>(ElectronConstants.enableCloseToTrayKey)) {
                     if(!this.windowMain.isQuitting){

--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -59,7 +59,7 @@ export class TrayMain {
             this.showTray();
         }
 
-        if (process.platform === 'win32' || process.platform === 'linux') {
+        if (process.platform === 'win32') {
             this.windowMain.win.on('minimize', async (e: Event) => {
                 if (await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey)) {
                     e.preventDefault();
@@ -68,7 +68,7 @@ export class TrayMain {
             });
         }
 
-        if (process.platform === 'win32' || process.platform === 'linux') {
+        if (process.platform === 'win32') {
             this.windowMain.win.on('close', async (e: Event) => {
                 if (await this.storageService.get<boolean>(ElectronConstants.enableCloseToTrayKey)) {
                     if(!this.windowMain.isQuitting){

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -13,6 +13,7 @@ const Keys = {
 
 export class WindowMain {
     win: BrowserWindow;
+    isQuitting: boolean = false;
 
     private windowStateChangeTimer: NodeJS.Timer;
     private windowStates: { [key: string]: any; } = {};
@@ -38,6 +39,12 @@ export class WindowMain {
                         return;
                     }
                 }
+
+                // This method will be called when Electron is shutting
+                // down the application.
+                app.on('before-quit', () => {
+                    this.isQuitting = true;
+                });
 
                 // This method will be called when Electron has finished
                 // initialization and is ready to create browser windows.
@@ -220,5 +227,9 @@ export class WindowMain {
     private stateHasBounds(state: any): boolean {
         return state != null && Number.isInteger(state.x) && Number.isInteger(state.y) &&
             Number.isInteger(state.width) && state.width > 0 && Number.isInteger(state.height) && state.height > 0;
+    }
+
+    public quit() {
+        this.isQuitting = true;
     }
 }

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -228,8 +228,4 @@ export class WindowMain {
         return state != null && Number.isInteger(state.x) && Number.isInteger(state.y) &&
             Number.isInteger(state.width) && state.width > 0 && Number.isInteger(state.height) && state.height > 0;
     }
-
-    public quit() {
-        this.isQuitting = true;
-    }
 }


### PR DESCRIPTION
Allow the app to be minimized to the tray icon if the window gets closed. This is disabled by default.

Tested (and therefore enabled for linux) on Archlinux.

See desktop pull request: https://github.com/bitwarden/desktop/pull/168