### PR TITLE
1password 1pif importer: create hidden fields

### DIFF
--- a/spec/common/importers/onepassword1PifImporter.spec.ts
+++ b/spec/common/importers/onepassword1PifImporter.spec.ts
@@ -61,7 +61,7 @@ const TestData: string = `***aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee***\n` +
     typeName: 'webforms.WebForm',
 });
 
-fdescribe('1Password 1Pif Importer', () => {
+describe('1Password 1Pif Importer', () => {
     it('should parse data', async () => {
         const importer = new Importer();
         const result = importer.parse(TestData);

--- a/spec/common/importers/onepassword1PifImporter.spec.ts
+++ b/spec/common/importers/onepassword1PifImporter.spec.ts
@@ -1,0 +1,95 @@
+import { FieldType } from '../../../src/enums/fieldType';
+import { OnePassword1PifImporter as Importer } from '../../../src/importers/onepassword1PifImporter';
+
+import { Utils } from '../../../src/misc/utils';
+
+if (Utils.isNode) {
+    // Polyfills
+    // tslint:disable-next-line
+    const jsdom: any = require('jsdom');
+    (global as any).DOMParser = new jsdom.JSDOM().window.DOMParser;
+}
+
+const TestData: string = `***aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee***\n` +
+    JSON.stringify({
+    uuid: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    updatedAt: 1486071244,
+    securityLevel: 'SL5',
+    contentsHash: 'aaaaaaaa',
+    title: 'Imported Entry',
+    location: 'https://www.google.com',
+    secureContents: {
+        fields: [
+            {
+                value: 'user@test.net',
+                id: 'email-input',
+                name: 'email',
+                type: 'T',
+                designation: 'username',
+            },
+            {
+                value: 'myservicepassword',
+                id: 'password-input',
+                name: 'password',
+                type: 'P',
+                designation: 'password',
+            },
+        ],
+        sections: [
+            {
+                fields: [
+                    {
+                        k: 'concealed',
+                        n: 'AAAAAAAAAAAABBBBBBBBBBBCCCCCCCCC',
+                        v: 'console-password-123',
+                        t: 'console password',
+                    },
+                ],
+                title: 'Admin Console',
+                name: 'admin_console',
+            },
+        ],
+    },
+    URLs: [
+        {
+            label: 'website',
+            url: 'https://www.google.com',
+        },
+    ],
+    txTimestamp: 1508941334,
+    createdAt: 1390426636,
+    typeName: 'webforms.WebForm',
+});
+
+fdescribe('1Password 1Pif Importer', () => {
+    it('should parse data', async () => {
+        const importer = new Importer();
+        const result = importer.parse(TestData);
+        expect(result != null).toBe(true);
+
+        const cipher = result.ciphers.shift();
+        expect(cipher.login.username).toEqual('user@test.net');
+        expect(cipher.login.password).toEqual('myservicepassword');
+        expect(cipher.login.uris.length).toEqual(1);
+        const uriView = cipher.login.uris.shift();
+        expect(uriView.uri).toEqual('https://www.google.com');
+    });
+
+    it('should create concealed field as "hidden" type', async () => {
+        const importer = new Importer();
+        const result = importer.parse(TestData);
+        expect(result != null).toBe(true);
+
+        const ciphers = result.ciphers;
+        expect(ciphers.length).toEqual(1);
+
+        const cipher = ciphers.shift();
+        const fields = cipher.fields;
+        expect(fields.length).toEqual(1);
+
+        const field = fields.shift();
+        expect(field.name).toEqual('console password');
+        expect(field.value).toEqual('console-password-123');
+        expect(field.type).toEqual(FieldType.Hidden);
+    });
+});

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -302,7 +302,7 @@ export abstract class BaseImporter {
         }
     }
 
-    protected processKvp(cipher: CipherView, key: string, value: string) {
+    protected processKvp(cipher: CipherView, key: string, value: string, type: FieldType = FieldType.Text) {
         if (this.isNullOrWhitespace(value)) {
             return;
         }
@@ -319,7 +319,7 @@ export abstract class BaseImporter {
                 cipher.fields = [];
             }
             const field = new FieldView();
-            field.type = FieldType.Text;
+            field.type = type;
             field.name = key;
             field.value = value;
             cipher.fields.push(field);

--- a/src/importers/onepassword1PifImporter.ts
+++ b/src/importers/onepassword1PifImporter.ts
@@ -169,11 +169,7 @@ export class OnePassword1PifImporter extends BaseImporter implements Importer {
                 }
             }
 
-            let fieldType = FieldType.Text;
-            if (field.k === 'concealed') {
-              fieldType = FieldType.Hidden;
-            }
-
+            const fieldType = (field.k === 'concealed') ? FieldType.Hidden : FieldType.Text;
             const fieldName = this.isNullOrWhitespace(field[nameKey]) ? 'no_name' : field[nameKey];
             this.processKvp(cipher, fieldName, fieldValue, fieldType);
         });

--- a/src/importers/onepassword1PifImporter.ts
+++ b/src/importers/onepassword1PifImporter.ts
@@ -8,6 +8,7 @@ import { CipherView } from '../models/view/cipherView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
 import { CipherType } from '../enums/cipherType';
+import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
 export class OnePassword1PifImporter extends BaseImporter implements Importer {
@@ -168,8 +169,13 @@ export class OnePassword1PifImporter extends BaseImporter implements Importer {
                 }
             }
 
+            let fieldType = FieldType.Text;
+            if (field.k === 'concealed') {
+              fieldType = FieldType.Hidden;
+            }
+
             const fieldName = this.isNullOrWhitespace(field[nameKey]) ? 'no_name' : field[nameKey];
-            this.processKvp(cipher, fieldName, fieldValue);
+            this.processKvp(cipher, fieldName, fieldValue, fieldType);
         });
     }
 }


### PR DESCRIPTION
When I migrated my 1Password archive into Bitwarden I noticed that concealed fields in 1Password are imported as regular "text" fields in Bitwarden. While the content itself is imported correctly it can do better by setting the FieldType to 'hidden'.

This PR adds this feature and related specs.