### PR TITLE
Upgrade TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,9 +325,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
+      "version": "12.12.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
+      "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -8129,9 +8129,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -8142,34 +8142,11 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.3",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.13.0",
+        "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-          "dev": true
-        }
       }
     },
     "tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8129,9 +8129,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -8142,11 +8142,34 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
       }
     },
     "tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -846,53 +846,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
@@ -2778,9 +2731,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diffie-hellman": {
@@ -4532,12 +4485,6 @@
           "dev": true
         }
       }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -8182,65 +8129,46 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
-      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "tslib": "^1.13.0",
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "minimist": "^1.2.5"
           }
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -8308,9 +8236,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
+      "integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,9 +325,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-      "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
+      "version": "10.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^2.6.2",
     "tslint": "^5.12.1",
     "typemoq": "^2.1.0",
-    "typescript": "3.2.4"
+    "typescript": "3.6.5"
   },
   "dependencies": {
     "@angular/animations": "7.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/jasmine": "^3.3.12",
     "@types/lowdb": "^1.0.5",
     "@types/lunr": "^2.3.3",
-    "@types/node": "^12.12.54",
+    "@types/node": "^10.17.28",
     "@types/node-fetch": "^2.1.2",
     "@types/node-forge": "^0.7.5",
     "@types/papaparse": "^4.5.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/jasmine": "^3.3.12",
     "@types/lowdb": "^1.0.5",
     "@types/lunr": "^2.3.3",
-    "@types/node": "^10.9.4",
+    "@types/node": "^12.12.54",
     "@types/node-fetch": "^2.1.2",
     "@types/node-forge": "^0.7.5",
     "@types/papaparse": "^4.5.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "karma-typescript": "^4.0.0",
     "nodemon": "^1.17.3",
     "rimraf": "^2.6.2",
-    "tslint": "^5.12.1",
+    "tslint": "^6.1.3",
     "typemoq": "^2.1.0",
     "typescript": "3.6.5"
   },

--- a/src/abstractions/collection.service.ts
+++ b/src/abstractions/collection.service.ts
@@ -14,7 +14,7 @@ export abstract class CollectionService {
     get: (id: string) => Promise<Collection>;
     getAll: () => Promise<Collection[]>;
     getAllDecrypted: () => Promise<CollectionView[]>;
-    getAllNested: (collections?: CollectionView[]) => Promise<Array<TreeNode<CollectionView>>>;
+    getAllNested: (collections?: CollectionView[]) => Promise<TreeNode<CollectionView>[]>;
     getNested: (id: string) => Promise<TreeNode<CollectionView>>;
     upsert: (collection: CollectionData | CollectionData[]) => Promise<any>;
     replace: (collections: { [id: string]: CollectionData; }) => Promise<any>;

--- a/src/abstractions/folder.service.ts
+++ b/src/abstractions/folder.service.ts
@@ -14,7 +14,7 @@ export abstract class FolderService {
     get: (id: string) => Promise<Folder>;
     getAll: () => Promise<Folder[]>;
     getAllDecrypted: () => Promise<FolderView[]>;
-    getAllNested: () => Promise<Array<TreeNode<FolderView>>>;
+    getAllNested: () => Promise<TreeNode<FolderView>[]>;
     getNested: (id: string) => Promise<TreeNode<FolderView>>;
     saveWithServer: (folder: Folder) => Promise<any>;
     upsert: (folder: FolderData | FolderData[]) => Promise<any>;

--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -5,7 +5,7 @@ export abstract class SearchService {
     isSearchable: (query: string) => boolean;
     indexCiphers: () => Promise<void>;
     searchCiphers: (query: string,
-        filter?: ((cipher: CipherView) => boolean) | (Array<(cipher: CipherView) => boolean>),
+        filter?: ((cipher: CipherView) => boolean) | (((cipher: CipherView) => boolean)[]),
         ciphers?: CipherView[]) => Promise<CipherView[]>;
     searchCiphersBasic: (ciphers: CipherView[], query: string, deleted?: boolean) => CipherView[];
 }

--- a/src/angular/components/groupings.component.ts
+++ b/src/angular/components/groupings.component.ts
@@ -34,9 +34,9 @@ export class GroupingsComponent {
     @Output() onCollectionClicked = new EventEmitter<CollectionView>();
 
     folders: FolderView[];
-    nestedFolders: Array<TreeNode<FolderView>>;
+    nestedFolders: TreeNode<FolderView>[];
     collections: CollectionView[];
-    nestedCollections: Array<TreeNode<CollectionView>>;
+    nestedCollections: TreeNode<CollectionView>[];
     loaded: boolean = false;
     cipherType = CipherType;
     selectedAll: boolean = false;

--- a/src/importers/kasperskyTxtImporter.ts
+++ b/src/importers/kasperskyTxtImporter.ts
@@ -75,11 +75,11 @@ export class KasperskyTxtImporter extends BaseImporter implements Importer {
         return result;
     }
 
-    private parseDataCategory(data: string): Array<Map<string, string>> {
+    private parseDataCategory(data: string): Map<string, string>[] {
         if (this.isNullOrWhitespace(data) || data.indexOf(Delimiter) === -1) {
             return [];
         }
-        const items: Array<Map<string, string>> = [];
+        const items: Map<string, string>[] = [];
         data.split(Delimiter).forEach((p) => {
             if (p.indexOf('\n') === -1) {
                 return;

--- a/src/misc/serviceUtils.ts
+++ b/src/misc/serviceUtils.ts
@@ -4,7 +4,7 @@ import {
 } from '../models/domain/treeNode';
 
 export class ServiceUtils {
-    static nestedTraverse(nodeTree: Array<TreeNode<ITreeNodeObject>>, partIndex: number, parts: string[],
+    static nestedTraverse(nodeTree: TreeNode<ITreeNodeObject>[], partIndex: number, parts: string[],
         obj: ITreeNodeObject, parent: ITreeNodeObject, delimiter: string) {
         if (parts.length <= partIndex) {
             return;
@@ -38,7 +38,7 @@ export class ServiceUtils {
         }
     }
 
-    static getTreeNodeObject(nodeTree: Array<TreeNode<ITreeNodeObject>>, id: string): TreeNode<ITreeNodeObject> {
+    static getTreeNodeObject(nodeTree: TreeNode<ITreeNodeObject>[], id: string): TreeNode<ITreeNodeObject> {
         for (let i = 0; i < nodeTree.length; i++) {
             if (nodeTree[i].node.id === id) {
                 return nodeTree[i];

--- a/src/misc/throttle.ts
+++ b/src/misc/throttle.ts
@@ -8,14 +8,14 @@ export function throttle(limit: number, throttleKey: (args: any[]) => string) {
     return <T>(target: any, propertyKey: string | symbol,
         descriptor: TypedPropertyDescriptor<(...args: any[]) => Promise<T>>) => {
         const originalMethod: () => Promise<T> = descriptor.value;
-        const allThrottles = new Map<any, Map<string, Array<() => void>>>();
+        const allThrottles = new Map<any, Map<string, (() => void)[]>>();
 
         const getThrottles = (obj: any) => {
             let throttles = allThrottles.get(obj);
             if (throttles != null) {
                 return throttles;
             }
-            throttles = new Map<string, Array<() => void>>();
+            throttles = new Map<string, (() => void)[]>();
             allThrottles.set(obj, throttles);
             return throttles;
         };

--- a/src/models/domain/importResult.ts
+++ b/src/models/domain/importResult.ts
@@ -7,7 +7,7 @@ export class ImportResult {
     errorMessage: string;
     ciphers: CipherView[] = [];
     folders: FolderView[] = [];
-    folderRelationships: Array<[number, number]> = [];
+    folderRelationships: [number, number][] = [];
     collections: CollectionView[] = [];
-    collectionRelationships: Array<[number, number]> = [];
+    collectionRelationships: [number, number][] = [];
 }

--- a/src/models/domain/treeNode.ts
+++ b/src/models/domain/treeNode.ts
@@ -1,7 +1,7 @@
 export class TreeNode<T extends ITreeNodeObject> {
     parent: T;
     node: T;
-    children: Array<TreeNode<T>> = [];
+    children: TreeNode<T>[] = [];
 
     constructor(node: T, name: string, parent: T) {
         this.parent = parent;

--- a/src/models/request/importCiphersRequest.ts
+++ b/src/models/request/importCiphersRequest.ts
@@ -5,5 +5,5 @@ import { KvpRequest } from './kvpRequest';
 export class ImportCiphersRequest {
     ciphers: CipherRequest[] = [];
     folders: FolderRequest[] = [];
-    folderRelationships: Array<KvpRequest<number, number>> = [];
+    folderRelationships: KvpRequest<number, number>[] = [];
 }

--- a/src/models/request/importOrganizationCiphersRequest.ts
+++ b/src/models/request/importOrganizationCiphersRequest.ts
@@ -5,5 +5,5 @@ import { KvpRequest } from './kvpRequest';
 export class ImportOrganizationCiphersRequest {
     ciphers: CipherRequest[] = [];
     collections: CollectionRequest[] = [];
-    collectionRelationships: Array<KvpRequest<number, number>> = [];
+    collectionRelationships: KvpRequest<number, number>[] = [];
 }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -170,7 +170,7 @@ export class CipherService implements CipherServiceAbstraction {
             return null;
         }
 
-        const promises: Array<Promise<any>> = [];
+        const promises: Promise<any>[] = [];
         const encAttachments: Attachment[] = [];
         attachmentsModel.forEach(async (model) => {
             const attachment = new Attachment();
@@ -510,7 +510,7 @@ export class CipherService implements CipherServiceAbstraction {
     }
 
     async shareWithServer(cipher: CipherView, organizationId: string, collectionIds: string[]): Promise<any> {
-        const attachmentPromises: Array<Promise<any>> = [];
+        const attachmentPromises: Promise<any>[] = [];
         if (cipher.attachments != null) {
             cipher.attachments.forEach((attachment) => {
                 if (attachment.key == null) {
@@ -531,7 +531,7 @@ export class CipherService implements CipherServiceAbstraction {
     }
 
     async shareManyWithServer(ciphers: CipherView[], organizationId: string, collectionIds: string[]): Promise<any> {
-        const promises: Array<Promise<any>> = [];
+        const promises: Promise<any>[] = [];
         const encCiphers: Cipher[] = [];
         for (const cipher of ciphers) {
             cipher.organizationId = organizationId;

--- a/src/services/collection.service.ts
+++ b/src/services/collection.service.ts
@@ -51,7 +51,7 @@ export class CollectionService implements CollectionServiceAbstraction {
             return [];
         }
         const decCollections: CollectionView[] = [];
-        const promises: Array<Promise<any>> = [];
+        const promises: Promise<any>[] = [];
         collections.forEach((collection) => {
             promises.push(collection.decrypt().then((c) => decCollections.push(c)));
         });
@@ -98,11 +98,11 @@ export class CollectionService implements CollectionServiceAbstraction {
         return this.decryptedCollectionCache;
     }
 
-    async getAllNested(collections: CollectionView[] = null): Promise<Array<TreeNode<CollectionView>>> {
+    async getAllNested(collections: CollectionView[] = null): Promise<TreeNode<CollectionView>[]> {
         if (collections == null) {
             collections = await this.getAllDecrypted();
         }
-        const nodes: Array<TreeNode<CollectionView>> = [];
+        const nodes: TreeNode<CollectionView>[] = [];
         collections.forEach((c) => {
             const collectionCopy = new CollectionView();
             collectionCopy.id = c.id;

--- a/src/services/folder.service.ts
+++ b/src/services/folder.service.ts
@@ -81,7 +81,7 @@ export class FolderService implements FolderServiceAbstraction {
         }
 
         const decFolders: FolderView[] = [];
-        const promises: Array<Promise<any>> = [];
+        const promises: Promise<any>[] = [];
         const folders = await this.getAll();
         folders.forEach((folder) => {
             promises.push(folder.decrypt().then((f) => decFolders.push(f)));
@@ -98,9 +98,9 @@ export class FolderService implements FolderServiceAbstraction {
         return this.decryptedFolderCache;
     }
 
-    async getAllNested(): Promise<Array<TreeNode<FolderView>>> {
+    async getAllNested(): Promise<TreeNode<FolderView>[]> {
         const folders = await this.getAllDecrypted();
-        const nodes: Array<TreeNode<FolderView>> = [];
+        const nodes: TreeNode<FolderView>[] = [];
         folders.forEach((f) => {
             const folderCopy = new FolderView();
             folderCopy.id = f.id;

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -72,7 +72,7 @@ export class SearchService implements SearchServiceAbstraction {
     }
 
     async searchCiphers(query: string,
-        filter: (((cipher: CipherView) => boolean) | (Array<(cipher: CipherView) => boolean>)) = null,
+        filter: (((cipher: CipherView) => boolean) | (((cipher: CipherView) => boolean)[])) = null,
         ciphers: CipherView[] = null):
         Promise<CipherView[]> {
         const results: CipherView[] = [];


### PR DESCRIPTION
TypeScript 3.6+ is required to access newer versions of the navigator. apis.

- TypeScript updated to 3.6.5 which is the minimum minor version required.
- TSLint updated to latest, however TSlint is now deprecated so we probably want to switch to ESlint and Prettier sometime in the future.
- @types/node updated to 10.17.28