### PR TITLE
Enforce Password Generator Policy

### DIFF
--- a/src/abstractions/passwordGeneration.service.ts
+++ b/src/abstractions/passwordGeneration.service.ts
@@ -1,9 +1,11 @@
 import { GeneratedPasswordHistory } from '../models/domain/generatedPasswordHistory';
+import { PasswordGeneratorPolicyOptions } from '../models/domain/passwordGeneratorPolicyOptions';
 
 export abstract class PasswordGenerationService {
     generatePassword: (options: any) => Promise<string>;
     generatePassphrase: (options: any) => Promise<string>;
-    getOptions: () => any;
+    getOptions: () => Promise<[any, PasswordGeneratorPolicyOptions]>;
+    getPasswordGeneratorPolicyOptions: () => Promise<PasswordGeneratorPolicyOptions>;
     saveOptions: (options: any) => Promise<any>;
     getHistory: () => Promise<GeneratedPasswordHistory[]>;
     addHistory: (password: string) => Promise<any>;

--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -8,6 +8,9 @@ import {
 import { I18nService } from '../../abstractions/i18n.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
+import { PolicyService } from '../../abstractions/policy.service';
+import { PolicyType } from '../../enums/policyType';
+import { Policy } from '../../models/domain/policy';
 
 export class PasswordGeneratorComponent implements OnInit {
     @Input() showSelect: boolean = false;
@@ -17,15 +20,23 @@ export class PasswordGeneratorComponent implements OnInit {
     password: string = '-';
     showOptions = false;
     avoidAmbiguous = false;
+    enforcedMinLength = 0;
+    hasEnforcedUppercase = false;
+    hasEnforcedLowercase = false;
+    hasEnforcedNumbers = false;
+    enforcedNumberCount = 0;
+    hasEnforcedSpecial = false;
+    enforcedSpecialCount = 0;
 
     constructor(protected passwordGenerationService: PasswordGenerationService,
         protected platformUtilsService: PlatformUtilsService, protected i18nService: I18nService,
-        private win: Window) { }
+        protected policyService: PolicyService, private win: Window) { }
 
     async ngOnInit() {
         this.options = await this.passwordGenerationService.getOptions();
         this.avoidAmbiguous = !this.options.ambiguous;
         this.options.type = this.options.type === 'passphrase' ? 'passphrase' : 'password';
+        this.enforcePolicies(await this.policyService.getAll(PolicyType.PasswordGenerator));
         this.password = await this.passwordGenerationService.generatePassword(this.options);
         this.platformUtilsService.eventTrack('Generated Password');
         await this.passwordGenerationService.addHistory(this.password);
@@ -74,6 +85,55 @@ export class PasswordGeneratorComponent implements OnInit {
         this.showOptions = !this.showOptions;
     }
 
+    protected enforcePolicies(policies: Policy[]) {
+        if (policies == null || policies.length === 0) {
+            return;
+        }
+
+        policies.forEach((currentPolicy) => {
+            if (currentPolicy.enabled && currentPolicy.data != null) {
+                const currentPolicyData = currentPolicy.data;
+
+                if (currentPolicyData.minLength != null && currentPolicyData.minLength > 0
+                    && currentPolicyData.minLength > this.enforcedMinLength) {
+                    this.enforcedMinLength = currentPolicyData.minLength;
+                }
+
+                if (currentPolicyData.useUpper && !this.hasEnforcedUppercase) {
+                    this.options.uppercase = this.hasEnforcedUppercase = true;
+                }
+
+                if (currentPolicyData.useLower && !this.hasEnforcedLowercase) {
+                    this.options.lowercase = this.hasEnforcedLowercase = true;
+                }
+
+                if (currentPolicyData.useNumbers && !this.hasEnforcedNumbers) {
+                    this.options.number = this.hasEnforcedNumbers = true;
+                }
+
+                if (currentPolicyData.minNumbers != null && currentPolicyData.minNumbers > 0
+                    && currentPolicyData.minNumbers > this.enforcedNumberCount) {
+                    this.enforcedNumberCount = currentPolicyData.minNumbers;
+                }
+
+                if (currentPolicyData.useSpecial && !this.hasEnforcedSpecial) {
+                    this.options.special = this.hasEnforcedSpecial = true;
+                }
+
+                if (currentPolicyData.minSpecial != null && currentPolicyData.minSpecial > 0
+                    && currentPolicyData.minSpecial > this.enforcedSpecialCount) {
+                    this.enforcedSpecialCount = currentPolicyData.minSpecial;
+                }
+            }
+        });
+
+        if (this.enforcedMinLength > 0 || this.hasEnforcedUppercase || this.hasEnforcedLowercase
+            || this.hasEnforcedNumbers || this.enforcedNumberCount > 0 || this.hasEnforcedSpecial
+            || this.enforcedSpecialCount > 0) {
+            this.saveOptions(false);
+        }
+    }
+
     private normalizeOptions() {
         this.options.minLowercase = 0;
         this.options.minUppercase = 0;
@@ -95,6 +155,10 @@ export class PasswordGeneratorComponent implements OnInit {
             this.options.length = 128;
         }
 
+        if (this.options.length < this.enforcedMinLength) {
+            this.options.length = this.enforcedMinLength;
+        }
+
         if (!this.options.minNumber) {
             this.options.minNumber = 0;
         } else if (this.options.minNumber > this.options.length) {
@@ -103,12 +167,20 @@ export class PasswordGeneratorComponent implements OnInit {
             this.options.minNumber = 9;
         }
 
+        if (this.options.minNumber < this.enforcedNumberCount) {
+            this.options.minNumber = this.enforcedNumberCount;
+        }
+
         if (!this.options.minSpecial) {
             this.options.minSpecial = 0;
         } else if (this.options.minSpecial > this.options.length) {
             this.options.minSpecial = this.options.length;
         } else if (this.options.minSpecial > 9) {
             this.options.minSpecial = 9;
+        }
+
+        if (this.options.minSpecial < this.enforcedSpecialCount) {
+            this.options.minSpecial = this.enforcedSpecialCount;
         }
 
         if (this.options.minSpecial + this.options.minNumber > this.options.length) {

--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -8,9 +8,7 @@ import {
 import { I18nService } from '../../abstractions/i18n.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
-import { PolicyService } from '../../abstractions/policy.service';
-import { PolicyType } from '../../enums/policyType';
-import { Policy } from '../../models/domain/policy';
+import { PasswordGeneratorPolicyOptions } from '../../models/domain/passwordGeneratorPolicyOptions';
 
 export class PasswordGeneratorComponent implements OnInit {
     @Input() showSelect: boolean = false;
@@ -20,23 +18,18 @@ export class PasswordGeneratorComponent implements OnInit {
     password: string = '-';
     showOptions = false;
     avoidAmbiguous = false;
-    enforcedMinLength = 0;
-    hasEnforcedUppercase = false;
-    hasEnforcedLowercase = false;
-    hasEnforcedNumbers = false;
-    enforcedNumberCount = 0;
-    hasEnforcedSpecial = false;
-    enforcedSpecialCount = 0;
+    enforcedPolicyOptions: PasswordGeneratorPolicyOptions;
 
     constructor(protected passwordGenerationService: PasswordGenerationService,
         protected platformUtilsService: PlatformUtilsService, protected i18nService: I18nService,
-        protected policyService: PolicyService, private win: Window) { }
+        private win: Window) { }
 
     async ngOnInit() {
-        this.options = await this.passwordGenerationService.getOptions();
+        const optionsResponse = await this.passwordGenerationService.getOptions();
+        this.options = optionsResponse[0];
+        this.enforcedPolicyOptions = optionsResponse[1];
         this.avoidAmbiguous = !this.options.ambiguous;
         this.options.type = this.options.type === 'passphrase' ? 'passphrase' : 'password';
-        this.enforcePolicies(await this.policyService.getAll(PolicyType.PasswordGenerator));
         this.password = await this.passwordGenerationService.generatePassword(this.options);
         this.platformUtilsService.eventTrack('Generated Password');
         await this.passwordGenerationService.addHistory(this.password);
@@ -85,55 +78,6 @@ export class PasswordGeneratorComponent implements OnInit {
         this.showOptions = !this.showOptions;
     }
 
-    protected enforcePolicies(policies: Policy[]) {
-        if (policies == null || policies.length === 0) {
-            return;
-        }
-
-        policies.forEach((currentPolicy) => {
-            if (currentPolicy.enabled && currentPolicy.data != null) {
-                const currentPolicyData = currentPolicy.data;
-
-                if (currentPolicyData.minLength != null && currentPolicyData.minLength > 0
-                    && currentPolicyData.minLength > this.enforcedMinLength) {
-                    this.enforcedMinLength = currentPolicyData.minLength;
-                }
-
-                if (currentPolicyData.useUpper && !this.hasEnforcedUppercase) {
-                    this.options.uppercase = this.hasEnforcedUppercase = true;
-                }
-
-                if (currentPolicyData.useLower && !this.hasEnforcedLowercase) {
-                    this.options.lowercase = this.hasEnforcedLowercase = true;
-                }
-
-                if (currentPolicyData.useNumbers && !this.hasEnforcedNumbers) {
-                    this.options.number = this.hasEnforcedNumbers = true;
-                }
-
-                if (currentPolicyData.minNumbers != null && currentPolicyData.minNumbers > 0
-                    && currentPolicyData.minNumbers > this.enforcedNumberCount) {
-                    this.enforcedNumberCount = currentPolicyData.minNumbers;
-                }
-
-                if (currentPolicyData.useSpecial && !this.hasEnforcedSpecial) {
-                    this.options.special = this.hasEnforcedSpecial = true;
-                }
-
-                if (currentPolicyData.minSpecial != null && currentPolicyData.minSpecial > 0
-                    && currentPolicyData.minSpecial > this.enforcedSpecialCount) {
-                    this.enforcedSpecialCount = currentPolicyData.minSpecial;
-                }
-            }
-        });
-
-        if (this.enforcedMinLength > 0 || this.hasEnforcedUppercase || this.hasEnforcedLowercase
-            || this.hasEnforcedNumbers || this.enforcedNumberCount > 0 || this.hasEnforcedSpecial
-            || this.enforcedSpecialCount > 0) {
-            this.saveOptions(false);
-        }
-    }
-
     private normalizeOptions() {
         this.options.minLowercase = 0;
         this.options.minUppercase = 0;
@@ -155,8 +99,8 @@ export class PasswordGeneratorComponent implements OnInit {
             this.options.length = 128;
         }
 
-        if (this.options.length < this.enforcedMinLength) {
-            this.options.length = this.enforcedMinLength;
+        if (this.options.length < this.enforcedPolicyOptions.minLength) {
+            this.options.length = this.enforcedPolicyOptions.minLength;
         }
 
         if (!this.options.minNumber) {
@@ -167,8 +111,8 @@ export class PasswordGeneratorComponent implements OnInit {
             this.options.minNumber = 9;
         }
 
-        if (this.options.minNumber < this.enforcedNumberCount) {
-            this.options.minNumber = this.enforcedNumberCount;
+        if (this.options.minNumber < this.enforcedPolicyOptions.numberCount) {
+            this.options.minNumber = this.enforcedPolicyOptions.numberCountt;
         }
 
         if (!this.options.minSpecial) {
@@ -179,8 +123,8 @@ export class PasswordGeneratorComponent implements OnInit {
             this.options.minSpecial = 9;
         }
 
-        if (this.options.minSpecial < this.enforcedSpecialCount) {
-            this.options.minSpecial = this.enforcedSpecialCount;
+        if (this.options.minSpecial < this.enforcedPolicyOptions.specialCount) {
+            this.options.minSpecial = this.enforcedPolicyOptions.specialCount;
         }
 
         if (this.options.minSpecial + this.options.minNumber > this.options.length) {

--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -8,6 +8,7 @@ import {
 import { I18nService } from '../../abstractions/i18n.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
+
 import { PasswordGeneratorPolicyOptions } from '../../models/domain/passwordGeneratorPolicyOptions';
 
 export class PasswordGeneratorComponent implements OnInit {
@@ -112,7 +113,7 @@ export class PasswordGeneratorComponent implements OnInit {
         }
 
         if (this.options.minNumber < this.enforcedPolicyOptions.numberCount) {
-            this.options.minNumber = this.enforcedPolicyOptions.numberCountt;
+            this.options.minNumber = this.enforcedPolicyOptions.numberCount;
         }
 
         if (!this.options.minSpecial) {

--- a/src/models/domain/passwordGeneratorPolicyOptions.ts
+++ b/src/models/domain/passwordGeneratorPolicyOptions.ts
@@ -8,43 +8,4 @@ export class PasswordGeneratorPolicyOptions extends Domain {
     numberCount: number = 0;
     useSpecial: boolean = false;
     specialCount: number = 0;
-
-    constructor(
-        minLength?: number,
-        useUppercase?: boolean,
-        useLowercase?: boolean,
-        useNumbers?: boolean,
-        numberCount?: number,
-        useSpecial?: boolean,
-        specialCount?: number) {
-        super();
-
-        if (minLength != null) {
-            this.minLength = minLength;
-        }
-
-        if (useUppercase != null) {
-            this.useUppercase = useUppercase;
-        }
-
-        if (useLowercase != null) {
-            this.useLowercase = useLowercase;
-        }
-
-        if (useNumbers != null) {
-            this.useNumbers = useNumbers;
-        }
-
-        if (numberCount != null) {
-            this.numberCount = numberCount;
-        }
-
-        if (useSpecial != null) {
-            this.useSpecial = useSpecial;
-        }
-
-        if (specialCount != null) {
-            this.specialCount = specialCount;
-        }
-    }
 }

--- a/src/models/domain/passwordGeneratorPolicyOptions.ts
+++ b/src/models/domain/passwordGeneratorPolicyOptions.ts
@@ -1,0 +1,50 @@
+import Domain from './domainBase';
+
+export class PasswordGeneratorPolicyOptions extends Domain {
+    minLength: number = 0;
+    useUppercase: boolean = false;
+    useLowercase: boolean = false;
+    useNumbers: boolean = false;
+    numberCount: number = 0;
+    useSpecial: boolean = false;
+    specialCount: number = 0;
+
+    constructor(
+        minLength?: number,
+        useUppercase?: boolean,
+        useLowercase?: boolean,
+        useNumbers?: boolean,
+        numberCount?: number,
+        useSpecial?: boolean,
+        specialCount?: number) {
+        super();
+
+        if (minLength != null) {
+            this.minLength = minLength;
+        }
+
+        if (useUppercase != null) {
+            this.useUppercase = useUppercase;
+        }
+
+        if (useLowercase != null) {
+            this.useLowercase = useLowercase;
+        }
+
+        if (useNumbers != null) {
+            this.useNumbers = useNumbers;
+        }
+
+        if (numberCount != null) {
+            this.numberCount = numberCount;
+        }
+
+        if (useSpecial != null) {
+            this.useSpecial = useSpecial;
+        }
+
+        if (specialCount != null) {
+            this.specialCount = specialCount;
+        }
+    }
+}


### PR DESCRIPTION
## Objective
> Make sure the Password Generator enforces the specific rules set by an Organization for password generation. In the case of multiple Organizational rules, apply the stricter option.

## Code Changes
- **abstractions/passwordGeneration.service.ts**: Adjusted abstraction to mirror function calls in `passwordGeneration.service.ts`
- **password-generator.component.ts**: Utilized new `getOptions` function that injects intermediate step for password options retrieval. It applies the rules set by the governing organization to the user's password generation options. UI adjusted by using information stored in the `PasswordGeneratorPolicyOptions` object. Because field's floors were being altered, the `normalizeOptions` function was used to further adjust potential changes.
- **passwordGeneratorPolicyOptions.ts**: Created domain object for storage/retrieval of compiled password generator organization policies
- **passwordGeneration.service.ts**: Adjust `getOptions` function to utilize new `getPasswordGeneratorPolicyOptions` helper method and manipulate the user's options based on the organizations' enabled policy.

