### PR TITLE
[Soft Delete] - view component to handle soft delete and restore

### DIFF
--- a/src/angular/components/add-edit.component.ts
+++ b/src/angular/components/add-edit.component.ts
@@ -328,8 +328,8 @@ export class AddEditComponent implements OnInit {
 
     async delete(): Promise<boolean> {
         const confirmed = await this.platformUtilsService.showDialog(
-            this.i18nService.t('deleteItemConfirmation'), this.i18nService.t('deleteItem'),
-            this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
+            this.i18nService.t(this.cipher.isDeleted ? 'permanentlyDeleteItemConfirmation' : 'deleteItemConfirmation'),
+            this.i18nService.t('deleteItem'), this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
         if (!confirmed) {
             return false;
         }

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -27,7 +27,6 @@ import { CipherView } from '../../models/view/cipherView';
 import { FieldView } from '../../models/view/fieldView';
 import { LoginUriView } from '../../models/view/loginUriView';
 import { BroadcasterService } from '../services/broadcaster.service';
-import { Cipher } from '../../models/domain';
 
 const BroadcasterSubscriptionId = 'ViewComponent';
 
@@ -35,8 +34,8 @@ export class ViewComponent implements OnDestroy, OnInit {
     @Input() cipherId: string;
     @Output() onEditCipher = new EventEmitter<CipherView>();
     @Output() onCloneCipher = new EventEmitter<CipherView>();
-    @Output() onRestoredCipher = new EventEmitter<CipherView>();
     @Output() onDeletedCipher = new EventEmitter<CipherView>();
+    @Output() onRestoredCipher = new EventEmitter<CipherView>();
 
     cipher: CipherView;
     showPassword: boolean;

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -27,6 +27,7 @@ import { CipherView } from '../../models/view/cipherView';
 import { FieldView } from '../../models/view/fieldView';
 import { LoginUriView } from '../../models/view/loginUriView';
 import { BroadcasterService } from '../services/broadcaster.service';
+import { Cipher } from '../../models/domain';
 
 const BroadcasterSubscriptionId = 'ViewComponent';
 
@@ -34,7 +35,8 @@ export class ViewComponent implements OnDestroy, OnInit {
     @Input() cipherId: string;
     @Output() onEditCipher = new EventEmitter<CipherView>();
     @Output() onCloneCipher = new EventEmitter<CipherView>();
-    @Output() onRestoreCipher = new EventEmitter<CipherView>();
+    @Output() onRestoredCipher = new EventEmitter<CipherView>();
+    @Output() onDeletedCipher = new EventEmitter<CipherView>();
 
     cipher: CipherView;
     showPassword: boolean;
@@ -111,11 +113,45 @@ export class ViewComponent implements OnDestroy, OnInit {
         this.onCloneCipher.emit(this.cipher);
     }
 
-    restore() {
-        if (!this.cipher.isDeleted) {
-            return;
+    async delete(): Promise<boolean> {
+        const confirmed = await this.platformUtilsService.showDialog(
+            this.i18nService.t(this.cipher.isDeleted ? 'permanentlyDeleteItemConfirmation' : 'deleteItemConfirmation'),
+            this.i18nService.t('deleteItem'), this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
+        if (!confirmed) {
+            return false;
         }
-        this.onRestoreCipher.emit(this.cipher);
+
+        try {
+            await this.deleteCipher();
+            this.platformUtilsService.eventTrack((this.cipher.isDeleted ? 'Permanently ' : '') + 'Deleted Cipher');
+            this.platformUtilsService.showToast('success', null,
+                this.i18nService.t(this.cipher.isDeleted ? 'permanentlyDeletedItem' : 'deletedItem'));
+            this.onDeletedCipher.emit(this.cipher);
+        } catch { }
+
+        return true;
+    }
+
+    async restore(): Promise<boolean> {
+        if (!this.cipher.isDeleted) {
+            return false;
+        }
+
+        const confirmed = await this.platformUtilsService.showDialog(
+            this.i18nService.t('restoreItemConfirmation'), this.i18nService.t('restoreItem'),
+            this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
+        if (!confirmed) {
+            return false;
+        }
+
+        try {
+            await this.restoreCipher();
+            this.platformUtilsService.eventTrack('Restored Cipher');
+            this.platformUtilsService.showToast('success', null, this.i18nService.t('restoredItem'));
+            this.onRestoredCipher.emit(this.cipher);
+        } catch { }
+
+        return true;
     }
 
     togglePassword() {
@@ -223,6 +259,15 @@ export class ViewComponent implements OnDestroy, OnInit {
         }
 
         a.downloading = false;
+    }
+
+    protected deleteCipher() {
+        return this.cipher.isDeleted ? this.cipherService.deleteWithServer(this.cipher.id)
+            : this.cipherService.softDeleteWithServer(this.cipher.id);
+    }
+
+    protected restoreCipher() {
+        return this.cipherService.restoreWithServer(this.cipher.id);
     }
 
     private cleanUp() {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -310,6 +310,9 @@ export class CipherService implements CipherServiceAbstraction {
         const ciphers = await this.getAllDecrypted();
 
         return ciphers.filter((cipher) => {
+            if (cipher.isDeleted) {
+                return false;
+            }
             if (folder && cipher.folderId === groupingId) {
                 return true;
             } else if (!folder && cipher.collectionIds != null && cipher.collectionIds.indexOf(groupingId) > -1) {
@@ -352,6 +355,9 @@ export class CipherService implements CipherServiceAbstraction {
         }
 
         return ciphers.filter((cipher) => {
+            if (cipher.deletedDate != null) {
+                return false;
+            }
             if (includeOtherTypes != null && includeOtherTypes.indexOf(cipher.type) > -1) {
                 return true;
             }


### PR DESCRIPTION
## Overview
Previous changes to jslib modified the add-edit component to handle soft-delete and restore actions, however the web vault only uses that component, the other clients do use the view component. It was decided that we would add Delete actions to the View page, as well as for viewing a deleted item (from the trash) a Restore option would also be available from this screen.

## Changes
* **add-edit.component.ts** - Miss on the i18n service call to get the proper dialog text in the confirmation for permanent vs soft-delete
* **view.component.ts** - Added new events and actions for handling delete and restore operations and event emitters
* **cipher.service.ts** - Previously missed and now discovered when working on the browser extension, when fetching from all ciphers to match a URL, Domain, pattern, org, etc. also need to filter out the deleted items
