### PR TITLE
Global history

### DIFF
--- a/src/models/view/passwordHistoryView.ts
+++ b/src/models/view/passwordHistoryView.ts
@@ -4,6 +4,7 @@ import { Password } from '../domain/password';
 
 export class PasswordHistoryView implements View {
     password: string = null;
+    type: string = null;
     lastUsedDate: Date = null;
 
     constructor(ph?: Password) {

--- a/src/models/view/passwordHistoryView.ts
+++ b/src/models/view/passwordHistoryView.ts
@@ -4,7 +4,6 @@ import { Password } from '../domain/password';
 
 export class PasswordHistoryView implements View {
     password: string = null;
-    type: string = null;
     lastUsedDate: Date = null;
 
     constructor(ph?: Password) {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -91,7 +91,6 @@ export class CipherService implements CipherServiceAbstraction {
         if (existingItem != null && existingItem !== '' && existingItem !== currentItem) {
             const ph = new PasswordHistoryView();
             ph.password = this.i18nService.t(type) + ": " + existingItem;
-            ph.type = type;
             ph.lastUsedDate = model.login.passwordRevisionDate = new Date();
 
             model.passwordHistory.splice(0, 0, ph);
@@ -123,7 +122,6 @@ export class CipherService implements CipherServiceAbstraction {
                         if (matchedField == null || matchedField.value !== ef.value) {
                             const ph = new PasswordHistoryView();
                             ph.password = ef.name + ': ' + ef.value;
-                            ph.type = "customFields";
                             ph.lastUsedDate = new Date();
                             model.passwordHistory.splice(0, 0, ph);
                         }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -87,19 +87,15 @@ export class CipherService implements CipherServiceAbstraction {
         this.decryptedCipherCache = null;
     }
 
-    addToEditHistory(model, existingItem, currentItem, type) {
+    addToEditHistory(model: CipherView, existingItem: string, currentItem: string, type: string) {
         if (existingItem != null && existingItem !== '' && existingItem !== currentItem) {
             const ph = new PasswordHistoryView();
-            ph.password = existingItem;
-            ph.type = this.i18nService.t(type);
+            ph.password = this.i18nService.t(type) + ": " + existingItem;
+            ph.type = type;
             ph.lastUsedDate = model.login.passwordRevisionDate = new Date();
 
             model.passwordHistory.splice(0, 0, ph);
-
-            return true;
         }
-
-        return false;
     }
 
     async encrypt(model: CipherView, key?: SymmetricCryptoKey, originalCipher: Cipher = null): Promise<Cipher> {
@@ -127,6 +123,7 @@ export class CipherService implements CipherServiceAbstraction {
                         if (matchedField == null || matchedField.value !== ef.value) {
                             const ph = new PasswordHistoryView();
                             ph.password = ef.name + ': ' + ef.value;
+                            ph.type = "customFields";
                             ph.lastUsedDate = new Date();
                             model.passwordHistory.splice(0, 0, ph);
                         }


### PR DESCRIPTION
This adds global edit history to notes and passwords.

Today I decided to try switching to Bitwarden from LastPass. It worked out well, but I was really missing this one feature.

This method only requires changing this library's code and does not require any server changes. It simply adds the item type to the saved item. I can prepare a client side PR as well to change the text to say "Edit History" instead of "Password History". 

![image](https://user-images.githubusercontent.com/12688112/71230358-5b0a9080-22b7-11ea-84c8-07d3eb41b81a.png)

Resolves https://github.com/bitwarden/server/issues/33
