### PR TITLE
Prevent malformed URLs from blocking the loading of the current tab

### DIFF
--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -204,9 +204,14 @@ export class Utils {
             } catch (e) { }
         }
 
-        const domain = tldjs != null && tldjs.getDomain != null ? tldjs.getDomain(uriString) : null;
-        if (domain != null) {
-            return domain;
+        try {
+            const domain = tldjs != null && tldjs.getDomain != null ? tldjs.getDomain(uriString) : null;
+
+            if (domain != null) {
+                return domain;
+            }
+        } catch {
+            return null;
         }
 
         return null;

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -333,11 +333,9 @@ export class CipherService implements CipherServiceAbstraction {
             this.settingsService.getEquivalentDomains().then((eqDomains: any[][]) => {
                 let matches: any[] = [];
                 eqDomains.forEach((eqDomain) => {
-                    try {
-                        if (eqDomain.length && eqDomain.indexOf(domain) >= 0) {
-                            matches = matches.concat(eqDomain);
-                        }
-                    } catch {}
+                    if (eqDomain.length && eqDomain.indexOf(domain) >= 0) {
+                        matches = matches.concat(eqDomain);
+                    }
                 });
 
                 if (!matches.length) {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -337,8 +337,7 @@ export class CipherService implements CipherServiceAbstraction {
                         if (eqDomain.length && eqDomain.indexOf(domain) >= 0) {
                             matches = matches.concat(eqDomain);
                         }
-                    }
-                    catch {}
+                    } catch {}
                 });
 
                 if (!matches.length) {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -333,9 +333,12 @@ export class CipherService implements CipherServiceAbstraction {
             this.settingsService.getEquivalentDomains().then((eqDomains: any[][]) => {
                 let matches: any[] = [];
                 eqDomains.forEach((eqDomain) => {
-                    if (eqDomain.length && eqDomain.indexOf(domain) >= 0) {
-                        matches = matches.concat(eqDomain);
+                    try {
+                        if (eqDomain.length && eqDomain.indexOf(domain) >= 0) {
+                            matches = matches.concat(eqDomain);
+                        }
                     }
+                    catch {}
                 });
 
                 if (!matches.length) {


### PR DESCRIPTION
## Objective

When loading the current tab, the cipher service loads creds matching the URL. It's possible to load malformed URLs into your matching, which then causes the entire tab to stop functioning. 

## Code Changes

**src/misc/utils.ts** The call to getDomain was throwing an error when URL was invalid. Wrapped with try / catch and returned null in the event of issue, following the pattern in the rest of the method.

### Future Enhancement

We should do checking for malformed situations - see https://github.com/bitwarden/browser/issues/1295 for some examples - from being entered. 