### PR TITLE
add window option: always on top of other windows

### DIFF
--- a/src/electron/electronConstants.ts
+++ b/src/electron/electronConstants.ts
@@ -3,4 +3,5 @@ export class ElectronConstants {
     static readonly enableCloseToTrayKey: string = 'enableCloseToTray';
     static readonly enableTrayKey: string = 'enableTray';
     static readonly enableStartToTrayKey: string = 'enableStartToTrayKey';
+    static readonly enableAlwaysOnTopKey: string = 'enableAlwaysOnTopKey';
 }

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -154,11 +154,9 @@ export class WindowMain {
 
     }
 
-    async alwaysOnTop(){
-
-        this.enableAlwaysOnTop = this.win.isAlwaysOnTop() ? false : true;
-        this.win.setAlwaysOnTop(this.enableAlwaysOnTop ? true : false);
-
+    async toggleAlwaysOnTop(){
+        this.enableAlwaysOnTop = !this.win.isAlwaysOnTop();
+        this.win.setAlwaysOnTop(this.enableAlwaysOnTop);
         await this.storageService.save(ElectronConstants.enableAlwaysOnTopKey, this.enableAlwaysOnTop);
     }
 

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, screen } from 'electron';
-import { ElectronConstants } from 'jslib/electron/electronConstants';
+import { ElectronConstants } from './electronConstants';
 
 import * as path from 'path';
 import * as url from 'url';


### PR DESCRIPTION
Adds a checkbox option to the window menu which makes Bitwarden always stay on top of other windows. This is really useful when copying more than one thing to an other program because the window doesn't get minimized. This option is disabled by default.

See desktop pull request: [https://github.com/bitwarden/desktop/pull/257](https://github.com/bitwarden/desktop/pull/257)

![image](https://user-images.githubusercontent.com/6097749/58707123-48c91380-83b4-11e9-84d3-31a701f57bf9.png)
