### PR TITLE
Enforce master password policy

### DIFF
--- a/src/abstractions/policy.service.ts
+++ b/src/abstractions/policy.service.ts
@@ -1,6 +1,7 @@
 import { PolicyData } from '../models/data/policyData';
 
-import { Policy } from '../models/domain/policy';
+import { MasterPasswordPolicyOptions } from '../models/domain/masterPasswordPolicyOptions'
+import { Policy } from '../models/domain/policy'
 
 import { PolicyType } from '../enums/policyType';
 
@@ -11,4 +12,7 @@ export abstract class PolicyService {
     getAll: (type?: PolicyType) => Promise<Policy[]>;
     replace: (policies: { [id: string]: PolicyData; }) => Promise<any>;
     clear: (userId: string) => Promise<any>;
+    getMasterPasswordPolicyOptions: () => Promise<MasterPasswordPolicyOptions>;
+    evaluateMasterPassword: (passwordStrength: number, newPassword: string,
+        enforcedPolicyOptions?: MasterPasswordPolicyOptions) => Promise<boolean>;
 }

--- a/src/abstractions/policy.service.ts
+++ b/src/abstractions/policy.service.ts
@@ -14,5 +14,5 @@ export abstract class PolicyService {
     clear: (userId: string) => Promise<any>;
     getMasterPasswordPolicyOptions: () => Promise<MasterPasswordPolicyOptions>;
     evaluateMasterPassword: (passwordStrength: number, newPassword: string,
-        enforcedPolicyOptions?: MasterPasswordPolicyOptions) => Promise<boolean>;
+        enforcedPolicyOptions?: MasterPasswordPolicyOptions) => boolean;
 }

--- a/src/models/domain/masterPasswordPolicyOptions.ts
+++ b/src/models/domain/masterPasswordPolicyOptions.ts
@@ -1,0 +1,10 @@
+import Domain from './domainBase';
+
+export class MasterPasswordPolicyOptions extends Domain {
+    minComplexity: number = 0;
+    minLength: number = 0;
+    requireUpper: boolean = false;
+    requireLower: boolean = false;
+    requireNumbers: boolean = false;
+    requireSpecial: boolean = false;
+}

--- a/src/services/policy.service.ts
+++ b/src/services/policy.service.ts
@@ -5,6 +5,7 @@ import { UserService } from '../abstractions/user.service';
 import { PolicyData } from '../models/data/policyData';
 
 import { Policy } from '../models/domain/policy';
+import { MasterPasswordPolicyOptions } from '../models/domain/masterPasswordPolicyOptions'
 
 import { PolicyType } from '../enums/policyType';
 
@@ -51,5 +52,85 @@ export class PolicyService implements PolicyServiceAbstraction {
     async clear(userId: string): Promise<any> {
         await this.storageService.remove(Keys.policiesPrefix + userId);
         this.policyCache = null;
+    }
+
+    async getMasterPasswordPolicyOptions(): Promise<MasterPasswordPolicyOptions> {
+        const policies: Policy[] = await this.getAll(PolicyType.MasterPassword);
+        let enforcedOptions: MasterPasswordPolicyOptions = null;
+
+        if (policies == null || policies.length === 0) {
+            return enforcedOptions;
+        }
+
+        policies.forEach((currentPolicy) => {
+            if (!currentPolicy.enabled || currentPolicy.data == null) {
+                return;
+            }
+
+            if (enforcedOptions == null) {
+                enforcedOptions = new MasterPasswordPolicyOptions();
+            }
+
+            if (currentPolicy.data.minComplexity != null
+                && currentPolicy.data.minComplexity > enforcedOptions.minComplexity) {
+                enforcedOptions.minComplexity = currentPolicy.data.minComplexity;
+            }
+
+            if (currentPolicy.data.minLength != null
+                && currentPolicy.data.minLength > enforcedOptions.minLength) {
+                enforcedOptions.minLength = currentPolicy.data.minLength;
+            }
+
+            if (currentPolicy.data.requireUpper) {
+                enforcedOptions.requireUpper = true;
+            }
+
+            if (currentPolicy.data.requireLower) {
+                enforcedOptions.requireLower = true;
+            }
+
+            if (currentPolicy.data.requireNumbers) {
+                enforcedOptions.requireNumbers = true;
+            }
+
+            if (currentPolicy.data.requireSpecial) {
+                enforcedOptions.requireSpecial = true;
+            }
+        });
+
+        return enforcedOptions;
+    }
+
+    async evaluateMasterPassword(passwordStrength: number, newPassword: string,
+        enforcedPolicyOptions: MasterPasswordPolicyOptions): Promise<boolean> {
+        if (enforcedPolicyOptions == null) {
+            return true;
+        }
+
+        if (enforcedPolicyOptions.minComplexity > 0 && enforcedPolicyOptions.minComplexity > passwordStrength) {
+            return false;
+        }
+
+        if (enforcedPolicyOptions.minLength > 0 && enforcedPolicyOptions.minLength > newPassword.length) {
+            return false;
+        }
+
+        if (enforcedPolicyOptions.requireUpper && newPassword.toLowerCase() === newPassword) {
+            return false;
+        }
+
+        if (enforcedPolicyOptions.requireLower && newPassword.toUpperCase() === newPassword) {
+            return false;
+        }
+
+        if (enforcedPolicyOptions.requireNumbers && !(/[0-9]/.test(newPassword))) {
+            return false;
+        }
+
+        if (enforcedPolicyOptions.requireSpecial && !(/[!@#$%\^&*]/g.test(newPassword))) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/services/policy.service.ts
+++ b/src/services/policy.service.ts
@@ -54,9 +54,14 @@ export class PolicyService implements PolicyServiceAbstraction {
         this.policyCache = null;
     }
 
-    async getMasterPasswordPolicyOptions(): Promise<MasterPasswordPolicyOptions> {
-        const policies: Policy[] = await this.getAll(PolicyType.MasterPassword);
+    async getMasterPasswordPolicyOptions(policies?: Policy[]): Promise<MasterPasswordPolicyOptions> {
         let enforcedOptions: MasterPasswordPolicyOptions = null;
+
+        if (policies == null) {
+            policies = await this.getAll(PolicyType.MasterPassword);
+        } else {
+            policies = policies.filter((p) => p.type === PolicyType.MasterPassword);
+        }
 
         if (policies == null || policies.length === 0) {
             return enforcedOptions;
@@ -101,8 +106,8 @@ export class PolicyService implements PolicyServiceAbstraction {
         return enforcedOptions;
     }
 
-    async evaluateMasterPassword(passwordStrength: number, newPassword: string,
-        enforcedPolicyOptions: MasterPasswordPolicyOptions): Promise<boolean> {
+    evaluateMasterPassword(passwordStrength: number, newPassword: string,
+        enforcedPolicyOptions: MasterPasswordPolicyOptions): boolean {
         if (enforcedPolicyOptions == null) {
             return true;
         }
@@ -115,11 +120,11 @@ export class PolicyService implements PolicyServiceAbstraction {
             return false;
         }
 
-        if (enforcedPolicyOptions.requireUpper && newPassword.toLowerCase() === newPassword) {
+        if (enforcedPolicyOptions.requireUpper && newPassword.toLocaleLowerCase() === newPassword) {
             return false;
         }
 
-        if (enforcedPolicyOptions.requireLower && newPassword.toUpperCase() === newPassword) {
+        if (enforcedPolicyOptions.requireLower && newPassword.toLocaleUpperCase() === newPassword) {
             return false;
         }
 


### PR DESCRIPTION
## Objective
> Update the policy service to allow client applications to retrieve a strict compiled object of master password policy options and also allow the policy service to evaluate a supplied password meets/exceeds the criteria.

## Code Changes
- **abstractions/policy.service.ts**: Added the two new functions `getMasterPasswordPolicyOptions`and `evaluateMasterPassword`
- **domain/masterPasswordPolicyOptions**: Created object for storing the strictest master password policy options between organizations
- **services/policy.service.ts**: Added function to retrieve and compile the strictest master password policy options.  Added function that evaluates the supplied master password against the password strength in conjunction with the enforced policy options.