### PR TITLE
Update groupings component for saved changes

### DIFF
--- a/src/angular/components/groupings.component.ts
+++ b/src/angular/components/groupings.component.ts
@@ -89,29 +89,53 @@ export class GroupingsComponent {
         this.nestedFolders = await this.folderService.getAllNested();
     }
 
-    selectAll() {
-        this.clearSelections();
-        this.selectedAll = true;
+    selectAll(emitOnly?: boolean) {
+        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+            this.clearAndSelectAll();
+        }
         this.onAllClicked.emit();
     }
 
-    selectFavorites() {
+    clearAndSelectAll() {
         this.clearSelections();
-        this.selectedFavorites = true;
+        this.selectedAll = true;
+    }
+
+    selectFavorites(emitOnly?: boolean) {
+        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+            this.clearAndSelectFavorites();
+        }
         this.onFavoritesClicked.emit();
     }
 
-    selectType(type: CipherType) {
+    clearAndSelectFavorites() {
         this.clearSelections();
-        this.selectedType = type;
+        this.selectedFavorites = true;
+    }
+
+    selectType(type: CipherType, emitOnly?: boolean) {
+        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+            this.clearAndSelectType(type);
+        }
         this.onCipherTypeClicked.emit(type);
     }
 
-    selectFolder(folder: FolderView) {
+    clearAndSelectType(type: CipherType) {
+        this.clearSelections();
+        this.selectedType = type;
+    }
+
+    selectFolder(folder: FolderView, emitOnly?: boolean) {
+        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+            this.clearAndSelectFolder(folder.id);
+        }
+        this.onFolderClicked.emit(folder);
+    }
+
+    clearAndSelectFolder(folderId: string) {
         this.clearSelections();
         this.selectedFolder = true;
-        this.selectedFolderId = folder.id;
-        this.onFolderClicked.emit(folder);
+        this.selectedFolderId = folderId;
     }
 
     addFolder() {
@@ -122,10 +146,16 @@ export class GroupingsComponent {
         this.onEditFolder.emit(folder);
     }
 
-    selectCollection(collection: CollectionView) {
-        this.clearSelections();
-        this.selectedCollectionId = collection.id;
+    selectCollection(collection: CollectionView, emitOnly?: boolean) {
+        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+            this.clearAndSelectCollection(collection.id);
+        }
         this.onCollectionClicked.emit(collection);
+    }
+
+    clearAndSelectCollection(collectionId: string) {
+        this.clearSelections();
+        this.selectedCollectionId = collectionId;
     }
 
     clearSelections() {

--- a/src/angular/components/groupings.component.ts
+++ b/src/angular/components/groupings.component.ts
@@ -90,7 +90,7 @@ export class GroupingsComponent {
     }
 
     selectAll(emitOnly?: boolean) {
-        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+        if (emitOnly === null || emitOnly === undefined || !emitOnly) {
             this.clearAndSelectAll();
         }
         this.onAllClicked.emit();
@@ -102,7 +102,7 @@ export class GroupingsComponent {
     }
 
     selectFavorites(emitOnly?: boolean) {
-        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+        if (emitOnly === null || emitOnly === undefined || !emitOnly) {
             this.clearAndSelectFavorites();
         }
         this.onFavoritesClicked.emit();
@@ -114,7 +114,7 @@ export class GroupingsComponent {
     }
 
     selectType(type: CipherType, emitOnly?: boolean) {
-        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+        if (emitOnly === null || emitOnly === undefined || !emitOnly) {
             this.clearAndSelectType(type);
         }
         this.onCipherTypeClicked.emit(type);
@@ -126,7 +126,7 @@ export class GroupingsComponent {
     }
 
     selectFolder(folder: FolderView, emitOnly?: boolean) {
-        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+        if (emitOnly === null || emitOnly === undefined || !emitOnly) {
             this.clearAndSelectFolder(folder.id);
         }
         this.onFolderClicked.emit(folder);
@@ -147,7 +147,7 @@ export class GroupingsComponent {
     }
 
     selectCollection(collection: CollectionView, emitOnly?: boolean) {
-        if (emitOnly == null || emitOnly == undefined || !emitOnly) {
+        if (emitOnly === null || emitOnly === undefined || !emitOnly) {
             this.clearAndSelectCollection(collection.id);
         }
         this.onCollectionClicked.emit(collection);


### PR DESCRIPTION
## Objective
> Update groupings component to handle (potential) intervening steps in regards to tracking selected filter options and emitting the callback. Will be utilized currently in the desktop application for saved changes dialog.  Make sure changes here are backwards compatible and web/browser codebases do NOT require an update.

## Bug Link
- Relates to [Desktop#415](https://github.com/bitwarden/desktop/issues/415)

## Code Changes
- **groupings.component.ts**: Decoupled emitting callback and clearing/setting selected filter.  This was done in a backwards-compat way that would not require updates from codebases not utilizing this functionality.  Instead of using truthy/falsy, explicitly checked the conditionals. 