### PR TITLE
[SSO] Set Password flow sync

### DIFF
--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -7,6 +7,7 @@ import { MessagingService } from '../../abstractions/messaging.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { PolicyService } from '../../abstractions/policy.service';
+import { SyncService } from '../../abstractions/sync.service';
 import { UserService } from '../../abstractions/user.service';
 
 import { CipherString } from '../../models/domain/cipherString';
@@ -29,9 +30,15 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     constructor(i18nService: I18nService, cryptoService: CryptoService, messagingService: MessagingService,
         userService: UserService, passwordGenerationService: PasswordGenerationService,
         platformUtilsService: PlatformUtilsService, policyService: PolicyService, private router: Router,
-        private apiService: ApiService) {
+        private apiService: ApiService, private syncService: SyncService) {
         super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
             platformUtilsService, policyService);
+    }
+
+    async ngOnInit() {
+        this.formPromise = this.syncService.fullSync(true);
+        await this.formPromise;
+        super.ngOnInit();
     }
 
     async setupSubmitActions() {

--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -21,7 +21,7 @@ import { ChangePasswordComponent as BaseChangePasswordComponent } from './change
 import { KdfType } from '../../enums/kdfType';
 
 export class SetPasswordComponent extends BaseChangePasswordComponent {
-    loadingSync: boolean = true;
+    syncLoading: boolean = true;
     showPassword: boolean = false;
     hint: string = '';
 
@@ -37,8 +37,8 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     }
 
     async ngOnInit() {
-
         await this.syncService.fullSync(true);
+        this.syncLoading = false;
         super.ngOnInit();
     }
 

--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -21,6 +21,7 @@ import { ChangePasswordComponent as BaseChangePasswordComponent } from './change
 import { KdfType } from '../../enums/kdfType';
 
 export class SetPasswordComponent extends BaseChangePasswordComponent {
+    loadingSync: boolean = true;
     showPassword: boolean = false;
     hint: string = '';
 
@@ -36,8 +37,8 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     }
 
     async ngOnInit() {
-        this.formPromise = this.syncService.fullSync(true);
-        await this.formPromise;
+
+        await this.syncService.fullSync(true);
         super.ngOnInit();
     }
 

--- a/src/cli/commands/login.command.ts
+++ b/src/cli/commands/login.command.ts
@@ -201,8 +201,8 @@ export class LoginCommand {
             }
 
             if (response.resetMasterPassword) {
-                return Response.error('In order to login with SSO from the CLI, you must first initiate the same' +
-                    ' process through the web vault to set a master password.');
+                return Response.error('In order to log in with SSO from the CLI, you must first log in' +
+                    ' through the web vault to set your master password.');
             }
 
             if (this.success != null) {

--- a/src/cli/commands/login.command.ts
+++ b/src/cli/commands/login.command.ts
@@ -200,6 +200,11 @@ export class LoginCommand {
                 return Response.error('Login failed.');
             }
 
+            if (response.resetMasterPassword) {
+                return Response.error('In order to login with SSO from the CLI, you must first initiate the same' +
+                    ' process through the web vault to set a master password.');
+            }
+
             if (this.success != null) {
                 const res = await this.success();
                 return Response.success(res);


### PR DESCRIPTION
## Objective
> The `set-password` flow needs to perform a full sync in order to pull down potential org policies. This flow will not be allowed on the `CLI` or `directory-connector` applications for the time being.

## Code Changes
- **set-password.component.ts**: Added private `syncService`. Added tracking boolean for UI management.
- **login.command.ts**: Added error response for `resetMasterPassword` flow. 