### PR TITLE
pre-create and chmod 600 data file

### DIFF
--- a/src/services/lowdbStorage.service.ts
+++ b/src/services/lowdbStorage.service.ts
@@ -22,6 +22,10 @@ export class LowdbStorageService implements StorageService {
                 NodeUtils.mkdirpSync(dir, '700');
             }
             this.dataFilePath = path.join(dir, 'data.json');
+            if (!fs.existsSync(this.dataFilePath)) {
+                fs.writeFileSync(this.dataFilePath, '', { mode: 0o600 });
+                fs.chmodSync(this.dataFilePath, 0o600);
+            }
             adapter = new FileSync(this.dataFilePath);
         }
         try {


### PR DESCRIPTION
Resolves https://github.com/bitwarden/cli/issues/160

Pre-creates the data.json file on init and chmods it to 600.

For whatever reason, the mode is not set properly on the initial `writeFileSync`, so a follow up `chmodSync` is required.