### PR TITLE
check for empty string on malformed URL

### DIFF
--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -157,7 +157,7 @@ export class Utils {
     static getHostname(uriString: string): string {
         const url = Utils.getUrl(uriString);
         try {
-            return url != null ? url.hostname : null;
+            return url != null && url.hostname !== '' ? url.hostname : null;
         } catch {
             return null;
         }
@@ -166,7 +166,7 @@ export class Utils {
     static getHost(uriString: string): string {
         const url = Utils.getUrl(uriString);
         try {
-            return url != null ? url.host : null;
+            return url != null && url.host !== '' ? url.host : null;
         } catch {
             return null;
         }


### PR DESCRIPTION
When parsing a URL string that meets the proper format to construct a URL, but the hostname/host is malformed, you end up with an empty string for the hostname/host rather than `null`. We handle the `null` condition when comparing URLs for autofill, but not an empty string. This leads to two malformed hostnames/hosts being able to match `('' === '') == true`. This PR ensures that hostname/host parsing always treats an empty string the same as `null`.

resolves https://github.com/bitwarden/browser/issues/1267