### PR TITLE
[Business Portal] Added portal usage boolean to necessary objects

### DIFF
--- a/src/models/data/organizationData.ts
+++ b/src/models/data/organizationData.ts
@@ -16,6 +16,7 @@ export class OrganizationData {
     useTotp: boolean;
     use2fa: boolean;
     useApi: boolean;
+    useBusinessPortal: boolean;
     selfHost: boolean;
     usersGetPremium: boolean;
     seats: number;
@@ -35,6 +36,7 @@ export class OrganizationData {
         this.useTotp = response.useTotp;
         this.use2fa = response.use2fa;
         this.useApi = response.useApi;
+        this.useBusinessPortal = response.useBusinessPortal;
         this.selfHost = response.selfHost;
         this.usersGetPremium = response.usersGetPremium;
         this.seats = response.seats;

--- a/src/models/domain/organization.ts
+++ b/src/models/domain/organization.ts
@@ -16,6 +16,7 @@ export class Organization {
     useTotp: boolean;
     use2fa: boolean;
     useApi: boolean;
+    useBusinessPortal: boolean;
     selfHost: boolean;
     usersGetPremium: boolean;
     seats: number;
@@ -39,6 +40,7 @@ export class Organization {
         this.useTotp = obj.useTotp;
         this.use2fa = obj.use2fa;
         this.useApi = obj.useApi;
+        this.useBusinessPortal = obj.useBusinessPortal;
         this.selfHost = obj.selfHost;
         this.usersGetPremium = obj.usersGetPremium;
         this.seats = obj.seats;

--- a/src/models/response/profileOrganizationResponse.ts
+++ b/src/models/response/profileOrganizationResponse.ts
@@ -13,6 +13,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
     useTotp: boolean;
     use2fa: boolean;
     useApi: boolean;
+    useBusinessPortal: boolean;
     selfHost: boolean;
     usersGetPremium: boolean;
     seats: number;
@@ -34,6 +35,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
         this.useTotp = this.getResponseProperty('UseTotp');
         this.use2fa = this.getResponseProperty('Use2fa');
         this.useApi = this.getResponseProperty('UseApi');
+        this.useBusinessPortal = this.getResponseProperty('UseBusinessPortal');
         this.selfHost = this.getResponseProperty('SelfHost');
         this.usersGetPremium = this.getResponseProperty('UsersGetPremium');
         this.seats = this.getResponseProperty('Seats');


### PR DESCRIPTION
## Objective
> Create `UseBusinessPortal` boolean for use in client-side applications via jslib.

## Code Changes
- **organizationData.ts**: Added `useBusinessPortal` boolean and updated constructor
- **organization.ts**: Added `useBusinessPortal` boolean and updated constructor
- **profileOrganizationResponse.ts**: Added `useBusinessPortal` boolean and updated constructor to look for the newly added view from the server side API response.