### PR TITLE
Add Microsoft RDP URI schemes

### DIFF
--- a/src/models/view/loginUriView.ts
+++ b/src/models/view/loginUriView.ts
@@ -14,6 +14,9 @@ const CanLaunchWhitelist = [
     'sftp://',
     'irc://',
     'vnc://',
+    // https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-uri
+    'rdp://', // Legacy RDP URI scheme
+    'ms-rd:', // Preferred RDP URI scheme
     'chrome://',
     'iosapp://',
     'androidapp://',


### PR DESCRIPTION
This will allow users to launch the Remote Desktop client directly from
Bitwarden if their OS supports the URI scheme.

Per
https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-uri,
rdp:// is legacy and ms-rd: is the preferred one. I'm adding both so
that either can be used as ms-rd: is not available on all versions of
Windows and rdp:// is easier to add as a custom URI scheme in Windows 10
if it is desired.