### PR TITLE
Soft delete - update cipher search and added restore functionality

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -5,6 +5,7 @@ import { EnvironmentUrls } from '../models/domain/environmentUrls';
 import { BitPayInvoiceRequest } from '../models/request/bitPayInvoiceRequest';
 import { CipherBulkDeleteRequest } from '../models/request/cipherBulkDeleteRequest';
 import { CipherBulkMoveRequest } from '../models/request/cipherBulkMoveRequest';
+import { CipherBulkRestoreRequest } from '../models/request/cipherBulkRestoreRequest';
 import { CipherBulkShareRequest } from '../models/request/cipherBulkShareRequest';
 import { CipherCollectionsRequest } from '../models/request/cipherCollectionsRequest';
 import { CipherCreateRequest } from '../models/request/cipherCreateRequest';
@@ -163,6 +164,12 @@ export abstract class ApiService {
     postPurgeCiphers: (request: PasswordVerificationRequest, organizationId?: string) => Promise<any>;
     postImportCiphers: (request: ImportCiphersRequest) => Promise<any>;
     postImportOrganizationCiphers: (organizationId: string, request: ImportOrganizationCiphersRequest) => Promise<any>;
+    putDeleteCipher: (id: string) => Promise<any>;
+    putDeleteCipherAdmin: (id: string) => Promise<any>;
+    putDeleteManyCiphers: (request: CipherBulkDeleteRequest) => Promise<any>;
+    putRestoreCipher: (id: string) => Promise<any>;
+    putRestoreCipherAdmin: (id: string) => Promise<any>;
+    putRestoreManyCiphers: (request: CipherBulkRestoreRequest) => Promise<any>;
 
     postCipherAttachment: (id: string, data: FormData) => Promise<CipherResponse>;
     postCipherAttachmentAdmin: (id: string, data: FormData) => Promise<CipherResponse>;

--- a/src/abstractions/cipher.service.ts
+++ b/src/abstractions/cipher.service.ts
@@ -45,4 +45,10 @@ export abstract class CipherService {
     sortCiphersByLastUsed: (a: any, b: any) => number;
     sortCiphersByLastUsedThenName: (a: any, b: any) => number;
     getLocaleSortingFunction: () => (a: CipherView, b: CipherView) => number;
+    softDelete: (id: string | string[]) => Promise<any>;
+    softDeleteWithServer: (id: string) => Promise<any>;
+    softDeleteManyWithServer: (ids: string[]) => Promise<any>;
+    restore: (id: string | string[]) => Promise<any>;
+    restoreWithServer: (id: string) => Promise<any>;
+    restoreManyWithServer: (ids: string[]) => Promise<any>;
 }

--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -5,6 +5,6 @@ export abstract class SearchService {
     isSearchable: (query: string) => boolean;
     indexCiphers: () => Promise<void>;
     searchCiphers: (query: string, filter?: (cipher: CipherView) => boolean,
-        ciphers?: CipherView[]) => Promise<CipherView[]>;
-    searchCiphersBasic: (ciphers: CipherView[], query: string) => CipherView[];
+        ciphers?: CipherView[], deleted?: boolean) => Promise<CipherView[]>;
+    searchCiphersBasic: (ciphers: CipherView[], query: string, deleted?: boolean) => CipherView[];
 }

--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -4,7 +4,8 @@ export abstract class SearchService {
     clearIndex: () => void;
     isSearchable: (query: string) => boolean;
     indexCiphers: () => Promise<void>;
-    searchCiphers: (query: string, filter?: (cipher: CipherView) => boolean,
-        ciphers?: CipherView[], deleted?: boolean) => Promise<CipherView[]>;
+    searchCiphers: (query: string,
+        filter?: ((cipher: CipherView) => boolean) | (Array<(cipher: CipherView) => boolean>),
+        ciphers?: CipherView[]) => Promise<CipherView[]>;
     searchCiphersBasic: (ciphers: CipherView[], query: string, deleted?: boolean) => CipherView[];
 }

--- a/src/angular/components/ciphers.component.ts
+++ b/src/angular/components/ciphers.component.ts
@@ -64,7 +64,7 @@ export class CiphersComponent {
     async refresh() {
         try {
             this.refreshing = true;
-            await this.reload(this.filter);
+            await this.reload(this.filter, this.deleted);
         } finally {
             this.refreshing = false;
         }
@@ -80,14 +80,15 @@ export class CiphersComponent {
         if (this.searchTimeout != null) {
             clearTimeout(this.searchTimeout);
         }
+        const deletedFilter: (cipher: CipherView) => boolean = (c) => c.isDeleted === this.deleted;
         if (timeout == null) {
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, this.filter, null, this.deleted);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, [this.filter, deletedFilter], null);
             await this.resetPaging();
             return;
         }
         this.searchPending = true;
         this.searchTimeout = setTimeout(async () => {
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, this.filter, null, this.deleted);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, [this.filter, deletedFilter], null);
             await this.resetPaging();
             this.searchPending = false;
         }, timeout);

--- a/src/angular/components/ciphers.component.ts
+++ b/src/angular/components/ciphers.component.ts
@@ -21,6 +21,7 @@ export class CiphersComponent {
     searchText: string;
     searchPlaceholder: string = null;
     filter: (cipher: CipherView) => boolean = null;
+    deleted: boolean = false;
 
     protected searchPending = false;
     protected didScroll = false;
@@ -32,7 +33,8 @@ export class CiphersComponent {
 
     constructor(protected searchService: SearchService) { }
 
-    async load(filter: (cipher: CipherView) => boolean = null) {
+    async load(filter: (cipher: CipherView) => boolean = null, deleted: boolean = false) {
+        this.deleted = deleted || false;
         await this.applyFilter(filter);
         this.loaded = true;
     }
@@ -79,13 +81,13 @@ export class CiphersComponent {
             clearTimeout(this.searchTimeout);
         }
         if (timeout == null) {
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, this.filter);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, this.filter, null, this.deleted);
             await this.resetPaging();
             return;
         }
         this.searchPending = true;
         this.searchTimeout = setTimeout(async () => {
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, this.filter);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, this.filter, null, this.deleted);
             await this.resetPaging();
             this.searchPending = false;
         }, timeout);

--- a/src/angular/components/ciphers.component.ts
+++ b/src/angular/components/ciphers.component.ts
@@ -55,10 +55,10 @@ export class CiphersComponent {
         this.didScroll = this.pagedCiphers.length > this.pageSize;
     }
 
-    async reload(filter: (cipher: CipherView) => boolean = null) {
+    async reload(filter: (cipher: CipherView) => boolean = null, deleted: boolean = false) {
         this.loaded = false;
         this.ciphers = [];
-        await this.load(filter);
+        await this.load(filter, deleted);
     }
 
     async refresh() {

--- a/src/angular/components/groupings.component.ts
+++ b/src/angular/components/groupings.component.ts
@@ -22,9 +22,11 @@ export class GroupingsComponent {
     @Input() showFolders = true;
     @Input() showCollections = true;
     @Input() showFavorites = true;
+    @Input() showTrash = true;
 
     @Output() onAllClicked = new EventEmitter();
     @Output() onFavoritesClicked = new EventEmitter();
+    @Output() onTrashClicked = new EventEmitter();
     @Output() onCipherTypeClicked = new EventEmitter<CipherType>();
     @Output() onFolderClicked = new EventEmitter<FolderView>();
     @Output() onAddFolder = new EventEmitter();
@@ -39,6 +41,7 @@ export class GroupingsComponent {
     cipherType = CipherType;
     selectedAll: boolean = false;
     selectedFavorites: boolean = false;
+    selectedTrash: boolean = false;
     selectedType: CipherType = null;
     selectedFolder: boolean = false;
     selectedFolderId: string = null;
@@ -101,6 +104,12 @@ export class GroupingsComponent {
         this.onFavoritesClicked.emit();
     }
 
+    selectTrash() {
+        this.clearSelections();
+        this.selectedTrash = true;
+        this.onTrashClicked.emit();
+    }
+
     selectType(type: CipherType) {
         this.clearSelections();
         this.selectedType = type;
@@ -131,6 +140,7 @@ export class GroupingsComponent {
     clearSelections() {
         this.selectedAll = false;
         this.selectedFavorites = false;
+        this.selectedTrash = false;
         this.selectedType = null;
         this.selectedFolder = false;
         this.selectedFolderId = null;

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -34,6 +34,7 @@ export class ViewComponent implements OnDestroy, OnInit {
     @Input() cipherId: string;
     @Output() onEditCipher = new EventEmitter<CipherView>();
     @Output() onCloneCipher = new EventEmitter<CipherView>();
+    @Output() onRestoreCipher = new EventEmitter<CipherView>();
 
     cipher: CipherView;
     showPassword: boolean;
@@ -108,6 +109,13 @@ export class ViewComponent implements OnDestroy, OnInit {
 
     clone() {
         this.onCloneCipher.emit(this.cipher);
+    }
+
+    restore() {
+        if (!this.cipher.isDeleted) {
+            return;
+        }
+        this.onRestoreCipher.emit(this.cipher);
     }
 
     togglePassword() {

--- a/src/angular/pipes/search-ciphers.pipe.ts
+++ b/src/angular/pipes/search-ciphers.pipe.ts
@@ -19,17 +19,22 @@ export class SearchCiphersPipe implements PipeTransform {
         this.onlySearchName = platformUtilsService.getDevice() === DeviceType.EdgeExtension;
     }
 
-    transform(ciphers: CipherView[], searchText: string): CipherView[] {
+    transform(ciphers: CipherView[], searchText: string, deleted: boolean = false): CipherView[] {
         if (ciphers == null || ciphers.length === 0) {
             return [];
         }
 
         if (searchText == null || searchText.length < 2) {
-            return ciphers;
+            return ciphers.filter((c) => {
+                return deleted !== c.isDeleted;
+            });
         }
 
         searchText = searchText.trim().toLowerCase();
         return ciphers.filter((c) => {
+            if (deleted !== c.isDeleted) {
+                return false;
+            }
             if (c.name != null && c.name.toLowerCase().indexOf(searchText) > -1) {
                 return true;
             }

--- a/src/enums/eventType.ts
+++ b/src/enums/eventType.ts
@@ -23,6 +23,8 @@ export enum EventType {
     Cipher_ClientCopiedHiddenField = 1112,
     Cipher_ClientCopiedCardCode = 1113,
     Cipher_ClientAutofilled = 1114,
+    Cipher_SoftDeleted = 1115,
+    Cipher_Restored = 1116,
 
     Collection_Created = 1300,
     Collection_Updated = 1301,

--- a/src/models/data/cipherData.ts
+++ b/src/models/data/cipherData.ts
@@ -31,6 +31,7 @@ export class CipherData {
     attachments?: AttachmentData[];
     passwordHistory?: PasswordHistoryData[];
     collectionIds?: string[];
+    deletedDate: string;
 
     constructor(response?: CipherResponse, userId?: string, collectionIds?: string[]) {
         if (response == null) {
@@ -49,6 +50,7 @@ export class CipherData {
         this.name = response.name;
         this.notes = response.notes;
         this.collectionIds = collectionIds != null ? collectionIds : response.collectionIds;
+        this.deletedDate = response.deletedDate;
 
         switch (this.type) {
             case CipherType.Login:

--- a/src/models/domain/cipher.ts
+++ b/src/models/domain/cipher.ts
@@ -34,6 +34,7 @@ export class Cipher extends Domain {
     fields: Field[];
     passwordHistory: Password[];
     collectionIds: string[];
+    deletedDate: Date;
 
     constructor(obj?: CipherData, alreadyEncrypted: boolean = false, localData: any = null) {
         super();
@@ -57,6 +58,7 @@ export class Cipher extends Domain {
         this.revisionDate = obj.revisionDate != null ? new Date(obj.revisionDate) : null;
         this.collectionIds = obj.collectionIds;
         this.localData = localData;
+        this.deletedDate = obj.deletedDate != null ? new Date(obj.deletedDate) : null;
 
         switch (this.type) {
             case CipherType.Login:
@@ -172,6 +174,7 @@ export class Cipher extends Domain {
         c.revisionDate = this.revisionDate != null ? this.revisionDate.toISOString() : null;
         c.type = this.type;
         c.collectionIds = this.collectionIds;
+        c.deletedDate = this.deletedDate != null ? this.deletedDate.toISOString() : null;
 
         this.buildDataModel(this, c, {
             name: null,

--- a/src/models/request/cipherBulkRestoreRequest.ts
+++ b/src/models/request/cipherBulkRestoreRequest.ts
@@ -1,0 +1,7 @@
+export class CipherBulkRestoreRequest {
+    ids: string[];
+
+    constructor(ids: string[]) {
+        this.ids = ids == null ? [] : ids;
+    }
+}

--- a/src/models/response/cipherResponse.ts
+++ b/src/models/response/cipherResponse.ts
@@ -27,6 +27,7 @@ export class CipherResponse extends BaseResponse {
     attachments: AttachmentResponse[];
     passwordHistory: PasswordHistoryResponse[];
     collectionIds: string[];
+    deletedDate: string;
 
     constructor(response: any) {
         super(response);
@@ -41,6 +42,7 @@ export class CipherResponse extends BaseResponse {
         this.organizationUseTotp = this.getResponseProperty('OrganizationUseTotp');
         this.revisionDate = this.getResponseProperty('RevisionDate');
         this.collectionIds = this.getResponseProperty('CollectionIds');
+        this.deletedDate = this.getResponseProperty('DeletedDate');
 
         const login = this.getResponseProperty('Login');
         if (login != null) {

--- a/src/models/view/cipherView.ts
+++ b/src/models/view/cipherView.ts
@@ -31,6 +31,7 @@ export class CipherView implements View {
     passwordHistory: PasswordHistoryView[] = null;
     collectionIds: string[] = null;
     revisionDate: Date = null;
+    deletedDate: Date = null;
 
     constructor(c?: Cipher) {
         if (!c) {
@@ -47,6 +48,7 @@ export class CipherView implements View {
         this.localData = c.localData;
         this.collectionIds = c.collectionIds;
         this.revisionDate = c.revisionDate;
+        this.deletedDate = c.deletedDate;
     }
 
     get subTitle(): string {
@@ -96,5 +98,9 @@ export class CipherView implements View {
             return null;
         }
         return this.login.passwordRevisionDate;
+    }
+
+    get isDeleted(): boolean {
+        return this.deletedDate != null;
     }
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -434,6 +434,30 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/ciphers/import-organization?organizationId=' + organizationId, request, true, false);
     }
 
+    putDeleteCipher(id: string): Promise<any> {
+        return this.send('PUT', '/ciphers/' + id + '/delete', null, true, false);
+    }
+
+    putDeleteCipherAdmin(id: string): Promise<any> {
+        return this.send('PUT', '/ciphers/' + id + '/delete-admin', null, true, false);
+    }
+
+    putDeleteManyCiphers(request: CipherBulkDeleteRequest): Promise<any> {
+        return this.send('PUT', '/ciphers/delete', request, true, false);
+    }
+
+    putRestoreCipher(id: string): Promise<any> {
+        return this.send('PUT', '/ciphers/' + id + '/restore', null, true, false);
+    }
+
+    putRestoreCipherAdmin(id: string): Promise<any> {
+        return this.send('PUT', '/ciphers/' + id + '/restore-admin', null, true, false);
+    }
+
+    putRestoreManyCiphers(request: CipherBulkDeleteRequest): Promise<any> {
+        return this.send('PUT', '/ciphers/restore', request, true, false);
+    }
+
     // Attachments APIs
 
     async postCipherAttachment(id: string, data: FormData): Promise<CipherResponse> {


### PR DESCRIPTION
Added the following changes with latest commit:
* **search.service.ts** - filter can be 1 or array of functions (or null or any combination, array with nulls, etc.)
  * removed deleted flag parameter for search function, ensure a deleted filter is included in call
* **components** - ensure restore functionality works, also ensure all deletes detect whether they should be soft or permanent deletes

> ## Objective
> Integrate the new API updates for soft delete (PUT /delete) and bulk operations as well as restore (PUT /restore) into the jslib common library for use by JavaScript based clients. This would integrate the fundamental tenants of:
> 
> * Items deleted now go to Trash (soft delete)
> * Items in Trash when deleted are deleted permanently
> * Items in Trash can be restored
> * Searching items excludes soft deleted items in Trash unless you are viewing the Trash
> * Delete/Restore operations follow the same pattern(s) as existing Delete operations (bulk/admin/org)
> * New event type enum changes are propagated to the client
