### PR TITLE
Prettier UI on macOS

### DIFF
--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -94,6 +94,7 @@ export class WindowMain {
             y: this.windowStates[Keys.mainWindowSize].y,
             title: app.getName(),
             icon: process.platform === 'linux' ? path.join(__dirname, '/images/icon.png') : undefined,
+            titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : undefined,
             show: false,
         });
 


### PR DESCRIPTION
Main goal of this change is to remove ugly (at least in my opinion) title bar from application on macOS, which looks terrible when app is using dark and nord themes. This is a simple css change in desktop (also a PR), with additional change in jslib to allow electron to hide titlebar on 'darwin' platforms.

Application is draggable by most of the empty spaces.

I tested it as well as I could, to make sure important elements do not cause window to be dragged. If there are any left, let me know. I hope i didn't break anything (I shouldn't really, this is just CSS).

Here are screenshots after changes:

![bitwarden-macos-2](https://user-images.githubusercontent.com/802214/56075539-6fab9600-5dc4-11e9-9c7c-916a5d501741.png)
![bitwarden-macos-1](https://user-images.githubusercontent.com/802214/56075540-6fab9600-5dc4-11e9-9ce3-0645ae2d6645.png)
![bitwarden-macos-3](https://user-images.githubusercontent.com/802214/56075541-6fab9600-5dc4-11e9-8582-a255e1ac490e.png)
![bitwarden-macos-4](https://user-images.githubusercontent.com/802214/56075542-6fab9600-5dc4-11e9-9de7-56d9413127c0.png)
