### PR TITLE
feat(unpwnpassword): generate unpwned password and sync with server

### DIFF
--- a/src/angular/components/add-edit.component.ts
+++ b/src/angular/components/add-edit.component.ts
@@ -208,7 +208,16 @@ export class AddEditComponent implements OnInit {
                 this.collections.filter((c) => (c as any).checked).map((c) => c.id);
         }
 
+        const matches = await this.auditService.passwordLeaked(this.cipher.login.password);
+        if (matches > 0) {
+            this.cipher.pwned = true;
+        } else {
+            this.cipher.pwned = false;
+        }
+        this.cipher.pwnedCheckDate = new Date();
+
         const cipher = await this.encryptCipher();
+
         try {
             this.formPromise = this.saveCipher(cipher);
             await this.formPromise;
@@ -220,7 +229,6 @@ export class AddEditComponent implements OnInit {
             this.messagingService.send(this.editMode ? 'editedCipher' : 'addedCipher');
             return true;
         } catch { }
-
         return false;
     }
 
@@ -377,8 +385,10 @@ export class AddEditComponent implements OnInit {
         if (matches > 0) {
             this.platformUtilsService.showToast('warning', null,
                 this.i18nService.t('passwordExposed', matches.toString()));
+            this.cipher.pwned = true;
         } else {
             this.platformUtilsService.showToast('success', null, this.i18nService.t('passwordSafe'));
+            this.cipher.pwned = false;
         }
     }
 

--- a/src/angular/components/groupings.component.ts
+++ b/src/angular/components/groupings.component.ts
@@ -22,9 +22,11 @@ export class GroupingsComponent {
     @Input() showFolders = true;
     @Input() showCollections = true;
     @Input() showFavorites = true;
+    @Input() showPwnedPasswords = true;
 
     @Output() onAllClicked = new EventEmitter();
     @Output() onFavoritesClicked = new EventEmitter();
+    @Output() onPwnedPasswordsClicked = new EventEmitter();
     @Output() onCipherTypeClicked = new EventEmitter<CipherType>();
     @Output() onFolderClicked = new EventEmitter<FolderView>();
     @Output() onAddFolder = new EventEmitter();
@@ -39,6 +41,7 @@ export class GroupingsComponent {
     cipherType = CipherType;
     selectedAll: boolean = false;
     selectedFavorites: boolean = false;
+    selectedPwnedPasswords: boolean = false;
     selectedType: CipherType = null;
     selectedFolder: boolean = false;
     selectedFolderId: string = null;
@@ -101,6 +104,12 @@ export class GroupingsComponent {
         this.onFavoritesClicked.emit();
     }
 
+    selectPwnedPasswords() {
+        this.clearSelections();
+        this.selectedPwnedPasswords = true;
+        this.onPwnedPasswordsClicked.emit();
+    }
+
     selectType(type: CipherType) {
         this.clearSelections();
         this.selectedType = type;
@@ -131,6 +140,7 @@ export class GroupingsComponent {
     clearSelections() {
         this.selectedAll = false;
         this.selectedFavorites = false;
+        this.selectedPwnedPasswords = false;
         this.selectedType = null;
         this.selectedFolder = false;
         this.selectedFolderId = null;

--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -17,6 +17,7 @@ export class PasswordGeneratorComponent implements OnInit {
     password: string = '-';
     showOptions = false;
     avoidAmbiguous = false;
+    unpwnPassword = true;
 
     constructor(protected passwordGenerationService: PasswordGenerationService,
         protected platformUtilsService: PlatformUtilsService, protected i18nService: I18nService,
@@ -25,6 +26,7 @@ export class PasswordGeneratorComponent implements OnInit {
     async ngOnInit() {
         this.options = await this.passwordGenerationService.getOptions();
         this.avoidAmbiguous = !this.options.ambiguous;
+        this.unpwnPassword = this.options.unpwnPassword;
         this.options.type = this.options.type === 'passphrase' ? 'passphrase' : 'password';
         this.password = await this.passwordGenerationService.generatePassword(this.options);
         this.platformUtilsService.eventTrack('Generated Password');
@@ -78,6 +80,7 @@ export class PasswordGeneratorComponent implements OnInit {
         this.options.minLowercase = 0;
         this.options.minUppercase = 0;
         this.options.ambiguous = !this.avoidAmbiguous;
+        this.options.unpwnPassword = this.unpwnPassword;
 
         if (!this.options.uppercase && !this.options.lowercase && !this.options.number && !this.options.special) {
             this.options.lowercase = true;

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -20,6 +20,8 @@ import { TokenService } from '../../abstractions/token.service';
 import { TotpService } from '../../abstractions/totp.service';
 import { UserService } from '../../abstractions/user.service';
 
+import { Cipher } from '../../models/domain/cipher';
+
 import { AttachmentView } from '../../models/view/attachmentView';
 import { CipherView } from '../../models/view/cipherView';
 import { FieldView } from '../../models/view/fieldView';
@@ -118,8 +120,13 @@ export class ViewComponent implements OnDestroy, OnInit {
         if (matches > 0) {
             this.platformUtilsService.showToast('warning', null,
                 this.i18nService.t('passwordExposed', matches.toString()));
+            this.cipher.pwned = true;
         } else {
             this.platformUtilsService.showToast('success', null, this.i18nService.t('passwordSafe'));
+            this.cipher.pwned = false;
+            this.cipher.pwnedCheckDate = new Date();
+            const cipher = await this.encryptCipher();
+            this.saveCipher(cipher);
         }
     }
 
@@ -180,6 +187,14 @@ export class ViewComponent implements OnDestroy, OnInit {
         }
 
         a.downloading = false;
+    }
+
+    protected encryptCipher() {
+        return this.cipherService.encrypt(this.cipher);
+    }
+
+    protected saveCipher(cipher: Cipher) {
+        return this.cipherService.saveWithServer(cipher);
     }
 
     private cleanUp() {

--- a/src/models/data/cipherData.ts
+++ b/src/models/data/cipherData.ts
@@ -18,7 +18,9 @@ export class CipherData {
     edit: boolean;
     organizationUseTotp: boolean;
     favorite: boolean;
+    pwned: boolean;
     revisionDate: string;
+    pwnedCheckDate: string;
     type: CipherType;
     sizeName: string;
     name: string;
@@ -44,6 +46,7 @@ export class CipherData {
         this.edit = response.edit;
         this.organizationUseTotp = response.organizationUseTotp;
         this.favorite = response.favorite;
+        this.pwned = response.pwned;
         this.revisionDate = response.revisionDate;
         this.type = response.type;
         this.name = response.name;

--- a/src/models/domain/cipher.ts
+++ b/src/models/domain/cipher.ts
@@ -22,9 +22,11 @@ export class Cipher extends Domain {
     notes: CipherString;
     type: CipherType;
     favorite: boolean;
+    pwned: boolean;
     organizationUseTotp: boolean;
     edit: boolean;
     revisionDate: Date;
+    pwnedCheckDate: Date;
     localData: any;
     login: Login;
     identity: Identity;
@@ -52,9 +54,11 @@ export class Cipher extends Domain {
 
         this.type = obj.type;
         this.favorite = obj.favorite;
+        this.pwned = obj.pwned;
         this.organizationUseTotp = obj.organizationUseTotp;
         this.edit = obj.edit;
         this.revisionDate = obj.revisionDate != null ? new Date(obj.revisionDate) : null;
+        this.pwnedCheckDate = obj.pwnedCheckDate != null ? new Date(obj.pwnedCheckDate) : null;
         this.collectionIds = obj.collectionIds;
         this.localData = localData;
 
@@ -178,7 +182,9 @@ export class Cipher extends Domain {
         c.edit = this.edit;
         c.organizationUseTotp = this.organizationUseTotp;
         c.favorite = this.favorite;
+        c.pwned = this.pwned;
         c.revisionDate = this.revisionDate != null ? this.revisionDate.toISOString() : null;
+        c.pwnedCheckDate = this.pwnedCheckDate != null ? this.pwnedCheckDate.toISOString() : null;
         c.type = this.type;
         c.collectionIds = this.collectionIds;
 

--- a/src/models/request/cipherRequest.ts
+++ b/src/models/request/cipherRequest.ts
@@ -19,6 +19,7 @@ export class CipherRequest {
     name: string;
     notes: string;
     favorite: boolean;
+    pwned: boolean;
     login: LoginApi;
     secureNote: SecureNoteApi;
     card: CardApi;
@@ -28,6 +29,7 @@ export class CipherRequest {
     // Deprecated, remove at some point and rename attachments2 to attachments
     attachments: { [id: string]: string; };
     attachments2: { [id: string]: AttachmentRequest; };
+    pwnedCheckDate: string;
 
     constructor(cipher: Cipher) {
         this.type = cipher.type;
@@ -55,6 +57,8 @@ export class CipherRequest {
                         return uri;
                     });
                 }
+                this.pwned = cipher.pwned;
+                this.pwnedCheckDate = cipher.pwnedCheckDate.toISOString();
                 break;
             case CipherType.SecureNote:
                 this.secureNote = new SecureNoteApi();

--- a/src/models/response/cipherResponse.ts
+++ b/src/models/response/cipherResponse.ts
@@ -21,6 +21,7 @@ export class CipherResponse extends BaseResponse {
     identity: IdentityApi;
     secureNote: SecureNoteApi;
     favorite: boolean;
+    pwned: boolean;
     edit: boolean;
     organizationUseTotp: boolean;
     revisionDate: string;
@@ -37,6 +38,7 @@ export class CipherResponse extends BaseResponse {
         this.name = this.getResponseProperty('Name');
         this.notes = this.getResponseProperty('Notes');
         this.favorite = this.getResponseProperty('Favorite') || false;
+        this.pwned = this.getResponseProperty('Pwned') || false;
         this.edit = this.getResponseProperty('Edit') || true;
         this.organizationUseTotp = this.getResponseProperty('OrganizationUseTotp');
         this.revisionDate = this.getResponseProperty('RevisionDate');

--- a/src/models/view/cipherView.ts
+++ b/src/models/view/cipherView.ts
@@ -19,6 +19,7 @@ export class CipherView implements View {
     notes: string = null;
     type: CipherType = null;
     favorite = false;
+    pwned = false;
     organizationUseTotp = false;
     edit = false;
     localData: any;
@@ -31,6 +32,7 @@ export class CipherView implements View {
     passwordHistory: PasswordHistoryView[] = null;
     collectionIds: string[] = null;
     revisionDate: Date = null;
+    pwnedCheckDate: Date = null;
 
     constructor(c?: Cipher) {
         if (!c) {
@@ -41,12 +43,14 @@ export class CipherView implements View {
         this.organizationId = c.organizationId;
         this.folderId = c.folderId;
         this.favorite = c.favorite;
+        this.pwned = c.pwned;
         this.organizationUseTotp = c.organizationUseTotp;
         this.edit = c.edit;
         this.type = c.type;
         this.localData = c.localData;
         this.collectionIds = c.collectionIds;
         this.revisionDate = c.revisionDate;
+        this.pwnedCheckDate = c.pwnedCheckDate;
     }
 
     get subTitle(): string {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -137,6 +137,8 @@ export class CipherService implements CipherServiceAbstraction {
         cipher.organizationId = model.organizationId;
         cipher.type = model.type;
         cipher.collectionIds = model.collectionIds;
+        cipher.pwned = model.pwned;
+        cipher.pwnedCheckDate = model.pwnedCheckDate;
 
         if (key == null && cipher.organizationId != null) {
             key = await this.cryptoService.getOrgKey(cipher.organizationId);


### PR DESCRIPTION
This pull request is a followup to [452](https://github.com/bitwarden/server/pull/452) on the server

With this pull request the process of generating a password changes a little.
By default the new password is validated against [haveibeenpwned](https://haveibeenpwned.com/) in order to only generate passwords, that are not currently exposed. 
Submitting the new cipher, independent of the previous result, also forces a check against haveibeenpwned and afterwards includes the information pwned and the pwnedCheckDate to the storing process in the database. 
There is also a new group _pwnedPasswords_ that gives a direct overview over all pwned passwords