### PR TITLE
Bugfix https://github.com/bitwarden/browser/issues/1023

### DIFF
--- a/spec/common/misc/utils.spec.ts
+++ b/spec/common/misc/utils.spec.ts
@@ -10,6 +10,10 @@ describe('Utils Service', () => {
             expect(Utils.getDomain('bitwarden')).toBeNull();
         });
 
+        it('should fail for data urls', () => {
+            expect(Utils.getDomain('data:image/jpeg;base64,AAA')).toBeNull();
+        });
+
         it('should handle urls without protocol', () => {
             expect(Utils.getDomain('bitwarden.com')).toBe('bitwarden.com');
             expect(Utils.getDomain('wrong://bitwarden.com')).toBe('bitwarden.com');

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -182,6 +182,10 @@ export class Utils {
             return null;
         }
 
+        if (uriString.startsWith('data:')) {
+            return null;
+        }
+
         let httpUrl = uriString.startsWith('http://') || uriString.startsWith('https://');
         if (!httpUrl && uriString.indexOf('://') < 0 && Utils.tldEndingRegex.test(uriString)) {
             uriString = 'http://' + uriString;


### PR DESCRIPTION
Resolves https://github.com/bitwarden/browser/issues/1023: high CPU usage issue with large data URLs.

The issue is caused by the regex used to determine whether the URL ends with a common TLD:

```
// Utils.getDomain
if (!httpUrl && uriString.indexOf('://') < 0 && Utils.tldEndingRegex.test(uriString)) {
...
}
````
