### PR TITLE
implement launchUri function

### DIFF
--- a/src/cli/commands/login.command.ts
+++ b/src/cli/commands/login.command.ts
@@ -13,6 +13,7 @@ import { CryptoFunctionService } from '../../abstractions/cryptoFunction.service
 import { EnvironmentService } from '../../abstractions/environment.service';
 import { I18nService } from '../../abstractions/i18n.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
+import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 
 import { Response } from '../models/response';
 
@@ -35,7 +36,8 @@ export class LoginCommand {
     constructor(protected authService: AuthService, protected apiService: ApiService,
         protected i18nService: I18nService, protected environmentService: EnvironmentService,
         protected passwordGenerationService: PasswordGenerationService,
-        protected cryptoFunctionService: CryptoFunctionService, clientId: string) {
+        protected cryptoFunctionService: CryptoFunctionService, protected platformUtilsService: PlatformUtilsService,
+        clientId: string) {
         this.clientId = clientId;
     }
 
@@ -249,8 +251,8 @@ export class LoginCommand {
             for (let port = 8065; port <= 8070; port++) {
                 try {
                     this.ssoRedirectUri = 'http://localhost:' + port;
-                    callbackServer.listen(port, async () => {
-                        await open(webUrl + '/#/sso?clientId=' + this.clientId +
+                    callbackServer.listen(port, () => {
+                        this.platformUtilsService.launchUri(webUrl + '/#/sso?clientId=' + this.clientId +
                             '&redirectUri=' + encodeURIComponent(this.ssoRedirectUri) +
                             '&state=' + state + '&codeChallenge=' + codeChallenge);
                     });

--- a/src/cli/services/cliPlatformUtils.service.ts
+++ b/src/cli/services/cliPlatformUtils.service.ts
@@ -1,7 +1,11 @@
+import * as child_process from 'child_process';
 
 import { DeviceType } from '../../enums/deviceType';
 
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
+
+// tslint:disable-next-line
+const open = require('open');
 
 export class CliPlatformUtilsService implements PlatformUtilsService {
     identityClientId: string;
@@ -81,7 +85,11 @@ export class CliPlatformUtilsService implements PlatformUtilsService {
     }
 
     launchUri(uri: string, options?: any): void {
-        throw new Error('Not implemented.');
+        if (process.platform === 'linux') {
+            child_process.spawnSync('xdg-open', [uri]);
+        } else {
+            open(uri);
+        }
     }
 
     saveFile(win: Window, blobData: any, blobOptions: any, fileName: string): void {


### PR DESCRIPTION
ref #165

This PR implements launchUri for CLI platform utils by using the `open` library. The `open` library is broken with packaged as a binary with `pkg`, so we handle that case manually.