### PR TITLE
[Auto-Logout] Update Token Service 

### DIFF
--- a/src/abstractions/token.service.ts
+++ b/src/abstractions/token.service.ts
@@ -7,6 +7,7 @@ export abstract class TokenService {
     getToken: () => Promise<string>;
     setRefreshToken: (refreshToken: string) => Promise<any>;
     getRefreshToken: () => Promise<string>;
+    toggleTokens: () => Promise<any>;
     setTwoFactorToken: (token: string, email: string) => Promise<any>;
     getTwoFactorToken: (email: string) => Promise<string>;
     clearTwoFactorToken: (email: string) => Promise<any>;

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -19,7 +19,7 @@ export class TokenService implements TokenServiceAbstraction {
     constructor(private storageService: StorageService) {
     }
 
-    async setTokens(accessToken: string, refreshToken: string): Promise<any> {
+    setTokens(accessToken: string, refreshToken: string): Promise<any> {
         return Promise.all([
             this.setToken(accessToken),
             this.setRefreshToken(refreshToken),

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -21,8 +21,8 @@ export class TokenService implements TokenServiceAbstraction {
 
     async setTokens(accessToken: string, refreshToken: string): Promise<any> {
         return Promise.all([
-            await this.setToken(accessToken),
-            await this.setRefreshToken(refreshToken),
+            this.setToken(accessToken),
+            this.setRefreshToken(refreshToken),
         ]);
     }
 

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -19,16 +19,22 @@ export class TokenService implements TokenServiceAbstraction {
     constructor(private storageService: StorageService) {
     }
 
-    setTokens(accessToken: string, refreshToken: string): Promise<any> {
+    async setTokens(accessToken: string, refreshToken: string): Promise<any> {
         return Promise.all([
-            this.setToken(accessToken),
-            this.setRefreshToken(refreshToken),
+            await this.setToken(accessToken),
+            await this.setRefreshToken(refreshToken),
         ]);
     }
 
-    setToken(token: string): Promise<any> {
+    async setToken(token: string): Promise<any> {
         this.token = token;
         this.decodedToken = null;
+
+        if (await this.skipTokenStorage()) {
+            // if we have a vault timeout and the action is log out, don't store token
+            return;
+        }
+
         return this.storageService.save(Keys.accessToken, token);
     }
 
@@ -41,8 +47,14 @@ export class TokenService implements TokenServiceAbstraction {
         return this.token;
     }
 
-    setRefreshToken(refreshToken: string): Promise<any> {
+    async setRefreshToken(refreshToken: string): Promise<any> {
         this.refreshToken = refreshToken;
+
+        if (await this.skipTokenStorage()) {
+            // if we have a vault timeout and the action is log out, don't store token
+            return;
+        }
+
         return this.storageService.save(Keys.refreshToken, refreshToken);
     }
 
@@ -53,6 +65,23 @@ export class TokenService implements TokenServiceAbstraction {
 
         this.refreshToken = await this.storageService.get<string>(Keys.refreshToken);
         return this.refreshToken;
+    }
+
+    async toggleTokens(): Promise<any> {
+        const token = await this.getToken();
+        const refreshToken = await this.getRefreshToken();
+        const timeout = await this.storageService.get(ConstantsService.vaultTimeoutKey);
+        const action = await this.storageService.get(ConstantsService.vaultTimeoutActionKey);
+        if ((timeout != null || timeout === 0) && action === 'logOut') {
+            // if we have a vault timeout and the action is log out, reset tokens
+            await this.clearToken();
+            this.token = token;
+            this.refreshToken = refreshToken;
+            return;
+        }
+
+        await this.setToken(token);
+        await this.setRefreshToken(refreshToken);
     }
 
     setTwoFactorToken(token: string, email: string): Promise<any> {
@@ -182,5 +211,11 @@ export class TokenService implements TokenServiceAbstraction {
         }
 
         return decoded.iss as string;
+    }
+
+    private async skipTokenStorage(): Promise<boolean> {
+        const timeout = await this.storageService.get<number>(ConstantsService.vaultTimeoutKey);
+        const action = await this.storageService.get<string>(ConstantsService.vaultTimeoutActionKey);
+        return timeout != null && action === 'logOut';
     }
 }

--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -8,6 +8,7 @@ import { MessagingService } from '../abstractions/messaging.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { SearchService } from '../abstractions/search.service';
 import { StorageService } from '../abstractions/storage.service';
+import { TokenService } from '../abstractions/token.service';
 import { UserService } from '../abstractions/user.service';
 import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from '../abstractions/vaultTimeout.service';
 
@@ -22,8 +23,8 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         private collectionService: CollectionService, private cryptoService: CryptoService,
         private platformUtilsService: PlatformUtilsService, private storageService: StorageService,
         private messagingService: MessagingService, private searchService: SearchService,
-        private userService: UserService, private lockedCallback: () => Promise<void> = null,
-        private loggedOutCallback: () => Promise<void> = null) {
+        private userService: UserService, private tokenService: TokenService,
+        private lockedCallback: () => Promise<void> = null, private loggedOutCallback: () => Promise<void> = null) {
     }
 
     init(checkOnInterval: boolean) {
@@ -117,6 +118,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         await this.storageService.save(ConstantsService.vaultTimeoutKey, timeout);
         await this.storageService.save(ConstantsService.vaultTimeoutActionKey, action);
         await this.cryptoService.toggleKey();
+        await this.tokenService.toggleTokens();
     }
 
     async isPinLockSet(): Promise<[boolean, boolean]> {


### PR DESCRIPTION
## Objective
> Allow applications to properly present login vs lock based the presence of auth tokens.  Don't save auth tokens to disk when a timeout is selected and the action is log out.

## Code Changes 
- **abstractions/token.service.ts**: Added `toggleTokens` to interface
- **token.service.ts**: Updated `setTokens` to handle async. Updated `setToken` and `setRefreshToken` functions to not save to disk if a timeout it set and the action is log out. Added `toggleTokens` function for adjusting token storage based on change in timeout/action. Added helper function `skipTokenStorage`.
- **vaultTimeout.service.ts**: Added `tokenStorage` dependency. Added call to `toggleTokens` on saving of timeout/action.