### PR TITLE
Lp import improvements

### DIFF
--- a/lastpass-export-examples.csv
+++ b/lastpass-export-examples.csv
@@ -1,0 +1,241 @@
+url,username,password,extra,name,grouping,fav
+http://password.com,frank,fr@nk,"my notes
+",test-import-password,Social,0
+http://sn,,,"some notes
+on multiple lines",test-import-note,Social,0
+http://sn,,,"NoteType:Address
+Language:en-US
+Title:mr
+First Name:Frank
+Middle Name:Ashby
+Last Name:Willowby
+Username:fwillow
+Gender:m
+Birthday:January,1,1980
+Company:Frank and Associates
+Address 1:123 Fake St
+Address 2:Apt #2
+Address 3:CO Frank
+City / Town:Franktown
+County:Mars
+State:CA
+Zip / Postal Code:90210
+Country:US
+Timezone:-08:00,1
+Email Address:frank@example.com
+Phone:{""num"":""15555551234"",""ext"":""5"",""cc3l"":""USA""}
+Evening Phone:{""num"":""2131234"",""ext"":""5"",""cc3l"":""DZA""}
+Mobile Phone:{""num"":""3751234"",""ext"":""5"",""cc3l"":""BLR""}
+Fax:{""num"":""531234"",""ext"":""5"",""cc3l"":""CUB""}
+Notes:some notes",test-import-address,Social,0
+http://sn,,,"NoteType:Credit Card
+Language:en-US
+Name on Card:Frank Willowby
+Type:Credit
+Number:4321123456789876
+Security Code:123
+Start Date:January,2019
+Expiration Date:March,2022
+Notes:some notes",test-import-payment-card,Social,0
+http://sn,,,"NoteType:Credit Card
+Language:en-US
+Name on Card:Frank Willowby
+Type:Credit
+Number:4321 1234 5678 9876
+Security Code:123
+Start Date:,
+Expiration Date:March,2022
+Notes:some notes",test-import-payment-card-spaces,Social,0
+http://sn,,,"NoteType:Bank Account
+Language:en-US
+Bank Name:Chase
+Account Type:Checking
+Routing Number:044000037
+Account Number:1234567890
+SWIFT Code:CHASUS33XXX
+IBAN Number:GB82WEST123456987654 32
+Pin:1234
+Branch Address:123 Fake St
+Branch Phone:555-555-1234
+Notes:some notes",test-import-bank-account,Social,0
+http://sn,,,"NoteType:Driver's License
+Language:en-US
+Number:A123-456-789-123
+Expiration Date:January,1,2024
+License Class:D
+Name:Frank Willowby
+Address:123 Fake St
+City / Town:Franktown
+State:California
+ZIP / Postal Code:90210
+Country:USA
+Date of Birth:January,1,1985
+Sex:M
+Height:5'10""
+Notes:some notes",test-import-drivers-license,Social,0
+http://sn,,,"NoteType:Passport
+Language:en-US
+Type:Diplomatic
+Name:Frank Willowby
+Country:USA
+Number:31195855
+Sex:M
+Nationality:USA
+Issuing Authority:United States Department of State
+Date of Birth:January,1,1985
+Issued Date:January,02,2015
+Expiration Date:January,3,2025
+Notes:some notes",test-import-passport,Social,0
+http://sn,,,"NoteType:Social Security
+Language:en-US
+Name:Frank Willowby
+Number:123-45-6789
+Notes:some notes",test-import-social-security-number,Social,0
+http://sn,,,"NoteType:Insurance
+Language:en-US
+Company:Gecko
+Policy Type:Auto
+Policy Number:123456789
+Expiration:January,2,2022
+Agent Name:Sally Sitwell
+Agent Phone:555-555-4321
+URL:gecko-insurance.com
+Notes:some notes",test-import-insurance-policy,Social,0
+http://sn,,,"NoteType:Health Insurance
+Language:en-US
+Company:Kaiser
+Company Phone:555-555-9876
+Policy Type:PPO
+Policy Number:12345678
+Group ID:9876543
+Member Name:Frank Willowby
+Member ID:159753-A
+Physician Name:Dr. House
+Physician Phone:555-555-6543
+Physician Address:124 Fake St
+Co-pay:$20
+Notes:some notes",test-import-health-insurance,Social,0
+http://sn,,fr@nk,"NoteType:Membership
+Language:en-US
+Organization:Ikea
+Membership Number:123456789
+Member Name:Frank Willowby
+Start Date:January,1,2018
+Expiration Date:January,2,2024
+Website:ikea.com
+Telephone:555-555-8523
+Password:fr@nk
+Notes:some notes",test-import-membership,Social,0
+http://sn,,swissarmy,"NoteType:Wi-Fi Password
+Language:en-US
+SSID:tell my wifi love her
+Password:swissarmy
+Connection Type:fast
+Connection Mode:automatic
+Authentication:yes
+Encryption:WPA2
+Use 802.1X:sure
+FIPS Mode:maybe
+Key Type:shared
+Protected:ok?
+Key Index:7
+Notes:some notes",test-import-wifi,Social,0
+http://sn,frank,fr@nk,"NoteType:Email Account
+Language:en-US
+Username:frank
+Password:fr@nk
+Server:example.com
+Port:443
+Type:IMAP
+SMTP Server:smtp.example.com
+SMTP Port:80
+Notes:some notes",test-import-email,Social,0
+http://sn,frank,fr@nk,"NoteType:Instant Messenger
+Language:en-US
+Type:AIM
+Username:frank
+Password:fr@nk
+Server:chat.aol.com
+Port:1024
+Notes:some notes",test-import-instant-messenger,Social,0
+http://sn,frank,fr@nk,"NoteType:Database
+Language:en-US
+Type:sqlite
+Hostname:sqlite.example.com
+Port:3306
+Database:users
+Username:frank
+Password:fr@nk
+SID:ORCL
+Alias:no
+Notes:some notes",test-import-database,Social,0
+http://sn,frank,fr@nk,"NoteType:Server
+Language:en-US
+Hostname:example.com
+Username:frank
+Password:fr@nk
+Notes:some notes",test-import-server,Social,0
+http://sn,,,"NoteType:SSH Key
+Language:en-US
+Bit Strength:1024
+Format:PEM
+Passphrase:fr@nk
+Private Key:-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEArWq88uJUJkhIxIEOvH4OYjnGCfC9LbPwJ/TXaXWNQfpVlITE
+CcPkGwhdwqaJd6hl6tSeti3alIg6IjozyWaj35msLu4EzCD6zfUGyLpjAvvrGVuj
+RtGgwtc0i+iRn4f4faoHlN5NLH5VKRrs0RtOhCA79tTl3ntbSdngUE6SDVw5bmOa
+ub+2kBeiZHqONCoyjfYiyWvnxy4rkv8I5GfyFyfhA2lGfUa5dDB152e1WAPiOvfC
+D/5U1mEI0JYRoK3XBIv/5vFQKOS7Mvw8txCJeeAGEUHlHUE02sfpkx0pdEqWuorB
+AbabmuAQkt4xZYpI8cmi+I23OybzL/m8JQ+qUwIDAQABAoIBAFOXuyL9VIDroSAP
+8fGMdhSFMuBByn9IWIB6NoggYQonyK8B3Jm0crVRMBkPO/6RDyfGfAbnTZEBpbww
+AByaPG4hXm100J0xXJSBA1co+WdL1gTwNmGB1RN2t16lqeSTn4W7u1HYYq0K7LQW
+xYb6ubtY6m7OK0w2fEe6HbW4WhDT01A/ChONk86D/cs5I5bzGbGDeKXOmDm//2nI
+Z0cs6L/nDDyRVz5qul725ie3uDkh/HGne/LQ/m4vbWsfkNYACd2l6L4vREZpphDq
+LYw6FgM/VGFW+of8gMdZEOBa0ATkHS0KBI49TjZ39VwTBV5wIu5i4PCe9tuNDLeF
+UIisY8ECgYEA4M28CH7CKEAJKcNwQFc8OBA1BMHopSWSAllEo40AGGPmujC9e+Om
+6dEe9YVdq3q/lTVs1sad3wP2YHSGQj+p3BvWtU4Y32s5BSAgo3YgfzxhgqVoPFsT
+4YshL5MYFa8NxilZ9jYVx/WOkLd8LyRmZJLr9vmpheJwnPcCAKMOFCECgYEAxXt2
+4/M+hPPMibvlYsLrbcJ0g044+XxS2tNAdf1VOp7X3m/TvEZic9mtGOU0ZXn2wt3i
+ZGytKqr+cAkKcA9lufxYTs1S+pn7tLEFeWMa9F/C7T+gSXX0XgiLLkI2XDHKvXtj
+8flfwFpd9L4eJVjpeG0+QXZIOCpihwipe+Dwr/MCgYEAr4k2eFOyfAd0oD3RmwwD
+I6vUGoDnjn0Fw/u8kxD4sBLiCSUh8GlU3mLCj+ixucLBclsjP5obkBbh/XM/mt9n
+XU4Hm879sQdioNPzaHBG89NMON27xNVBcu5W3XU4a0YjtUZ4zr5wx5DA39PGjnEX
+2xS2WEWez8J/OLHPyHuJ9MECgYAykCYkv0cmq3WXXnChFN9Kvxst831LA7YDKUu7
+6h1EYR9MaL2B21Oh7f4P/b+oq82unzk0FU9ROW7kKKxvfMHDGQVTR+cTGxIDdb+9
+EM75+vrh3ASiSn1DBlT8hx98A5OxaEJy1jLaAUlFPNhjH5zHpNDn2e0r1E5d3K3o
+dfOqWQKBgCo0HZyG7LNdf4p9uhu1hIn6iIt9EkaYpPgrXKO/NevkjzPrZsUn5reH
+HPqAcOB3NaEsSy4bXfrFXIG8lHmyoJJCXUxmreA126yuBUyv2c6rVv6ChWk7YAti
+02pUCRtEJ/s/2aa//TgFT3FKyN8KIcHwEH9j3pECBBMQS/+9YCk1
+-----END RSA PRIVATE KEY-----
+Public Key:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtarzy4lQmSEjEgQ68fg5iOcYJ8L0ts/An9NdpdY1B+lWUhMQJw+QbCF3Cpol3qGXq1J62LdqUiDoiOjPJZqPfmawu7gTMIPrN9QbIumMC++sZW6NG0aDC1zSL6JGfh/h9qgeU3k0sflUpGuzRG06EIDv21OXee1tJ2eBQTpINXDluY5q5v7aQF6Jkeo40KjKN9iLJa+fHLiuS/wjkZ/IXJ+EDaUZ9Rrl0MHXnZ7VYA+I698IP/lTWYQjQlhGgrdcEi//m8VAo5Lsy/Dy3EIl54AYRQeUdQTTax+mTHSl0Spa6isEBtpua4BCS3jFlikjxyaL4jbc7JvMv+bwlD6pT frank@frank-PC
+Hostname:home.example.com
+Date:January,3,1999
+Notes:some notes",test-import-ssh-key,Social,0
+http://sn,,,"NoteType:Software License
+Language:en-US
+License Key:1234567890
+Licensee:Frank
+Version:1.2.3
+Publisher:Squaresoft
+Support Email:support@example.com
+Website:example.com
+Price:$49.99
+Purchase Date:January,4,2020
+Order Number:9877654
+Number of Licenses:13
+Order Total:$649.87
+Notes:some notes",test-import-software-license,Social,0
+http://sn,,,"NoteType:Custom_1399315180831972306
+Language:en-US
+textfield:frank
+copytextfield:willowby
+monthdayyear:January,1,2020
+monthyear:January,2021
+passkey:fr@nk
+Notes:some notes",test-import-custom-type,Social,0
+http://sn,franco,fr@nc0,"NoteType:Server
+Language:es-ES
+Hostname:example.es
+Username:franco
+Password:fr@nc0
+Notes:unas notas",test-import-spanish-autofill,Social,0

--- a/spec/common/importers/lastpassCsvImporter.spec.ts
+++ b/spec/common/importers/lastpassCsvImporter.spec.ts
@@ -116,6 +116,22 @@ Start Date: ,`,
     },
 ];
 
+const Imports = [
+    {
+        title: 'should parse custom note type date',
+        csv: `url,username,password,extra,name,grouping,fav
+http://sn,,,"NoteType:Custom_1399315180831972306
+Language:en-US
+textfield:frank
+copytextfield:willowby
+monthdayyear:January,1,2020
+monthyear:January,2021
+passkey:fr@nk
+Notes:some notes",test-import-custom-type,Social,0`,
+        expected: {},
+    },
+];
+
 describe('Lastpass CSV Importer', () => {
     CipherData.forEach((data) => {
         it(data.title, async () => {
@@ -131,6 +147,14 @@ describe('Lastpass CSV Importer', () => {
                     expect(cipher[property]).toEqual(data.expected[property]);
                 }
             }
+        });
+    });
+    Imports.forEach((data) => {
+        it(data.title, async () => {
+            const importer = new Importer();
+            const result = importer.parse(data.csv);
+            expect(result != null).toBe(true);
+            expect(result.ciphers.length).toBeGreaterThan(0);
         });
     });
 });

--- a/spec/common/importers/lastpassCsvImporter.spec.ts
+++ b/spec/common/importers/lastpassCsvImporter.spec.ts
@@ -1,0 +1,136 @@
+import { LastPassCsvImporter as Importer } from '../../../src/importers/lastpassCsvImporter';
+import { CipherView } from '../../../src/models/view/cipherView';
+
+import { Utils } from '../../../src/misc/utils';
+
+if (Utils.isNode) {
+    // Polyfills
+    // tslint:disable-next-line
+    const jsdom: any = require('jsdom');
+    (global as any).DOMParser = new jsdom.JSDOM().window.DOMParser;
+}
+
+const CipherData = [
+    {
+        title: 'should parse expiration date',
+        csv: `url,username,password,extra,name,grouping,fav
+http://sn,,,"NoteType:Credit Card
+Name on Card:John Doe
+Type:
+Number:1234567812345678
+Security Code:123
+Start Date:October,2017
+Expiration Date:June,2020
+Notes:some text
+",Credit-card,,0`,
+        expected: Object.assign(new CipherView(), {
+                id: null,
+                organizationId: null,
+                folderId: null,
+                name: 'Credit-card',
+                notes: 'Start Date: October,2017\nsome text\n',
+                type: 3,
+                card: {
+                    cardholderName: 'John Doe',
+                    number: '1234567812345678',
+                    code: '123',
+                    expYear: '2020',
+                    expMonth: '6',
+                },
+        }),
+    },
+    {
+        title: 'should parse blank card note',
+        csv: `url,username,password,extra,name,grouping,fav
+http://sn,,,"NoteType:Credit Card
+Name on Card:
+Type:
+Number:
+Security Code:
+Start Date:,
+Expiration Date:,
+Notes:",empty,,0`,
+        expected: Object.assign(new CipherView(), {
+                id: null,
+                organizationId: null,
+                folderId: null,
+                name: 'empty',
+                notes: `Start Date: ,`,
+                type: 3,
+                card: {},
+        }),
+    },
+    {
+        title: 'should parse card expiration date w/ no exp year',
+        csv: `url,username,password,extra,name,grouping,fav
+http://sn,,,"NoteType:Credit Card
+Name on Card:John Doe
+Type:Visa
+Number:1234567887654321
+Security Code:321
+Start Date:,
+Expiration Date:January,
+Notes:",noyear,,0`,
+        expected: Object.assign(new CipherView(), {
+                id: null,
+                organizationId: null,
+                folderId: null,
+                name: 'noyear',
+                notes: `Type: Visa
+Start Date: ,`,
+                type: 3,
+                card: {
+                    cardholderName: 'John Doe',
+                    number: '1234567887654321',
+                    code: '321',
+                    expMonth: '1',
+                },
+        }),
+    },
+    {
+        title: 'should parse card expiration date w/ no month',
+        csv: `url,username,password,extra,name,grouping,fav
+http://sn,,,"NoteType:Credit Card
+Name on Card:John Doe
+Type:Mastercard
+Number:8765432112345678
+Security Code:987
+Start Date:,
+Expiration Date:,2020
+Notes:",nomonth,,0`,
+        expected: Object.assign(new CipherView(), {
+                id: null,
+                organizationId: null,
+                folderId: null,
+                name: 'nomonth',
+                notes: `Type: Mastercard
+Start Date: ,`,
+                type: 3,
+                card: {
+                    cardholderName: 'John Doe',
+                    number: '8765432112345678',
+                    code: '987',
+                    expYear: '2020',
+                },
+        }),
+    },
+];
+
+describe('Lastpass CSV Importer', () => {
+    CipherData.forEach((data) => {
+        it(data.title, async () => {
+            const importer = new Importer();
+            const result = importer.parse(data.csv);
+            expect(result != null).toBe(true);
+            expect(result.ciphers.length).toBeGreaterThan(0);
+
+            const cipher = result.ciphers.shift();
+            for (const property in data.expected) {
+                if (data.expected.hasOwnProperty(property)) {
+                    expect(cipher.hasOwnProperty(property)).toBe(true);
+                    expect(cipher[property]).toEqual(data.expected[property]);
+                }
+            }
+        });
+    });
+});

--- a/src/importers/lastpassCsvImporter.ts
+++ b/src/importers/lastpassCsvImporter.ts
@@ -181,13 +181,13 @@ export class LastPassCsvImporter extends BaseImporter implements Importer {
                     } else {
                         const [monthString, year] = mappedData[0].expMonth.split(',');
                         // Parse month name into number
-                        if (monthString) {
+                        if (!this.isNullOrWhitespace(monthString)) {
                             const month = new Date(Date.parse(monthString + '1, 2012')).getMonth() + 1;
                             mappedData[0].expMonth = month.toString();
                         } else {
                             delete mappedData[0].expMonth;
                         }
-                        if (year) {
+                        if (!this.isNullOrWhitespace(year)) {
                             mappedData[0].expYear = year;
                         }
                     }

--- a/src/importers/lastpassCsvImporter.ts
+++ b/src/importers/lastpassCsvImporter.ts
@@ -166,11 +166,23 @@ export class LastPassCsvImporter extends BaseImporter implements Importer {
             if (typeParts.length > 1 && typeParts[0] === 'NoteType' &&
                 (typeParts[1] === 'Credit Card' || typeParts[1] === 'Address')) {
                 if (typeParts[1] === 'Credit Card') {
-                    const mappedData = this.parseSecureNoteMapping<CardView>(extraParts, {
+                    let mappedData = this.parseSecureNoteMapping<CardView>(extraParts, {
                         'Number': 'number',
                         'Name on Card': 'cardholderName',
                         'Security Code': 'code',
+                        'Expiration Date': 'expMonth',
                     });
+
+                    // Split string 'January,2020' into two
+                    const tempExpDate = mappedData[0].expMonth.split(',');
+                    // Parse month name into number
+                    mappedData[0].expMonth = (
+                        new Date(
+                            Date.parse(tempExpDate[0] + '1, 2012')
+                        ).getMonth() + 1
+                    ).toString();
+                    mappedData[0].expYear = tempExpDate[1];
+
                     cipher.type = CipherType.Card;
                     cipher.card = mappedData[0];
                     cipher.notes = mappedData[1];

--- a/src/importers/lastpassCsvImporter.ts
+++ b/src/importers/lastpassCsvImporter.ts
@@ -175,11 +175,12 @@ export class LastPassCsvImporter extends BaseImporter implements Importer {
                         'Expiration Date': 'expMonth',
                     });
 
-                    if (mappedData[0].expMonth === ',') {
+                    const exp = mappedData[0].expMonth;
+                    if (exp === ',' || this.isNullOrWhitespace(exp)) {
                         // No expiration data
                         delete mappedData[0].expMonth;
                     } else {
-                        const [monthString, year] = mappedData[0].expMonth.split(',');
+                        const [monthString, year] = exp.split(',');
                         // Parse month name into number
                         if (!this.isNullOrWhitespace(monthString)) {
                             const month = new Date(Date.parse(monthString + '1, 2012')).getMonth() + 1;


### PR DESCRIPTION
Requesting feedback before digging into this task. My import experience was a little less than ideal once I found that it imported most of the fields as plain text in the 'notes' field.
I'm wondering about modifying the lastpass csv importer to read the remaining extra lines into custom fields or key value pairs, similar to https://github.com/bitwarden/jslib/blob/1859357ddbde2f55ae0ff033cdc9f4cf6cd0b4f6/src/importers/onepassword1PifImporter.ts#L245
maybe they'd all be text fields unless the keys contain certain keywords like `key` or `password`, in which case they'd be hidden.
I have some sample export data which I'd use as reference along the way and in the tests (see line 119). not planning on committing the csv itself
1. would this have any negative implications?
2. would this be worth merging if accomplished?
3. any other contribution tips, like will the commits be squashed it merge, or whether or not to force push, etc?