### PR TITLE
dont set keys if not there on sso

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -309,6 +309,7 @@ export class AuthService implements AuthServiceAbstraction {
                 await this.cryptoService.setKeyHash(hashedPassword);
             }
 
+            // Skip this step during SSO new user flow. No key is returned from server.
             if (code == null || tokenResponse.key != null) {
                 await this.cryptoService.setEncKey(tokenResponse.key);
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -308,21 +308,24 @@ export class AuthService implements AuthServiceAbstraction {
             if (hashedPassword != null) {
                 await this.cryptoService.setKeyHash(hashedPassword);
             }
-            await this.cryptoService.setEncKey(tokenResponse.key);
 
-            // User doesn't have a key pair yet (old account), let's generate one for them
-            if (tokenResponse.privateKey == null) {
-                try {
-                    const keyPair = await this.cryptoService.makeKeyPair();
-                    await this.apiService.postAccountKeys(new KeysRequest(keyPair[0], keyPair[1].encryptedString));
-                    tokenResponse.privateKey = keyPair[1].encryptedString;
-                } catch (e) {
-                    // tslint:disable-next-line
-                    console.error(e);
+            if (code == null || tokenResponse.key != null) {
+                await this.cryptoService.setEncKey(tokenResponse.key);
+
+                // User doesn't have a key pair yet (old account), let's generate one for them
+                if (tokenResponse.privateKey == null) {
+                    try {
+                        const keyPair = await this.cryptoService.makeKeyPair();
+                        await this.apiService.postAccountKeys(new KeysRequest(keyPair[0], keyPair[1].encryptedString));
+                        tokenResponse.privateKey = keyPair[1].encryptedString;
+                    } catch (e) {
+                        // tslint:disable-next-line
+                        console.error(e);
+                    }
                 }
-            }
 
-            await this.cryptoService.setEncPrivateKey(tokenResponse.privateKey);
+                await this.cryptoService.setEncPrivateKey(tokenResponse.privateKey);
+            }
         }
 
         if (this.vaultTimeoutService != null) {


### PR DESCRIPTION
On a new user SSO flow, there are no encryption keys to set on auth response. These are set later on in the process when setting the password for the first time.