### PR TITLE
move bio prompt to onInit in desktop

### DIFF
--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -1,6 +1,5 @@
 import { OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { first } from 'rxjs/operators';
 
 import { ApiService } from '../../abstractions/api.service';
 import { CryptoService } from '../../abstractions/crypto.service';
@@ -59,11 +58,6 @@ export class LockComponent implements OnInit {
             vaultUrl = 'https://bitwarden.com';
         }
         this.webVaultHostname = Utils.getHostname(vaultUrl);
-        this.router.routerState.root.queryParams.pipe(first()).subscribe((params) => {
-            if (this.supportsBiometric && params.promptBiometric) {
-                this.unlockBiometric();
-            }
-        });
     }
 
     async submit() {


### PR DESCRIPTION
Prompting for biometrics based on a query parameter is more suited for the individual client implementation of the lock component. I also could not get the original implementation here in jslib to build.