### PR TITLE
change to environmentService.getWebVaultUrl

### DIFF
--- a/src/cli/commands/login.command.ts
+++ b/src/cli/commands/login.command.ts
@@ -242,8 +242,10 @@ export class LoginCommand {
                 }
             });
             let foundPort = false;
-            const webUrl = this.environmentService.webVaultUrl == null ? 'https://vault.bitwarden.com' :
-                this.environmentService.webVaultUrl;
+            let webUrl = this.environmentService.getWebVaultUrl();
+            if (webUrl == null) {
+                webUrl = 'https://vault.bitwarden.com';
+            }
             for (let port = 8065; port <= 8070; port++) {
                 try {
                     this.ssoRedirectUri = 'http://localhost:' + port;


### PR DESCRIPTION
CLI login command was using `environmentService.webVaultUrl`, which does not include logic to check base URL first. This PR fixes it by using the helper function `environmentService.getWebVaultUrl`