### PR TITLE
added try-catch around ext module calls

### DIFF
--- a/src/electron/biometric.windows.main.ts
+++ b/src/electron/biometric.windows.main.ts
@@ -62,12 +62,17 @@ export default class BiometricWindowsMain implements BiometricMain {
         const module = this.getWindowsSecurityCredentialsUiModule();
         if (module != null) {
             return new Promise((resolve, reject) => {
-                module.UserConsentVerifier.checkAvailabilityAsync((error: Error, result: any) => {
-                    if (error) {
-                        return resolve(null);
-                    }
-                    return resolve(result);
-                });
+                try {
+                    module.UserConsentVerifier.checkAvailabilityAsync((error: Error, result: any) => {
+                        if (error) {
+                            return resolve(null);
+                        }
+                        return resolve(result);
+                    });
+                } catch {
+                    this.isError = true;
+                    return resolve(null);
+                }
             });
         }
         return Promise.resolve(null);
@@ -77,25 +82,32 @@ export default class BiometricWindowsMain implements BiometricMain {
         const module = this.getWindowsSecurityCredentialsUiModule();
         if (module != null) {
             return new Promise((resolve, reject) => {
-                module.UserConsentVerifier.requestVerificationAsync(message, (error: Error, result: any) => {
-                    if (error) {
-                        return resolve(null);
-                    }
-                    return resolve(result);
-                });
+                try {
+                    module.UserConsentVerifier.requestVerificationAsync(message, (error: Error, result: any) => {
+                        if (error) {
+                            return resolve(null);
+                        }
+                        return resolve(result);
+                    });
+                } catch (error) {
+                    this.isError = true;
+                    return reject(error);
+                }
             });
         }
         return Promise.resolve(null);
     }
 
     getAllowedAvailabilities(): any[] {
-        const module = this.getWindowsSecurityCredentialsUiModule();
-        if (module != null) {
-            return [
-                module.UserConsentVerifierAvailability.available,
-                module.UserConsentVerifierAvailability.deviceBusy,
-            ];
-        }
+        try {
+            const module = this.getWindowsSecurityCredentialsUiModule();
+            if (module != null) {
+                return [
+                    module.UserConsentVerifierAvailability.available,
+                    module.UserConsentVerifierAvailability.deviceBusy,
+                ];
+            }
+        } catch { /*Ignore error*/ }
         return [];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/bitwarden/desktop/issues/507

This _should_ resolve an issue where the NodeRT module successfully loads on a Windows 7 machine due to necessary development libraries, etc. being present for a VC++ developer, however then fails at run time with an application crash because the appropriate Windows APIs are not present/available when invoked by the library.