### PR TITLE
remove old Edge browser hacks

### DIFF
--- a/spec/common/misc/utils.spec.ts
+++ b/spec/common/misc/utils.spec.ts
@@ -49,13 +49,6 @@ describe('Utils Service', () => {
             expect(Utils.getHostname('https://bitwarden.com')).toBe('bitwarden.com');
             expect(Utils.getHostname('http://bitwarden.com')).toBe('bitwarden.com');
             expect(Utils.getHostname('http://vault.bitwarden.com')).toBe('vault.bitwarden.com');
-
-            if (Utils.isNode || window.navigator.userAgent.indexOf(' Edge/') === -1) {
-                // Note: Broken in Edge browser. See
-                // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8004284/
-                expect(Utils.getHostname('https://user:password@bitwarden.com:8080/password/sites?and&query#hash'))
-                    .toBe('bitwarden.com');
-            }
         });
 
         it('should support localhost and IP', () => {

--- a/spec/web/services/webCryptoFunction.service.spec.ts
+++ b/spec/web/services/webCryptoFunction.service.spec.ts
@@ -380,8 +380,8 @@ function testRsaGenerateKeyPair(length: 1024 | 2048 | 4096) {
 
 function getWebCryptoFunctionService() {
     const platformUtilsMock = TypeMoq.Mock.ofType<PlatformUtilsService>(PlatformUtilsServiceMock);
-    platformUtilsMock.setup((x) => x.isEdge()).returns(() => navigator.userAgent.indexOf(' Edge/') !== -1);
-    platformUtilsMock.setup((x) => x.isIE()).returns(() => navigator.userAgent.indexOf(' Edge/') === -1 &&
+    platformUtilsMock.setup((x) => x.isEdge()).returns(() => navigator.userAgent.indexOf(' Edg/') !== -1);
+    platformUtilsMock.setup((x) => x.isIE()).returns(() => navigator.userAgent.indexOf(' Edg/') === -1 &&
         navigator.userAgent.indexOf(' Trident/') !== -1);
     return new WebCryptoFunctionService(window, platformUtilsMock.object);
 }

--- a/src/angular/components/register.component.ts
+++ b/src/angular/components/register.component.ts
@@ -105,7 +105,7 @@ export class RegisterComponent {
         this.name = this.name === '' ? null : this.name;
         this.email = this.email.trim().toLowerCase();
         const kdf = KdfType.PBKDF2_SHA256;
-        const useLowerKdf = this.platformUtilsService.isEdge() || this.platformUtilsService.isIE();
+        const useLowerKdf = this.platformUtilsService.isIE();
         const kdfIterations = useLowerKdf ? 10000 : 100000;
         const key = await this.cryptoService.makeKey(this.masterPassword, this.email, kdf, kdfIterations);
         const encKey = await this.cryptoService.makeEncKey(key);

--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -44,7 +44,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
 
     async setupSubmitActions() {
         this.kdf = KdfType.PBKDF2_SHA256;
-        const useLowerKdf = this.platformUtilsService.isEdge() || this.platformUtilsService.isIE();
+        const useLowerKdf = this.platformUtilsService.isIE();
         this.kdfIterations = useLowerKdf ? 10000 : 100000;
         return true;
     }

--- a/src/angular/pipes/search-ciphers.pipe.ts
+++ b/src/angular/pipes/search-ciphers.pipe.ts
@@ -10,7 +10,7 @@ import { CipherView } from '../../models/view/cipherView';
 })
 export class SearchCiphersPipe implements PipeTransform {
 
-    constructor(platformUtilsService: PlatformUtilsService) {
+    constructor() {
     }
 
     transform(ciphers: CipherView[], searchText: string, deleted: boolean = false): CipherView[] {

--- a/src/angular/pipes/search-ciphers.pipe.ts
+++ b/src/angular/pipes/search-ciphers.pipe.ts
@@ -5,18 +5,12 @@ import {
 
 import { CipherView } from '../../models/view/cipherView';
 
-import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
-
-import { DeviceType } from '../../enums';
-
 @Pipe({
     name: 'searchCiphers',
 })
 export class SearchCiphersPipe implements PipeTransform {
-    private onlySearchName = false;
 
     constructor(platformUtilsService: PlatformUtilsService) {
-        this.onlySearchName = platformUtilsService.getDevice() === DeviceType.EdgeExtension;
     }
 
     transform(ciphers: CipherView[], searchText: string, deleted: boolean = false): CipherView[] {
@@ -37,9 +31,6 @@ export class SearchCiphersPipe implements PipeTransform {
             }
             if (c.name != null && c.name.toLowerCase().indexOf(searchText) > -1) {
                 return true;
-            }
-            if (this.onlySearchName) {
-                return false;
             }
             if (searchText.length >= 8 && c.id.startsWith(searchText)) {
                 return true;

--- a/src/angular/pipes/search-ciphers.pipe.ts
+++ b/src/angular/pipes/search-ciphers.pipe.ts
@@ -9,10 +9,6 @@ import { CipherView } from '../../models/view/cipherView';
     name: 'searchCiphers',
 })
 export class SearchCiphersPipe implements PipeTransform {
-
-    constructor() {
-    }
-
     transform(ciphers: CipherView[], searchText: string, deleted: boolean = false): CipherView[] {
         if (ciphers == null || ciphers.length === 0) {
             return [];

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -3,22 +3,17 @@ import * as lunr from 'lunr';
 import { CipherView } from '../models/view/cipherView';
 
 import { CipherService } from '../abstractions/cipher.service';
-import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { SearchService as SearchServiceAbstraction } from '../abstractions/search.service';
 
 import { CipherType } from '../enums/cipherType';
-import { DeviceType } from '../enums/deviceType';
 import { FieldType } from '../enums/fieldType';
 import { UriMatchType } from '../enums/uriMatchType';
 
 export class SearchService implements SearchServiceAbstraction {
     private indexing = false;
     private index: lunr.Index = null;
-    private onlySearchName = false;
 
     constructor(private cipherService: CipherService, platformUtilsService: PlatformUtilsService) {
-        this.onlySearchName = platformUtilsService == null ||
-            platformUtilsService.getDevice() === DeviceType.EdgeExtension;
     }
 
     clearIndex(): void {
@@ -151,9 +146,6 @@ export class SearchService implements SearchServiceAbstraction {
             }
             if (c.name != null && c.name.toLowerCase().indexOf(query) > -1) {
                 return true;
-            }
-            if (this.onlySearchName) {
-                return false;
             }
             if (query.length >= 8 && c.id.startsWith(query)) {
                 return true;

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -13,7 +13,7 @@ export class SearchService implements SearchServiceAbstraction {
     private indexing = false;
     private index: lunr.Index = null;
 
-    constructor(private cipherService: CipherService, platformUtilsService: PlatformUtilsService) {
+    constructor(private cipherService: CipherService) {
     }
 
     clearIndex(): void {

--- a/src/services/webCryptoFunction.service.ts
+++ b/src/services/webCryptoFunction.service.ts
@@ -11,14 +11,12 @@ import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 export class WebCryptoFunctionService implements CryptoFunctionService {
     private crypto: Crypto;
     private subtle: SubtleCrypto;
-    private isEdge: boolean;
     private isIE: boolean;
     private isOldSafari: boolean;
 
     constructor(private win: Window, private platformUtilsService: PlatformUtilsService) {
         this.crypto = typeof win.crypto !== 'undefined' ? win.crypto : null;
         this.subtle = (!!this.crypto && typeof win.crypto.subtle !== 'undefined') ? win.crypto.subtle : null;
-        this.isEdge = platformUtilsService.isEdge();
         this.isIE = platformUtilsService.isIE();
         const ua = win.navigator.userAgent;
         this.isOldSafari = platformUtilsService.isSafari() &&
@@ -27,7 +25,7 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
 
     async pbkdf2(password: string | ArrayBuffer, salt: string | ArrayBuffer, algorithm: 'sha256' | 'sha512',
         iterations: number): Promise<ArrayBuffer> {
-        if (this.isEdge || this.isIE || this.isOldSafari) {
+        if (this.isIE || this.isOldSafari) {
             const forgeLen = algorithm === 'sha256' ? 32 : 64;
             const passwordBytes = this.toByteString(password);
             const saltBytes = this.toByteString(salt);
@@ -52,7 +50,7 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
     }
 
     async hash(value: string | ArrayBuffer, algorithm: 'sha1' | 'sha256' | 'sha512' | 'md5'): Promise<ArrayBuffer> {
-        if (((this.isEdge || this.isIE) && algorithm === 'sha1') || algorithm === 'md5') {
+        if ((this.isIE && algorithm === 'sha1') || algorithm === 'md5') {
             const md = algorithm === 'md5' ? forge.md.md5.create() : forge.md.sha1.create();
             const valueBytes = this.toByteString(value);
             md.update(valueBytes, 'raw');


### PR DESCRIPTION
Related to https://github.com/bitwarden/web/issues/653

## Overview
Old IE Edge is no longer supported. This PR removes the hacks put in place to support the older Edge version so that the newer Edge version, when properly detected as "Edge" doesn't invoke the same hacks (and essentially break).