### PR TITLE
[SSO] New user provision flow

### DIFF
--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -1,4 +1,7 @@
-import { Router } from '@angular/router';
+import {
+    ActivatedRoute,
+    Router
+} from '@angular/router';
 
 import { ApiService } from '../../abstractions/api.service';
 import { CryptoService } from '../../abstractions/crypto.service';
@@ -24,6 +27,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     syncLoading: boolean = true;
     showPassword: boolean = false;
     hint: string = '';
+    identifier: string = null;
 
     onSuccessfulChangePassword: () => Promise<any>;
     successRoute = 'vault';
@@ -31,7 +35,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     constructor(i18nService: I18nService, cryptoService: CryptoService, messagingService: MessagingService,
         userService: UserService, passwordGenerationService: PasswordGenerationService,
         platformUtilsService: PlatformUtilsService, policyService: PolicyService, private router: Router,
-        private apiService: ApiService, private syncService: SyncService) {
+        private apiService: ApiService, private syncService: SyncService, private route: ActivatedRoute) {
         super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
             platformUtilsService, policyService);
     }
@@ -39,6 +43,17 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     async ngOnInit() {
         await this.syncService.fullSync(true);
         this.syncLoading = false;
+
+        const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            if (qParams.identifier != null) {
+                this.identifier = qParams.identifier;
+            }
+
+            if (queryParamsSub != null) {
+                queryParamsSub.unsubscribe();
+            }
+        });
+
         super.ngOnInit();
     }
 
@@ -57,6 +72,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
         request.masterPasswordHint = this.hint;
         request.kdf = this.kdf;
         request.kdfIterations = this.kdfIterations;
+        request.orgIdentifier = this.identifier;
 
         const keys = await this.cryptoService.makeKeyPair(encKey[0]);
         request.keys = new KeysRequest(keys[0], keys[1].encryptedString);

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -52,7 +52,7 @@ export class SsoComponent {
                 await this.storageService.remove(ConstantsService.ssoCodeVerifierKey);
                 await this.storageService.remove(ConstantsService.ssoStateKey);
                 if (qParams.code != null && codeVerifier != null && state != null && state === qParams.state) {
-                    await this.logIn(qParams.code, codeVerifier);
+                    await this.logIn(qParams.code, codeVerifier, this.getOrgIdentiferFromState(state));
                 }
             } else if (qParams.clientId != null && qParams.redirectUri != null && qParams.state != null &&
                 qParams.codeChallenge != null) {
@@ -109,9 +109,13 @@ export class SsoComponent {
             if (returnUri) {
                 state += `_returnUri='${returnUri}'`;
             }
-
-            await this.storageService.save(ConstantsService.ssoStateKey, state);
         }
+
+        // Add Organization Identifier to state
+        state += `_identifier=${this.identifier}`;
+
+        // Save state (regardless of new or existing)
+        await this.storageService.save(ConstantsService.ssoStateKey, state);
 
         let authorizeUrl = this.apiService.identityBaseUrl + '/connect/authorize?' +
             'client_id=' + this.clientId + '&redirect_uri=' + encodeURIComponent(this.redirectUri) + '&' +
@@ -128,7 +132,7 @@ export class SsoComponent {
         return authorizeUrl;
     }
 
-    private async logIn(code: string, codeVerifier: string) {
+    private async logIn(code: string, codeVerifier: string, orgIdFromState: string) {
         this.loggingIn = true;
         try {
             this.formPromise = this.authService.logInSso(code, codeVerifier, this.redirectUri);
@@ -140,7 +144,7 @@ export class SsoComponent {
                 } else {
                     this.router.navigate([this.twoFactorRoute], {
                         queryParams: {
-                            resetMasterPassword: response.resetMasterPassword,
+                            identifier: orgIdFromState,
                         },
                     });
                 }
@@ -149,7 +153,11 @@ export class SsoComponent {
                 if (this.onSuccessfulLoginChangePasswordNavigate != null) {
                     this.onSuccessfulLoginChangePasswordNavigate();
                 } else {
-                    this.router.navigate([this.changePasswordRoute]);
+                    this.router.navigate([this.changePasswordRoute], {
+                        queryParams: {
+                            identifier: orgIdFromState,
+                        },
+                    });
                 }
             } else {
                 const disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
@@ -166,5 +174,14 @@ export class SsoComponent {
             }
         } catch { }
         this.loggingIn = false;
+    }
+
+    private getOrgIdentiferFromState(state: string): string {
+        if (!state) {
+            return null;
+        }
+
+        const stateSplit = state.split('_identifier=');
+        return stateSplit[1] ? stateSplit[1] : null;
     }
 }

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -182,6 +182,6 @@ export class SsoComponent {
         }
 
         const stateSplit = state.split('_identifier=');
-        return stateSplit[1] ? stateSplit[1] : null;
+        return stateSplit.length > 1 ? stateSplit[1] : null;
     }
 }

--- a/src/models/request/setPasswordRequest.ts
+++ b/src/models/request/setPasswordRequest.ts
@@ -9,4 +9,5 @@ export class SetPasswordRequest {
     keys: KeysRequest;
     kdf: KdfType;
     kdfIterations: number;
+    orgIdentifier: string;
 }


### PR DESCRIPTION
## Objective
> Currently, when a new bitwarden/org user is created, they are given a status of `accepted`.  This can create issues for organizations trying to `confirm` the same user (which can't happen until they've set their master password). To alleviate the issue, change new user's `orgUser` status to `invited` until after they've set a master password.

## Code Changes
- **set-password.component.ts**: Added new string `identifier` for parsing the query params and keep track of the entered org identifier. This is passed through to the API.
- **sso.component.ts**: Added org identifier to the state and saved (regardless of the `state` object's state). Passed along the org identifier to two of the potential routes (2fa, set password). Created function to parse org identifier from the saved `state` object.
- **two-factor.component.ts**: Parsed query params for saved org identifier. Passed along the org identifier to the `set-password` flow.
- **setPasswordRequest.ts**: Added `orgIdentifier` string parameter
