### PR TITLE
Bug fix: made lock default conditional check

### DIFF
--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -81,7 +81,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         if (diffSeconds >= vaultTimeoutSeconds) {
             // Pivot based on the saved vault timeout action
             const timeoutAction = await this.storageService.get<string>(ConstantsService.vaultTimeoutActionKey);
-            timeoutAction === 'lock' ? await this.lock(true) : await this.logOut();
+            timeoutAction === 'logOut' ? await this.logOut() : await this.lock(true);
         }
     }
 


### PR DESCRIPTION
## Objective
> Fix bug reported where during upgrade, defaults for a `null` timeout action resulted in user's being logged out.

## Code Changes
- **vaultTimeout.service.ts**: Updated conditional to properly default to a locked state instead of logging out (incase the action is `null`) 