### PR TITLE
hide bio unlock option when logging in with sso

### DIFF
--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -50,7 +50,7 @@ export class LockComponent implements OnInit {
         this.pinSet = await this.vaultTimeoutService.isPinLockSet();
         this.pinLock = (this.pinSet[0] && this.vaultTimeoutService.pinProtectedKey != null) || this.pinSet[1];
         this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
-        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet();
+        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() && await this.cryptoService.hasKey();
         this.biometricText = await this.storageService.get(ConstantsService.biometricText);
         this.email = await this.userService.getEmail();
         let vaultUrl = this.environmentService.getWebVaultUrl();


### PR DESCRIPTION
Check for key availability on lock screen before allowing bio unlock option (password is required to unlock vault after logging in with SSO)