### PR TITLE
Wrap sso login with pre-validation check

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -306,4 +306,6 @@ export abstract class ApiService {
     getActiveBearerToken: () => Promise<string>;
     fetch: (request: Request) => Promise<Response>;
     nativeFetch: (request: Request) => Promise<Response>;
+
+    preValidateSso: (identifier: string) => Promise<boolean>;
 }

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -21,8 +21,10 @@ import { AuthResult } from '../../models/domain/authResult';
 export class SsoComponent {
     identifier: string;
     loggingIn = false;
+    initiatingSso = false;
 
     formPromise: Promise<AuthResult>;
+    initiateSsoFormPromise: Promise<boolean>;
     onSuccessfulLogin: () => Promise<any>;
     onSuccessfulLoginNavigate: () => Promise<any>;
     onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
@@ -67,9 +69,15 @@ export class SsoComponent {
     }
 
     async submit(returnUri?: string, includeUserIdentifier?: boolean) {
-        if (await this.preValidate()) {
-            const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier);
-            this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
+        this.initiatingSso = true;
+        try {
+            this.initiateSsoFormPromise = this.preValidate();
+            if (await this.initiateSsoFormPromise) {
+                const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier);
+                this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
+            }
+        } finally {
+            this.initiatingSso = false;
         }
     }
 

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -21,10 +21,9 @@ import { AuthResult } from '../../models/domain/authResult';
 export class SsoComponent {
     identifier: string;
     loggingIn = false;
-    initiatingSso = false;
 
     formPromise: Promise<AuthResult>;
-    initiateSsoFormPromise: Promise<boolean>;
+    initiateSsoFormPromise: Promise<any>;
     onSuccessfulLogin: () => Promise<any>;
     onSuccessfulLoginNavigate: () => Promise<any>;
     onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
@@ -69,15 +68,10 @@ export class SsoComponent {
     }
 
     async submit(returnUri?: string, includeUserIdentifier?: boolean) {
-        this.initiatingSso = true;
-        try {
-            this.initiateSsoFormPromise = this.preValidate();
-            if (await this.initiateSsoFormPromise) {
-                const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier);
-                this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
-            }
-        } finally {
-            this.initiatingSso = false;
+        this.initiateSsoFormPromise = this.preValidate();
+        if (await this.initiateSsoFormPromise) {
+            const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier);
+            this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
         }
     }
 
@@ -87,11 +81,7 @@ export class SsoComponent {
                 this.i18nService.t('ssoIdentifierRequired'));
             return false;
         }
-        return await this.apiService.preValidateSso(this.identifier).catch((errorResponse) => {
-            const message = errorResponse?.response?.message || this.i18nService.t('errorOccurred');
-            this.platformUtilsService.showToast('error', this.i18nService.t('ssoValidationFailed'), message);
-            return false;
-        });
+        return await this.apiService.preValidateSso(this.identifier);
     }
 
     protected async buildAuthorizeUrl(returnUri?: string, includeUserIdentifier?: boolean): Promise<string> {

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1040,6 +1040,35 @@ export class ApiService implements ApiServiceAbstraction {
         return fetch(request);
     }
 
+    async preValidateSso(identifier: string): Promise<boolean> {
+
+        if (identifier == null || identifier === '') {
+            throw new Error('Organization Identifier was not provided.');
+        }
+        const headers = new Headers({
+            'Accept': 'application/json',
+            'Device-Type': this.deviceType,
+        });
+        if (this.customUserAgent != null) {
+            headers.set('User-Agent', this.customUserAgent);
+        }
+
+        const path = `/account/prevalidate?domainHint=${encodeURIComponent(identifier)}`;
+        const response = await this.fetch(new Request(this.identityBaseUrl + path, {
+            cache: 'no-store',
+            credentials: this.getCredentials(),
+            headers: headers,
+            method: 'GET',
+        }));
+
+        if (response.status === 200) {
+            return true;
+        } else {
+            const error = await this.handleError(response, false);
+            return Promise.reject(error);
+        }
+    }
+
     private async send(method: 'GET' | 'POST' | 'PUT' | 'DELETE', path: string, body: any,
         authed: boolean, hasResponse: boolean): Promise<any> {
         const headers = new Headers({


### PR DESCRIPTION
## Overview
Added a pre-validation check for SSO calls to pass the org identifier (domain_hint) through the Identity PreValidate endpoint to ensure the SSO pipeline _should_ work end-to-end.

## Changes
* **api.service** - function calls the Identity /Account/PreValidate pre-validate endpoint which runs a full-spectrum deep validation of SSO setup before actually redirecting the user to attempt the SSO flow itself. This will show any error messages to the user in a friendly manner, and otherwise kick off the flow as usual/expected.
* **sso.component** - Added `preValidate()` method to wrap and handle the call to validate the domain_hint and pipe the error to the user if necessary.

## Screen Shot
![image](https://user-images.githubusercontent.com/3904944/91603939-d2f78300-e93b-11ea-93d5-6b98b2bb0a44.png)
