### PR TITLE
Remove tld checking

### DIFF
--- a/src/models/view/loginUriView.ts
+++ b/src/models/view/loginUriView.ts
@@ -74,7 +74,7 @@ export class LoginUriView implements View {
 
     get isWebsite(): boolean {
         const uri = this.launchUri;
-        return uri != null &&
+        return uri !== null && uri !== '' &&
             (uri.indexOf('http://') === 0 || uri.indexOf('https://') === 0);
     }
 
@@ -82,7 +82,7 @@ export class LoginUriView implements View {
         if (this._canLaunch != null) {
             return this._canLaunch;
         }
-        if (this.uri != null && this.match !== UriMatchType.RegularExpression) {
+        if (this.uri !== null && this.uri !== '' && this.match !== UriMatchType.RegularExpression) {
             const uri = this.launchUri;
             for (let i = 0; i < CanLaunchWhitelist.length; i++) {
                 if (uri.indexOf(CanLaunchWhitelist[i]) === 0) {
@@ -96,6 +96,6 @@ export class LoginUriView implements View {
     }
 
     get launchUri(): string {
-        return (this.uri != null && this.uri.indexOf('://') < 0) ? ('http://' + this.uri) : this.uri;
+        return (this.uri !== null && this.uri.indexOf('://') < 0) ? ('http://' + this.uri) : this.uri;
     }
 }

--- a/src/models/view/loginUriView.ts
+++ b/src/models/view/loginUriView.ts
@@ -95,6 +95,6 @@ export class LoginUriView implements View {
     }
 
     get launchUri(): string {
-        return this.uri.indexOf('://') < 0 && Utils.tldEndingRegex.test(this.uri) ? ('http://' + this.uri) : this.uri;
+        return this.uri.indexOf('://') < 0 ? ('http://' + this.uri) : this.uri;
     }
 }

--- a/src/models/view/loginUriView.ts
+++ b/src/models/view/loginUriView.ts
@@ -73,8 +73,9 @@ export class LoginUriView implements View {
     }
 
     get isWebsite(): boolean {
-        return this.uri != null && (this.uri.indexOf('http://') === 0 || this.uri.indexOf('https://') === 0 ||
-            (this.uri.indexOf('://') < 0 && Utils.tldEndingRegex.test(this.uri)));
+        const uri = this.launchUri;
+        return uri != null &&
+            (uri.indexOf('http://') === 0 || uri.indexOf('https://') === 0);
     }
 
     get canLaunch(): boolean {
@@ -95,6 +96,6 @@ export class LoginUriView implements View {
     }
 
     get launchUri(): string {
-        return this.uri.indexOf('://') < 0 ? ('http://' + this.uri) : this.uri;
+        return (this.uri != null && this.uri.indexOf('://') < 0) ? ('http://' + this.uri) : this.uri;
     }
 }


### PR DESCRIPTION
Fix https://github.com/bitwarden/web/issues/507

Uri doesn't systematically have a tld. Even more from the list defined in the regex "tldEndingRegex" (/.*\.(com|net|org|edu|uk|gov|ca|de|jp|fr|au|ru|ch|io|es|us|co|xyz|info|ly|mil)$/) in src/misc/utils.ts

Considere the uri as a "http" resource if the user doesn't provide a scheme.