### PR TITLE
Modified response to include port if exists

### DIFF
--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -159,7 +159,7 @@ export class Utils {
         try {
             let hostname = url != null && url.hostname !== '' ? url.hostname : null;
 
-            if(hostname != null && url.port !== '') {
+            if (hostname != null && url.port !== '') {
                 hostname += ":" + url.port;
             }
 

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -157,7 +157,13 @@ export class Utils {
     static getHostname(uriString: string): string {
         const url = Utils.getUrl(uriString);
         try {
-            return url != null && url.hostname !== '' ? url.hostname : null;
+            let hostname = url != null && url.hostname !== '' ? url.hostname : null;
+
+            if(hostname != null && url.port !== '') {
+                hostname += ":" + url.port;
+            }
+
+            return hostname;
         } catch {
             return null;
         }

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -157,13 +157,7 @@ export class Utils {
     static getHostname(uriString: string): string {
         const url = Utils.getUrl(uriString);
         try {
-            let hostname = url != null && url.hostname !== '' ? url.hostname : null;
-
-            if (hostname != null && url.port !== '') {
-                hostname += ":" + url.port;
-            }
-
-            return hostname;
+            return url != null && url.hostname !== '' ? url.hostname : null;
         } catch {
             return null;
         }

--- a/src/models/view/loginUriView.ts
+++ b/src/models/view/loginUriView.ts
@@ -26,6 +26,7 @@ export class LoginUriView implements View {
     private _uri: string = null;
     private _domain: string = null;
     private _hostname: string = null;
+    private _host: string = null;
     private _canLaunch: boolean = null;
     // tslint:enable
 
@@ -62,7 +63,7 @@ export class LoginUriView implements View {
             return null;
         }
         if (this._hostname == null && this.uri != null) {
-            this._hostname = Utils.getHost(this.uri);
+            this._hostname = Utils.getHostname(this.uri);
             if (this._hostname === '') {
                 this._hostname = null;
             }
@@ -71,8 +72,26 @@ export class LoginUriView implements View {
         return this._hostname;
     }
 
+    get host(): string {
+        if (this.match === UriMatchType.RegularExpression) {
+            return null;
+        }
+        if (this._host == null && this.uri != null) {
+            this._host = Utils.getHost(this.uri);
+            if (this._host === '') {
+                this._host = null;
+            }
+        }
+
+        return this._host;
+    }
+
     get hostnameOrUri(): string {
         return this.hostname != null ? this.hostname : this.uri;
+    }
+
+    get hostOrUri(): string {
+        return this.host != null ? this.host : this.uri;
     }
 
     get isWebsite(): boolean {

--- a/src/models/view/loginUriView.ts
+++ b/src/models/view/loginUriView.ts
@@ -62,7 +62,7 @@ export class LoginUriView implements View {
             return null;
         }
         if (this._hostname == null && this.uri != null) {
-            this._hostname = Utils.getHostname(this.uri);
+            this._hostname = Utils.getHost(this.uri);
             if (this._hostname === '') {
                 this._hostname = null;
             }


### PR DESCRIPTION
## Objective

It was requested in https://github.com/bitwarden/desktop/issues/449 that we don't parse out port in the Website list. Small modification / request, added port if it exists to the host that returns from getHostname to support this request.

## Code Changes

**src/misc/utils.ts** Modified response - added if port isn't null, append to end of hostname.