### PR TITLE
Enable alternative ways for settings passwords

### DIFF
--- a/src/cli/commands/login.command.ts
+++ b/src/cli/commands/login.command.ts
@@ -41,10 +41,10 @@ export class LoginCommand {
         }
 
         if (password == null || password === '') {
-            if (cmd.passwordFile) {
-                password = await NodeUtils.readFirstLine(cmd.passwordFile);
-            } else if (cmd.passwordEnv && process.env[cmd.passwordEnv]) {
-                password = process.env[cmd.passwordEnv];
+            if (cmd.passwordfile) {
+                password = await NodeUtils.readFirstLine(cmd.passwordfile);
+            } else if (cmd.passwordenv && process.env[cmd.passwordenv]) {
+                password = process.env[cmd.passwordenv];
             } else if (canInteract) {
                 const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
                     type: 'password',

--- a/src/misc/nodeUtils.ts
+++ b/src/misc/nodeUtils.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as readline from 'readline';
 import * as path from 'path';
 
 export class NodeUtils {
@@ -12,5 +13,17 @@ export class NodeUtils {
             }
             return dir;
         }, initialDir);
+    }
+    static readFirstLine(fileName: string) {
+        return new Promise<string>((resolve, reject) => {
+            const readStream = fs.createReadStream(fileName, {encoding: 'utf8'});
+            const readInterface = readline.createInterface(readStream);
+            readInterface
+                .on('line', line => {
+                    readStream.close();
+                    resolve(line);
+                })
+                .on('error', err => reject(err));
+        });
     }
 }

--- a/src/misc/nodeUtils.ts
+++ b/src/misc/nodeUtils.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
-import * as readline from 'readline';
 import * as path from 'path';
+import * as readline from 'readline';
 
 export class NodeUtils {
     static mkdirpSync(targetDir: string, mode = '700', relative = false, relativeDir: string = null) {
@@ -19,11 +19,11 @@ export class NodeUtils {
             const readStream = fs.createReadStream(fileName, {encoding: 'utf8'});
             const readInterface = readline.createInterface(readStream);
             readInterface
-                .on('line', line => {
+                .on('line', (line) => {
                     readStream.close();
                     resolve(line);
                 })
-                .on('error', err => reject(err));
+                .on('error', (err) => reject(err));
         });
     }
 }


### PR DESCRIPTION
* the environment variable BW_PASSWORD
* prefix the command line argument with "file:" and the password will read from the first line of that file
* prefix the command line argument with "env:" and the password will be read from that environment variable

I would like to avoid giving passwords on command lines. From the command line it would then be written into command histories and visible to other users and processes on the same machine.