### PR TITLE
Ensure viewPassword has a default value

### DIFF
--- a/src/models/domain/cipher.ts
+++ b/src/models/domain/cipher.ts
@@ -56,7 +56,11 @@ export class Cipher extends Domain {
         this.favorite = obj.favorite;
         this.organizationUseTotp = obj.organizationUseTotp;
         this.edit = obj.edit;
-        this.viewPassword = obj.viewPassword;
+        if (obj.viewPassword != null) {
+            this.viewPassword = obj.viewPassword;
+        } else {
+            this.viewPassword = true; // Default for already synced Ciphers without viewPassword
+        }
         this.revisionDate = obj.revisionDate != null ? new Date(obj.revisionDate) : null;
         this.collectionIds = obj.collectionIds;
         this.localData = localData;


### PR DESCRIPTION
Resolves bitwarden/mobile#973 for remaining client libs.

Tested on:

- [x] Web
- [x] Desktop
- [x] Browser

Had to use a slightly different approach since default values in TypeScript are not set when casting objects. Hence why it's instead checked if the value is null (undefined) in `Cipher` and not `CipherData`.