### PR TITLE
check authed before checking if token has premium

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -107,6 +107,11 @@ export class UserService implements UserServiceAbstraction {
     }
 
     async canAccessPremium(): Promise<boolean> {
+        const authed = await this.isAuthenticated();
+        if (!authed) {
+            return false;
+        }
+
         const tokenPremium = this.tokenService.getPremium();
         if (tokenPremium) {
             return true;


### PR DESCRIPTION
Any checks to `canAccessPremium` will throw an exception when not authed since there is no token to reference. This stops it from even trying to access the token.