### PR TITLE
Allow app to start minimized (as tray icon)

### DIFF
--- a/src/electron/electronConstants.ts
+++ b/src/electron/electronConstants.ts
@@ -1,4 +1,5 @@
 export class ElectronConstants {
     static readonly enableMinimizeToTrayKey: string = 'enableMinimizeToTray';
     static readonly enableTrayKey: string = 'enableTray';
+    static readonly enableStartMinimizedKey: string = 'enableStartMinimizedKey';
 }


### PR DESCRIPTION
If this setting is enabled, the main window will be hidden after startup. Disabled by default.

This is useful if Bitwarden gets started automatically after boot.

See desktop pull request: https://github.com/bitwarden/desktop/pull/169