### PR TITLE
Add support for SOCKS proxy through 'socks_proxy' environment variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,6 +4041,11 @@
         }
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -7361,6 +7366,11 @@
         "string-width": "^1.0.1"
       }
     },
+    "smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7542,6 +7552,48 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
+        }
+      }
+    },
+    "socks": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+          "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "node-forge": "0.7.6",
     "papaparse": "4.6.0",
     "rxjs": "6.3.3",
+    "socks-proxy-agent": "5.0.0",
     "tldjs": "2.3.1",
     "zone.js": "0.8.28",
     "zxcvbn": "4.4.2"

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,6 +1,7 @@
 import * as FormData from 'form-data';
 import * as HttpsProxyAgent from 'https-proxy-agent';
 import * as fe from 'node-fetch';
+import { SocksProxyAgent } from 'socks-proxy-agent';
 
 import { ApiService } from './api.service';
 
@@ -20,9 +21,12 @@ export class NodeApiService extends ApiService {
     }
 
     nativeFetch(request: Request): Promise<Response> {
-        const proxy = process.env.http_proxy || process.env.https_proxy;
-        if (proxy) {
-            (request as any).agent = new HttpsProxyAgent(proxy);
+        const httpProxy = process.env.http_proxy || process.env.https_proxy;
+        const socksProxy = process.env.socks_proxy;
+        if (httpProxy) {
+            (request as any).agent = new HttpsProxyAgent(httpProxy);
+        } else if (socksProxy) {
+            (request as any).agent = new SocksProxyAgent(socksProxy);
         }
         return fetch(request);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "emitDecoratorMetadata": true,
     "declarationDir": "dist/types",
     "outDir": "dist",
+    "skipLibCheck": true,
     "typeRoots": [
       "node_modules/@types"
     ]


### PR DESCRIPTION
This PR is mostly intended for the [Bitwarden CLI](/bitwarden/cli). Adding support for a SOCKS4 or SOCKS5 proxy by using the `socks-proxy-agent` library. 

Since jslib already supports HTTP or HTTPS proxies through the `http_proxy` or `https_proxy` environment variables respectively, it made sense to also support SOCKS proxies. The SOCKS proxy library is provided by the same author being `https-proxy-agent`.

Example usage:
```bash
socks_proxy=socks5h://127.0.01:8010 bw login
```