### PR TITLE
MacOS: Closing with red button won't open window again through tray icon

### DIFF
--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -121,14 +121,17 @@ export class TrayMain {
     }
 
     private toggleWindow() {
-        if (this.windowMain.win == null) {
-            return;
-        }
-
-        if (this.windowMain.win.isVisible()) {
-            this.windowMain.win.hide();
+        if (this.windowMain.win === null) {
+            // On MacOS, closing the window via the red button destroys the BrowserWindow instance.
+            this.windowMain.recreateWindow().then(() => {
+                this.windowMain.win.show();
+            });
         } else {
-            this.windowMain.win.show();
+            if (this.windowMain.win.isVisible()) {
+                this.windowMain.win.hide();
+            } else {
+                this.windowMain.win.show();
+            }
         }
     }
 

--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -122,10 +122,12 @@ export class TrayMain {
 
     private toggleWindow() {
         if (this.windowMain.win === null) {
-            // On MacOS, closing the window via the red button destroys the BrowserWindow instance.
-            this.windowMain.recreateWindow().then(() => {
-                this.windowMain.win.show();
-            });
+            if (process.platform === 'darwin') {
+                // On MacOS, closing the window via the red button destroys the BrowserWindow instance.
+                this.windowMain.createWindow().then(() => {
+                    this.windowMain.win.show();
+                });
+            }
         } else {
             if (this.windowMain.win.isVisible()) {
                 this.windowMain.win.hide();

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -81,7 +81,13 @@ export class WindowMain {
         });
     }
 
-    private async createWindow() {
+    async recreateWindow(): Promise<void> {
+        if (this.win === null) {
+            await this.createWindow();
+        }
+    }
+
+    private async createWindow(): Promise<void> {
         this.windowStates[Keys.mainWindowSize] = await this.getWindowState(Keys.mainWindowSize, this.defaultWidth,
             this.defaultHeight);
 

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -81,13 +81,7 @@ export class WindowMain {
         });
     }
 
-    async recreateWindow(): Promise<void> {
-        if (this.win === null) {
-            await this.createWindow();
-        }
-    }
-
-    private async createWindow(): Promise<void> {
+    async createWindow(): Promise<void> {
         this.windowStates[Keys.mainWindowSize] = await this.getWindowState(Keys.mainWindowSize, this.defaultWidth,
             this.defaultHeight);
 


### PR DESCRIPTION
Fixed issue on MacOS where closing BW via the red button then reopening using tray icon wouldn't work.

See the issue on `bitwarden/desktop` here: [Issue 143](https://github.com/bitwarden/desktop/issues/143)

The issue was that when closing the window via the red circle, the `win` property in `windowMain` becomes null, and the window instance needs to be recreated.