### PR TITLE
Add login launch data

### DIFF
--- a/src/abstractions/cipher.service.ts
+++ b/src/abstractions/cipher.service.ts
@@ -26,8 +26,10 @@ export abstract class CipherService {
         defaultMatch?: UriMatchType) => Promise<CipherView[]>;
     getAllFromApiForOrganization: (organizationId: string) => Promise<CipherView[]>;
     getLastUsedForUrl: (url: string) => Promise<CipherView>;
+    getLastLaunchedForUrl: (url: string) => Promise<CipherView>;
     getNextCipherForUrl: (url: string) => Promise<CipherView>;
     updateLastUsedDate: (id: string) => Promise<void>;
+    updateLastLaunchedDate: (id: string) => Promise<void>;
     saveNeverDomain: (domain: string) => Promise<void>;
     saveWithServer: (cipher: Cipher) => Promise<any>;
     shareWithServer: (cipher: CipherView, organizationId: string, collectionIds: string[]) => Promise<any>;

--- a/src/models/domain/sortedCiphersCache.ts
+++ b/src/models/domain/sortedCiphersCache.ts
@@ -57,7 +57,7 @@ class Ciphers {
     }
 
     getLastLaunched() {
-        let sortedCiphers = this.ciphers.sort((x, y) => y.localData?.lastLaunched?.valueOf() - x.localData?.lastLaunched?.valueOf());
+        const sortedCiphers = this.ciphers.sort((x, y) => y.localData?.lastLaunched?.valueOf() - x.localData?.lastLaunched?.valueOf());
         return sortedCiphers[0];
     }
 

--- a/src/models/domain/sortedCiphersCache.ts
+++ b/src/models/domain/sortedCiphersCache.ts
@@ -23,6 +23,10 @@ export class SortedCiphersCache {
         return this.isCached(url) ? this.sortedCiphersByUrl.get(url).getLastUsed() : null;
     }
 
+    getLastLaunched(url: string) {
+        return this.isCached(url) ? this.sortedCiphersByUrl.get(url).getLastLaunched() : null;
+    }
+
     getNext(url: string) {
         this.resetTimer(url);
         return this.isCached(url) ? this.sortedCiphersByUrl.get(url).getNext() : null;
@@ -50,6 +54,11 @@ class Ciphers {
     getLastUsed() {
         this.lastUsedIndex = Math.max(this.lastUsedIndex, 0);
         return this.ciphers[this.lastUsedIndex];
+    }
+
+    getLastLaunched() {
+        let sortedCiphers = this.ciphers.sort((x, y) => y.localData?.lastLaunched?.valueOf() - x.localData?.lastLaunched?.valueOf());
+        return sortedCiphers[0];
     }
 
     getNext() {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -445,15 +445,15 @@ export class CipherService implements CipherServiceAbstraction {
     }
 
     async getLastUsedForUrl(url: string): Promise<CipherView> {
-        return await this.getCipherForUrl(url, true, false);
+        return this.getCipherForUrl(url, true, false);
     }
 
     async getLastLaunchedForUrl(url: string): Promise<CipherView> {
-        return await this.getCipherForUrl(url, false, true);
+        return this.getCipherForUrl(url, false, true);
     }
 
     async getNextCipherForUrl(url: string): Promise<CipherView> {
-        return await this.getCipherForUrl(url, false, false);
+        return this.getCipherForUrl(url, false, false);
     }
 
     async updateLastUsedDate(id: string): Promise<void> {
@@ -959,7 +959,7 @@ export class CipherService implements CipherServiceAbstraction {
             }
 
             // tslint:disable-next-line
-            (function(theProp, theObj) {
+            (function (theProp, theObj) {
                 const p = Promise.resolve().then(() => {
                     const modelProp = (model as any)[(map[theProp] || theProp)];
                     if (modelProp && modelProp !== '') {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -445,11 +445,15 @@ export class CipherService implements CipherServiceAbstraction {
     }
 
     async getLastUsedForUrl(url: string): Promise<CipherView> {
-        return this.getCipherForUrl(url, true);
+        return await this.getCipherForUrl(url, true, false);
+    }
+
+    async getLastLaunchedForUrl(url: string): Promise<CipherView> {
+        return await this.getCipherForUrl(url, false, true);
     }
 
     async getNextCipherForUrl(url: string): Promise<CipherView> {
-        return this.getCipherForUrl(url, false);
+        return await this.getCipherForUrl(url, false, false);
     }
 
     async updateLastUsedDate(id: string): Promise<void> {
@@ -460,6 +464,35 @@ export class CipherService implements CipherServiceAbstraction {
 
         if (ciphersLocalData[id]) {
             ciphersLocalData[id].lastUsedDate = new Date().getTime();
+        } else {
+            ciphersLocalData[id] = {
+                lastUsedDate: new Date().getTime(),
+            };
+        }
+
+        await this.storageService.save(Keys.localData, ciphersLocalData);
+
+        if (this.decryptedCipherCache == null) {
+            return;
+        }
+
+        for (let i = 0; i < this.decryptedCipherCache.length; i++) {
+            const cached = this.decryptedCipherCache[i];
+            if (cached.id === id) {
+                cached.localData = ciphersLocalData[id];
+                break;
+            }
+        }
+    }
+
+    async updateLastLaunchedDate(id: string): Promise<void> {
+        let ciphersLocalData = await this.storageService.get<any>(Keys.localData);
+        if (!ciphersLocalData) {
+            ciphersLocalData = {};
+        }
+
+        if (ciphersLocalData[id]) {
+            ciphersLocalData[id].lastLaunched = new Date().getTime();
         } else {
             ciphersLocalData[id] = {
                 lastUsedDate: new Date().getTime(),
@@ -926,7 +959,7 @@ export class CipherService implements CipherServiceAbstraction {
             }
 
             // tslint:disable-next-line
-            (function (theProp, theObj) {
+            (function(theProp, theObj) {
                 const p = Promise.resolve().then(() => {
                     const modelProp = (model as any)[(map[theProp] || theProp)];
                     if (modelProp && modelProp !== '') {
@@ -1009,7 +1042,7 @@ export class CipherService implements CipherServiceAbstraction {
         }
     }
 
-    private async getCipherForUrl(url: string, lastUsed: boolean): Promise<CipherView> {
+    private async getCipherForUrl(url: string, lastUsed: boolean, lastLaunched: boolean): Promise<CipherView> {
         if (!this.sortedCiphersCache.isCached(url)) {
             const ciphers = await this.getAllDecryptedForUrl(url);
             if (!ciphers) {
@@ -1018,6 +1051,13 @@ export class CipherService implements CipherServiceAbstraction {
             this.sortedCiphersCache.addCiphers(url, ciphers);
         }
 
-        return lastUsed ? this.sortedCiphersCache.getLastUsed(url) : this.sortedCiphersCache.getNext(url);
+        if (lastLaunched) {
+            return this.sortedCiphersCache.getLastLaunched(url);
+        } else if (lastUsed) {
+            return this.sortedCiphersCache.getLastUsed(url);
+        }
+        else {
+            return this.sortedCiphersCache.getNext(url);
+        }
     }
 }


### PR DESCRIPTION
Relates to bitwarden/browser#1391

### Issue
When using the search bar to launch a url & autofill the autofill process is not using the login that was clicked, it is using the last used login previous to the clicked login. 

### Resolution
We can locally track last launched logins and get that data back for autofill