### PR TITLE
Resolve edit always being true for ciphers

### DIFF
--- a/src/models/response/cipherResponse.ts
+++ b/src/models/response/cipherResponse.ts
@@ -38,7 +38,7 @@ export class CipherResponse extends BaseResponse {
         this.name = this.getResponseProperty('Name');
         this.notes = this.getResponseProperty('Notes');
         this.favorite = this.getResponseProperty('Favorite') || false;
-        this.edit = this.getResponseProperty('Edit') || true;
+        this.edit = !!this.getResponseProperty('Edit');
         this.organizationUseTotp = this.getResponseProperty('OrganizationUseTotp');
         this.revisionDate = this.getResponseProperty('RevisionDate');
         this.collectionIds = this.getResponseProperty('CollectionIds');


### PR DESCRIPTION
I noticed that ciphers will always have `edit = True` even if the sync response has `edit = false`.

The root cause seems to be a boolean default to true. And since `false || true => true` it would always be set to true.