### PR TITLE
Add noImplicitAny to tsc compiler options

### DIFF
--- a/spec/common/importers/lastpassCsvImporter.spec.ts
+++ b/spec/common/importers/lastpassCsvImporter.spec.ts
@@ -168,7 +168,8 @@ describe('Lastpass CSV Importer', () => {
             expect(result.ciphers.length).toBeGreaterThan(0);
 
             const cipher = result.ciphers.shift();
-            for (const property in data.expected) {
+            let property: keyof typeof data.expected;
+            for (property in data.expected) {
                 if (data.expected.hasOwnProperty(property)) {
                     expect(cipher.hasOwnProperty(property)).toBe(true);
                     expect(cipher[property]).toEqual(data.expected[property]);

--- a/spec/common/misc/sequentialize.spec.ts
+++ b/spec/common/misc/sequentialize.spec.ts
@@ -81,7 +81,7 @@ describe('sequentialize decorator', () => {
 
     it('should return correct result for each call', async () => {
         const foo = new Foo();
-        const allRes = [];
+        const allRes: number[] = [];
 
         await Promise.all([
             foo.bar(1).then((res) => allRes.push(res)),
@@ -99,7 +99,7 @@ describe('sequentialize decorator', () => {
 
     it('should return correct result for each call with key function', async () => {
         const foo = new Foo();
-        const allRes = [];
+        const allRes: number[] = [];
 
         await Promise.all([
             foo.baz(1).then((res) => allRes.push(res)),
@@ -120,7 +120,7 @@ class Foo {
     calls = 0;
 
     @sequentialize((args) => 'bar' + args[0])
-    bar(a: number) {
+    bar(a: number): Promise<number> {
         this.calls++;
         return new Promise((res) => {
             setTimeout(() => {
@@ -130,7 +130,7 @@ class Foo {
     }
 
     @sequentialize((args) => 'baz' + args[0])
-    baz(a: number) {
+    baz(a: number): Promise<number> {
         this.calls++;
         return new Promise((res) => {
             setTimeout(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "pretty": true,
     "moduleResolution": "node",
+    "noImplicitAny": true,
     "target": "ES6",
     "module": "commonjs",
     "lib": ["es5", "es6", "dom"],


### PR DESCRIPTION
To gain more security, we should use `--noImplicitAny` option of tsc.
https://www.typescriptlang.org/docs/handbook/compiler-options.html

Some spec files needs to be fixed.

desktop already enables `noImplicitAny`.
https://github.com/bitwarden/desktop/blob/master/tsconfig.json
cli enables too.
https://github.com/bitwarden/cli/blob/master/tsconfig.json