### PR TITLE
improve lastpass imports

### DIFF
--- a/spec/common/importers/lastpassCsvImporter.spec.ts
+++ b/spec/common/importers/lastpassCsvImporter.spec.ts
@@ -33,7 +33,7 @@ Notes:some text
             folderId: null,
             name: 'Credit-card',
             notes: 'some text\n',
-            type: 3,
+            type: 3, //card
             card: {
                 cardholderName: 'John Doe',
                 number: '1234567812345678',
@@ -67,7 +67,7 @@ Notes:",empty,,0`,
             folderId: null,
             name: 'empty',
             notes: null,
-            type: 3,
+            type: 3, //card
             card: {
                 expMonth: undefined,
             },
@@ -97,7 +97,7 @@ Notes:",noyear,,0`,
             folderId: null,
             name: 'noyear',
             notes: null,
-            type: 3,
+            type: 3, //card
             card: {
                 cardholderName: 'John Doe',
                 number: '1234567887654321',
@@ -135,7 +135,7 @@ Notes:",nomonth,,0`,
             folderId: null,
             name: 'nomonth',
             notes: null,
-            type: 3,
+            type: 3, //card
             card: {
                 cardholderName: 'John Doe',
                 number: '8765432112345678',
@@ -157,6 +157,97 @@ Notes:",nomonth,,0`,
             ],
         }),
     },
+    {
+        title: 'should parse ssh keypair with secret custom fields hidden',
+        csv: `url,username,password,extra,name,grouping,fav
+http://sn,,,"NoteType:SSH Key
+Language:en-US
+Bit Strength:1024
+Format:PEM
+Passphrase:fr@nk
+Private Key:-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEArWq88uJUJkhIxIEOvH4OYjnGCfC9LbPwJ/TXaXWNQfpVlITE
+CcPkGwhdwqaJd6hl6tSeti3alIg6IjozyWaj35msLu4EzCD6zfUGyLpjAvvrGVuj
+RtGgwtc0i+iRn4f4faoHlN5NLH5VKRrs0RtOhCA79tTl3ntbSdngUE6SDVw5bmOa
+ub+2kBeiZHqONCoyjfYiyWvnxy4rkv8I5GfyFyfhA2lGfUa5dDB152e1WAPiOvfC
+D/5U1mEI0JYRoK3XBIv/5vFQKOS7Mvw8txCJeeAGEUHlHUE02sfpkx0pdEqWuorB
+AbabmuAQkt4xZYpI8cmi+I23OybzL/m8JQ+qUwIDAQABAoIBAFOXuyL9VIDroSAP
+8fGMdhSFMuBByn9IWIB6NoggYQonyK8B3Jm0crVRMBkPO/6RDyfGfAbnTZEBpbww
+AByaPG4hXm100J0xXJSBA1co+WdL1gTwNmGB1RN2t16lqeSTn4W7u1HYYq0K7LQW
+xYb6ubtY6m7OK0w2fEe6HbW4WhDT01A/ChONk86D/cs5I5bzGbGDeKXOmDm//2nI
+Z0cs6L/nDDyRVz5qul725ie3uDkh/HGne/LQ/m4vbWsfkNYACd2l6L4vREZpphDq
+LYw6FgM/VGFW+of8gMdZEOBa0ATkHS0KBI49TjZ39VwTBV5wIu5i4PCe9tuNDLeF
+UIisY8ECgYEA4M28CH7CKEAJKcNwQFc8OBA1BMHopSWSAllEo40AGGPmujC9e+Om
+6dEe9YVdq3q/lTVs1sad3wP2YHSGQj+p3BvWtU4Y32s5BSAgo3YgfzxhgqVoPFsT
+4YshL5MYFa8NxilZ9jYVx/WOkLd8LyRmZJLr9vmpheJwnPcCAKMOFCECgYEAxXt2
+4/M+hPPMibvlYsLrbcJ0g044+XxS2tNAdf1VOp7X3m/TvEZic9mtGOU0ZXn2wt3i
+ZGytKqr+cAkKcA9lufxYTs1S+pn7tLEFeWMa9F/C7T+gSXX0XgiLLkI2XDHKvXtj
+8flfwFpd9L4eJVjpeG0+QXZIOCpihwipe+Dwr/MCgYEAr4k2eFOyfAd0oD3RmwwD
+I6vUGoDnjn0Fw/u8kxD4sBLiCSUh8GlU3mLCj+ixucLBclsjP5obkBbh/XM/mt9n
+XU4Hm879sQdioNPzaHBG89NMON27xNVBcu5W3XU4a0YjtUZ4zr5wx5DA39PGjnEX
+2xS2WEWez8J/OLHPyHuJ9MECgYAykCYkv0cmq3WXXnChFN9Kvxst831LA7YDKUu7
+6h1EYR9MaL2B21Oh7f4P/b+oq82unzk0FU9ROW7kKKxvfMHDGQVTR+cTGxIDdb+9
+EM75+vrh3ASiSn1DBlT8hx98A5OxaEJy1jLaAUlFPNhjH5zHpNDn2e0r1E5d3K3o
+dfOqWQKBgCo0HZyG7LNdf4p9uhu1hIn6iIt9EkaYpPgrXKO/NevkjzPrZsUn5reH
+HPqAcOB3NaEsSy4bXfrFXIG8lHmyoJJCXUxmreA126yuBUyv2c6rVv6ChWk7YAti
+02pUCRtEJ/s/2aa//TgFT3FKyN8KIcHwEH9j3pECBBMQS/+9YCk1
+-----END RSA PRIVATE KEY-----
+Public Key:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtarzy4lQmSEjEgQ68fg5iOcYJ8L0ts/An9NdpdY1B+lWUhMQJw+QbCF3Cpol3qGXq1J62LdqUiDoiOjPJZqPfmawu7gTMIPrN9QbIumMC++sZW6NG0aDC1zSL6JGfh/h9qgeU3k0sflUpGuzRG06EIDv21OXee1tJ2eBQTpINXDluY5q5v7aQF6Jkeo40KjKN9iLJa+fHLiuS/wjkZ/IXJ+EDaUZ9Rrl0MHXnZ7VYA+I698IP/lTWYQjQlhGgrdcEi//m8VAo5Lsy/Dy3EIl54AYRQeUdQTTax+mTHSl0Spa6isEBtpua4BCS3jFlikjxyaL4jbc7JvMv+bwlD6pT frank@frank-PC
+Hostname:home.example.com
+Date:January,3,1999
+Notes:some notes",test-import-ssh-key,Social,0`,
+        expected: Object.assign(new CipherView(), {
+            id: null,
+            organizationId: null,
+            folderId: null,
+            name: 'test-import-ssh-key',
+            notes: 'some notes',
+            type: 2, //secure note
+            fields: [
+                Object.assign(new FieldView(), {
+                    name: 'Language',
+                    value: 'en-US',
+                    type: FieldType.Text,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Bit Strength',
+                    value: '1024',
+                    type: FieldType.Text,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Format',
+                    value: 'PEM',
+                    type: FieldType.Text,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Passphrase',
+                    value: 'fr@nk',
+                    type: FieldType.Hidden,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Private Key',
+                    value: '-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEArWq88uJUJkhIxIEOvH4OYjnGCfC9LbPwJ/TXaXWNQfpVlITE\nCcPkGwhdwqaJd6hl6tSeti3alIg6IjozyWaj35msLu4EzCD6zfUGyLpjAvvrGVuj\nRtGgwtc0i+iRn4f4faoHlN5NLH5VKRrs0RtOhCA79tTl3ntbSdngUE6SDVw5bmOa\nub+2kBeiZHqONCoyjfYiyWvnxy4rkv8I5GfyFyfhA2lGfUa5dDB152e1WAPiOvfC\nD/5U1mEI0JYRoK3XBIv/5vFQKOS7Mvw8txCJeeAGEUHlHUE02sfpkx0pdEqWuorB\nAbabmuAQkt4xZYpI8cmi+I23OybzL/m8JQ+qUwIDAQABAoIBAFOXuyL9VIDroSAP\n8fGMdhSFMuBByn9IWIB6NoggYQonyK8B3Jm0crVRMBkPO/6RDyfGfAbnTZEBpbww\nAByaPG4hXm100J0xXJSBA1co+WdL1gTwNmGB1RN2t16lqeSTn4W7u1HYYq0K7LQW\nxYb6ubtY6m7OK0w2fEe6HbW4WhDT01A/ChONk86D/cs5I5bzGbGDeKXOmDm//2nI\nZ0cs6L/nDDyRVz5qul725ie3uDkh/HGne/LQ/m4vbWsfkNYACd2l6L4vREZpphDq\nLYw6FgM/VGFW+of8gMdZEOBa0ATkHS0KBI49TjZ39VwTBV5wIu5i4PCe9tuNDLeF\nUIisY8ECgYEA4M28CH7CKEAJKcNwQFc8OBA1BMHopSWSAllEo40AGGPmujC9e+Om\n6dEe9YVdq3q/lTVs1sad3wP2YHSGQj+p3BvWtU4Y32s5BSAgo3YgfzxhgqVoPFsT\n4YshL5MYFa8NxilZ9jYVx/WOkLd8LyRmZJLr9vmpheJwnPcCAKMOFCECgYEAxXt2\n4/M+hPPMibvlYsLrbcJ0g044+XxS2tNAdf1VOp7X3m/TvEZic9mtGOU0ZXn2wt3i\nZGytKqr+cAkKcA9lufxYTs1S+pn7tLEFeWMa9F/C7T+gSXX0XgiLLkI2XDHKvXtj\n8flfwFpd9L4eJVjpeG0+QXZIOCpihwipe+Dwr/MCgYEAr4k2eFOyfAd0oD3RmwwD\nI6vUGoDnjn0Fw/u8kxD4sBLiCSUh8GlU3mLCj+ixucLBclsjP5obkBbh/XM/mt9n\nXU4Hm879sQdioNPzaHBG89NMON27xNVBcu5W3XU4a0YjtUZ4zr5wx5DA39PGjnEX\n2xS2WEWez8J/OLHPyHuJ9MECgYAykCYkv0cmq3WXXnChFN9Kvxst831LA7YDKUu7\n6h1EYR9MaL2B21Oh7f4P/b+oq82unzk0FU9ROW7kKKxvfMHDGQVTR+cTGxIDdb+9\nEM75+vrh3ASiSn1DBlT8hx98A5OxaEJy1jLaAUlFPNhjH5zHpNDn2e0r1E5d3K3o\ndfOqWQKBgCo0HZyG7LNdf4p9uhu1hIn6iIt9EkaYpPgrXKO/NevkjzPrZsUn5reH\nHPqAcOB3NaEsSy4bXfrFXIG8lHmyoJJCXUxmreA126yuBUyv2c6rVv6ChWk7YAti\n02pUCRtEJ/s/2aa//TgFT3FKyN8KIcHwEH9j3pECBBMQS/+9YCk1\n-----END RSA PRIVATE KEY-----',
+                    type: FieldType.Text,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Hostname',
+                    value: 'home.example.com',
+                    type: FieldType.Text,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Date',
+                    value: 'January,3,1999',
+                    type: FieldType.Text,
+                }),
+                Object.assign(new FieldView(), {
+                    name: 'Public Key',
+                    value: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtarzy4lQmSEjEgQ68fg5iOcYJ8L0ts/An9NdpdY1B+lWUhMQJw+QbCF3Cpol3qGXq1J62LdqUiDoiOjPJZqPfmawu7gTMIPrN9QbIumMC++sZW6NG0aDC1zSL6JGfh/h9qgeU3k0sflUpGuzRG06EIDv21OXee1tJ2eBQTpINXDluY5q5v7aQF6Jkeo40KjKN9iLJa+fHLiuS/wjkZ/IXJ+EDaUZ9Rrl0MHXnZ7VYA+I698IP/lTWYQjQlhGgrdcEi//m8VAo5Lsy/Dy3EIl54AYRQeUdQTTax+mTHSl0Spa6isEBtpua4BCS3jFlikjxyaL4jbc7JvMv+bwlD6pT frank@frank-PC',
+                    type: FieldType.Text,
+                }),
+            ],
+        }),
+    },
+
 ];
 
 describe('Lastpass CSV Importer', () => {

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -302,7 +302,24 @@ export abstract class BaseImporter {
         }
     }
 
-    protected processKvp(cipher: CipherView, key: string, value: string, type: FieldType = FieldType.Text) {
+    protected getFieldTypeByKey(key: string) {
+        // Infer custom field type based on the field's name
+        const hiddenKeywords = [
+            'password',
+            'passphrase',
+            'secret',
+            'private',
+        ];
+        for (const hiddenKeyword of hiddenKeywords) {
+            const index = key.toLowerCase().indexOf(hiddenKeyword.toLowerCase());
+            if (index >= 0) {
+                return FieldType.Hidden;
+            }
+        }
+        return FieldType.Text;
+    }
+
+    protected processKvp(cipher: CipherView, key: string, value: string, type: FieldType = null) {
         if (this.isNullOrWhitespace(value)) {
             return;
         }
@@ -320,6 +337,9 @@ export abstract class BaseImporter {
             }
             const field = new FieldView();
             field.type = type;
+            if (type === null) {
+                field.type = this.getFieldTypeByKey(key);
+            }
             field.name = key;
             field.value = value;
             cipher.fields.push(field);

--- a/src/importers/lastpassCsvImporter.ts
+++ b/src/importers/lastpassCsvImporter.ts
@@ -225,7 +225,7 @@ export class LastPassCsvImporter extends BaseImporter implements Importer {
         if (!processedNote) {
             cipher.secureNote = new SecureNoteView();
             cipher.secureNote.type = SecureNoteType.Generic;
-            cipher.notes = this.getValueOrDefault(value.extra);
+            this.parseSecureNoteMapping(cipher, this.splitNewLine(value.extra), {});
         }
     }
 


### PR DESCRIPTION
* parse key-value pairs as custom fields for secure notes (previously only worked for all other types)
* infer field type from key name

tests currently do not pass because it does not handle multiline values. not sure if this is fixable, the only solution i've come up with so far is checking for `:`, which would work for lastpass' ssh key pair note type, _may_ be the only note type with a multiline field other than `notes`, but if this is not the case, then that logic would fail in other scenarios where `:` is a valid character. 

also not sure why the `public key` didn't get converted to a custom field, and shows up in `notes`