### PR TITLE
Chmod data.json to 600

### DIFF
--- a/src/services/lowdbStorage.service.ts
+++ b/src/services/lowdbStorage.service.ts
@@ -26,10 +26,12 @@ export class LowdbStorageService implements StorageService {
         }
         try {
             this.db = lowdb(adapter);
+            fs.chmodSync(this.dataFilePath, "600");
         } catch (e) {
             if (e instanceof SyntaxError) {
                 adapter.write({});
                 this.db = lowdb(adapter);
+                fs.chmodSync(this.dataFilePath, "600");
             } else {
                 throw e;
             }


### PR DESCRIPTION
Nothing scary or serious, this pull request is to complete the https://github.com/bitwarden/cli/issues/160.

I just changed mode to 600 with `fs.chmodSync`. I think `chmodSync` is pretty safe since the `lowdb` lib also use sync functions for both [writing and reading](https://github.com/typicode/lowdb/blob/b70669c12ac0d40e297da38620e210a805c4d8d9/src/adapters/FileSync.js#L5). I'm also aware that the read/write function in `lowdb` is imported from `graceful-fs` lib. However, `graceful-fs` is just improvements to help the `fs` "access more resilient to errors". This means no drastical change should happen and we are safe to use `fs`.

(I did this one because I could. I actually not so sure how value it is. So I hope it won't annoy anyone in here)