### PR TITLE
Fixed web vault URL reference for SSO launch

### DIFF
--- a/src/angular/components/login.component.ts
+++ b/src/angular/components/login.component.ts
@@ -138,8 +138,8 @@ export class LoginComponent implements OnInit {
         await this.storageService.save(ConstantsService.ssoCodeVerifierKey, ssoCodeVerifier);
 
         // Build URI
-        const webUrl = this.environmentService.webVaultUrl == null ? 'https://vault.bitwarden.com' :
-            this.environmentService.webVaultUrl;
+        const webUrl = this.environmentService.getWebVaultUrl() == null ? 'https://vault.bitwarden.com' :
+            this.environmentService.getWebVaultUrl();
 
         // Launch browser
         this.platformUtilsService.launchUri(webUrl + '/#/sso?clientId=' + clientId +


### PR DESCRIPTION
## Overview
SSO from the desktop in jslib was using the web vault URL directly, which is often `null` in self-hosted deployments, instead of using the derived URL method baked into the environment service for the web vault which handles the cascading nature necessary for getting the correct URL from the user's settings.