### PR TITLE
Password Generator Passphrase Policy

### DIFF
--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -31,13 +31,18 @@ export class PasswordGeneratorComponent implements OnInit {
         this.options = optionsResponse[0];
         this.enforcedPolicyOptions = optionsResponse[1];
         this.policyInEffect = this.enforcedPolicyOptions != null && (
+            this.enforcedPolicyOptions.allowPassword ||
             this.enforcedPolicyOptions.minLength > 0 ||
             this.enforcedPolicyOptions.numberCount > 0 ||
             this.enforcedPolicyOptions.specialCount > 0 ||
             this.enforcedPolicyOptions.useUppercase ||
             this.enforcedPolicyOptions.useLowercase ||
             this.enforcedPolicyOptions.useNumbers ||
-            this.enforcedPolicyOptions.useSpecial);
+            this.enforcedPolicyOptions.useSpecial ||
+            this.enforcedPolicyOptions.allowPassphrase ||
+            this.enforcedPolicyOptions.minNumberWords > 0 ||
+            this.enforcedPolicyOptions.capitalize ||
+            this.enforcedPolicyOptions.includeNumber);
         this.avoidAmbiguous = !this.options.ambiguous;
         this.options.type = this.options.type === 'passphrase' ? 'passphrase' : 'password';
         this.password = await this.passwordGenerationService.generatePassword(this.options);
@@ -145,6 +150,10 @@ export class PasswordGeneratorComponent implements OnInit {
             this.options.numWords = 3;
         } else if (this.options.numWords > 20) {
             this.options.numWords = 20;
+        }
+
+        if (this.options.numWords < this.enforcedPolicyOptions.minNumberWords) {
+            this.options.numWords = this.enforcedPolicyOptions.minNumberWords;
         }
 
         if (this.options.wordSeparator != null && this.options.wordSeparator.length > 1) {

--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -19,7 +19,6 @@ export class PasswordGeneratorComponent implements OnInit {
     password: string = '-';
     showOptions = false;
     avoidAmbiguous = false;
-    policyInEffect = false;
     enforcedPolicyOptions: PasswordGeneratorPolicyOptions;
 
     constructor(protected passwordGenerationService: PasswordGenerationService,
@@ -30,18 +29,6 @@ export class PasswordGeneratorComponent implements OnInit {
         const optionsResponse = await this.passwordGenerationService.getOptions();
         this.options = optionsResponse[0];
         this.enforcedPolicyOptions = optionsResponse[1];
-        this.policyInEffect = this.enforcedPolicyOptions != null && (
-            this.enforcedPolicyOptions.defaultType !== '' ||
-            this.enforcedPolicyOptions.minLength > 0 ||
-            this.enforcedPolicyOptions.numberCount > 0 ||
-            this.enforcedPolicyOptions.specialCount > 0 ||
-            this.enforcedPolicyOptions.useUppercase ||
-            this.enforcedPolicyOptions.useLowercase ||
-            this.enforcedPolicyOptions.useNumbers ||
-            this.enforcedPolicyOptions.useSpecial ||
-            this.enforcedPolicyOptions.minNumberWords > 0 ||
-            this.enforcedPolicyOptions.capitalize ||
-            this.enforcedPolicyOptions.includeNumber);
         this.avoidAmbiguous = !this.options.ambiguous;
         this.options.type = this.options.type === 'passphrase' ? 'passphrase' : 'password';
         this.password = await this.passwordGenerationService.generatePassword(this.options);

--- a/src/angular/components/password-generator.component.ts
+++ b/src/angular/components/password-generator.component.ts
@@ -31,7 +31,7 @@ export class PasswordGeneratorComponent implements OnInit {
         this.options = optionsResponse[0];
         this.enforcedPolicyOptions = optionsResponse[1];
         this.policyInEffect = this.enforcedPolicyOptions != null && (
-            this.enforcedPolicyOptions.allowPassword ||
+            this.enforcedPolicyOptions.defaultType !== '' ||
             this.enforcedPolicyOptions.minLength > 0 ||
             this.enforcedPolicyOptions.numberCount > 0 ||
             this.enforcedPolicyOptions.specialCount > 0 ||
@@ -39,7 +39,6 @@ export class PasswordGeneratorComponent implements OnInit {
             this.enforcedPolicyOptions.useLowercase ||
             this.enforcedPolicyOptions.useNumbers ||
             this.enforcedPolicyOptions.useSpecial ||
-            this.enforcedPolicyOptions.allowPassphrase ||
             this.enforcedPolicyOptions.minNumberWords > 0 ||
             this.enforcedPolicyOptions.capitalize ||
             this.enforcedPolicyOptions.includeNumber);

--- a/src/models/domain/passwordGeneratorPolicyOptions.ts
+++ b/src/models/domain/passwordGeneratorPolicyOptions.ts
@@ -1,6 +1,7 @@
 import Domain from './domainBase';
 
 export class PasswordGeneratorPolicyOptions extends Domain {
+    allowPassword: boolean = true;
     minLength: number = 0;
     useUppercase: boolean = false;
     useLowercase: boolean = false;
@@ -8,4 +9,8 @@ export class PasswordGeneratorPolicyOptions extends Domain {
     numberCount: number = 0;
     useSpecial: boolean = false;
     specialCount: number = 0;
+    allowPassphrase: boolean = true;
+    minNumberWords: number = 0;
+    capitalize: boolean = false;
+    includeNumber: boolean = false;
 }

--- a/src/models/domain/passwordGeneratorPolicyOptions.ts
+++ b/src/models/domain/passwordGeneratorPolicyOptions.ts
@@ -1,7 +1,7 @@
 import Domain from './domainBase';
 
 export class PasswordGeneratorPolicyOptions extends Domain {
-    allowPassword: boolean = true;
+    defaultType: string = '';
     minLength: number = 0;
     useUppercase: boolean = false;
     useLowercase: boolean = false;
@@ -9,7 +9,6 @@ export class PasswordGeneratorPolicyOptions extends Domain {
     numberCount: number = 0;
     useSpecial: boolean = false;
     specialCount: number = 0;
-    allowPassphrase: boolean = true;
     minNumberWords: number = 0;
     capitalize: boolean = false;
     includeNumber: boolean = false;

--- a/src/models/domain/passwordGeneratorPolicyOptions.ts
+++ b/src/models/domain/passwordGeneratorPolicyOptions.ts
@@ -12,4 +12,18 @@ export class PasswordGeneratorPolicyOptions extends Domain {
     minNumberWords: number = 0;
     capitalize: boolean = false;
     includeNumber: boolean = false;
+
+    inEffect() {
+        return this.defaultType !== '' ||
+            this.minLength > 0 ||
+            this.numberCount > 0 ||
+            this.specialCount > 0 ||
+            this.useUppercase ||
+            this.useLowercase ||
+            this.useNumbers ||
+            this.useSpecial ||
+            this.minNumberWords > 0 ||
+            this.capitalize ||
+            this.includeNumber;
+    }
 }

--- a/src/services/passwordGeneration.service.ts
+++ b/src/services/passwordGeneration.service.ts
@@ -304,9 +304,7 @@ export class PasswordGenerationService implements PasswordGenerationServiceAbstr
             }
 
             // Password wins in multi-org collisions
-            if (currentPolicy.data.defaultType &&
-                currentPolicy.data.defaultType !== 'user' &&
-                enforcedOptions.defaultType !== 'password') {
+            if (currentPolicy.data.defaultType != null && enforcedOptions.defaultType !== 'password') {
                 enforcedOptions.defaultType = currentPolicy.data.defaultType;
             }
 


### PR DESCRIPTION
## Objective
> Add missing components for passphrase policy. Use existing data structures/patterns to implement a shared password generator (password/passphrase)

## Code Changes
- **password-generator.component.ts**: Updated logic for defining a default type (user preference/password/passphrase). Updated `normalizeOptions` function to include raising the floor for the minimum number of words during passphrase generation
- **passwordGeneratorPolicyOptions.ts**: Added params for tracking passphrase policy options and default type selection and also added a helper method to retrieve whether or not the policy is in effect.
- **passwordGeneration.service.ts**: Updated `getPasswordGeneratorPolicyOptions()` function to instantiate/retrieve/set policy data options. Multi-org collision: password default type always wins (to mimic default options).   Updated `enforcePasswordGeneratorPoliciesOnOptions()` function to apply the enforced options.  Overrides default type selection if possible.