### PR TITLE
Conditional load of biometrics API on Win10+

### DIFF
--- a/src/electron/biometric.windows.main.ts
+++ b/src/electron/biometric.windows.main.ts
@@ -113,13 +113,13 @@ export default class BiometricWindowsMain implements BiometricMain {
 
     getWindowsMajorVersion(): number {
         if (process.platform !== 'win32') {
-            return null;
+            return -1;
         }
         try {
             const version = require('os').release();
             return Number.parseInt(version.split('.')[0], 10);
         }
         catch { }
-        return null;
+        return -1;
     }
 }

--- a/src/electron/biometric.windows.main.ts
+++ b/src/electron/biometric.windows.main.ts
@@ -48,10 +48,8 @@ export default class BiometricWindowsMain implements BiometricMain {
 
     getWindowsSecurityCredentialsUiModule(): any {
         try {
-            if (this.windowsSecurityCredentialsUiModule == null) {
-                if (this.getWindowsMajorVersion() >= 10) {
-                    this.windowsSecurityCredentialsUiModule = require('@nodert-win10-rs4/windows.security.credentials.ui');
-                }
+            if (this.windowsSecurityCredentialsUiModule == null && this.getWindowsMajorVersion() >= 10) {
+                this.windowsSecurityCredentialsUiModule = require('@nodert-win10-rs4/windows.security.credentials.ui');
             }
             return this.windowsSecurityCredentialsUiModule;
         } catch {

--- a/src/electron/biometric.windows.main.ts
+++ b/src/electron/biometric.windows.main.ts
@@ -49,7 +49,9 @@ export default class BiometricWindowsMain implements BiometricMain {
     getWindowsSecurityCredentialsUiModule(): any {
         try {
             if (this.windowsSecurityCredentialsUiModule == null) {
-                this.windowsSecurityCredentialsUiModule = require('@nodert-win10-rs4/windows.security.credentials.ui');
+                if (this.getWindowsMajorVersion() >= 10) {
+                    this.windowsSecurityCredentialsUiModule = require('@nodert-win10-rs4/windows.security.credentials.ui');
+                }
             }
             return this.windowsSecurityCredentialsUiModule;
         } catch {
@@ -109,5 +111,17 @@ export default class BiometricWindowsMain implements BiometricMain {
             }
         } catch { /*Ignore error*/ }
         return [];
+    }
+
+    getWindowsMajorVersion(): number {
+        if (process.platform !== 'win32') {
+            return null;
+        }
+        try {
+            const version = require('os').release();
+            return Number.parseInt(version.split('.')[0], 10);
+        }
+        catch { }
+        return null;
     }
 }


### PR DESCRIPTION
Related to and _should_ resolve https://github.com/bitwarden/desktop/issues/507.

## Overview
Apparently just a `try { ... } catch { ... }` alone isn't enough to prevent an app crash for some Windows 7 machines when attempting to load the WinRT node module used for Biometrics support (Windows Hello). Instead we need to simply circumvent that attempted load and just detect the major Windows version ahead of time and not attempt the module load on anything other than Windows 10+ (Windows Hello is not supported in prior versions of Windows, and Windows build 1511 is the earliest build supported by NodeRT module anyway).

Our current version of nodeJS we're using for build + dev doesn't yet support the `os.version()` (returning the build number) method, so we're stuck with `os.release()` (returns the major labeled version, i.e. "7.x", "8.x", 10.x", etc.).

## Screen Shots
Using the following code:
```JavaScript
// C:\AWS\os.js
const os = require('os');
const version = os.release();
console.info('Release: ' + version);
console.info(Number.parseInt(version.split(',')[0]));
```
![image](https://user-images.githubusercontent.com/3904944/93516891-a4e0df80-f8f8-11ea-9356-a2348e454c2b.png)
