### PR TITLE
support up to 256 char passwords

### DIFF
--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -91,8 +91,8 @@ export class PasswordGeneratorComponent implements OnInit {
 
         if (!this.options.length || this.options.length < 5) {
             this.options.length = 5;
-        } else if (this.options.length > 128) {
-            this.options.length = 128;
+        } else if (this.options.length > 256) {
+            this.options.length = 256;
         }
 
         if (!this.options.minNumber) {


### PR DESCRIPTION
MS accounts now support up to 256 character passwords, and it's possible for companies to set a policy to raise the minimum length to 256 also