### PR TITLE
auth service support for "complete" sso login

### DIFF
--- a/src/abstractions/auth.service.ts
+++ b/src/abstractions/auth.service.ts
@@ -18,6 +18,8 @@ export abstract class AuthService {
         remember?: boolean) => Promise<AuthResult>;
     logInComplete: (email: string, masterPassword: string, twoFactorProvider: TwoFactorProviderType,
         twoFactorToken: string, remember?: boolean) => Promise<AuthResult>;
+    logInSsoComplete: (code: string, codeVerifier: string, redirectUrl: string,
+        twoFactorProvider: TwoFactorProviderType, twoFactorToken: string, remember?: boolean) => Promise<AuthResult>;
     logOut: (callback: Function) => void;
     getSupportedTwoFactorProviders: (win: Window) => any[];
     getDefaultTwoFactorProvider: (u2fSupported: boolean) => TwoFactorProviderType;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -142,6 +142,13 @@ export class AuthService implements AuthServiceAbstraction {
             remember);
     }
 
+    async logInSsoComplete(code: string, codeVerifier: string, redirectUrl: string,
+        twoFactorProvider: TwoFactorProviderType, twoFactorToken: string, remember?: boolean): Promise<AuthResult> {
+        this.selectedTwoFactorProviderType = null;
+        return await this.logInHelper(null, null, code, codeVerifier, redirectUrl, null,
+            twoFactorProvider, twoFactorToken, remember);
+    }
+
     logOut(callback: Function) {
         callback();
         this.messagingService.send('loggedOut');


### PR DESCRIPTION
Adds "complete" sso login method which support 2FA + sso code login in one step. This flow is used in the CLI and complements the existing "complete" login method for email/password.