### PR TITLE
New method to update the last used index

### DIFF
--- a/src/abstractions/cipher.service.ts
+++ b/src/abstractions/cipher.service.ts
@@ -7,7 +7,6 @@ import { Cipher } from '../models/domain/cipher';
 import { Field } from '../models/domain/field';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
-import { AttachmentView } from '../models/view/attachmentView';
 import { CipherView } from '../models/view/cipherView';
 import { FieldView } from '../models/view/fieldView';
 
@@ -28,6 +27,7 @@ export abstract class CipherService {
     getLastUsedForUrl: (url: string) => Promise<CipherView>;
     getLastLaunchedForUrl: (url: string) => Promise<CipherView>;
     getNextCipherForUrl: (url: string) => Promise<CipherView>;
+    updateLastUsedIndexForUrl: (url: string) => void;
     updateLastUsedDate: (id: string) => Promise<void>;
     updateLastLaunchedDate: (id: string) => Promise<void>;
     saveNeverDomain: (domain: string) => Promise<void>;

--- a/src/models/domain/sortedCiphersCache.ts
+++ b/src/models/domain/sortedCiphersCache.ts
@@ -32,6 +32,12 @@ export class SortedCiphersCache {
         return this.isCached(url) ? this.sortedCiphersByUrl.get(url).getNext() : null;
     }
 
+    updateLastUsedIndex(url: string) {
+        if (this.isCached(url)) {
+            this.sortedCiphersByUrl.get(url).updateLastUsedIndex();
+        }
+    }
+
     clear() {
         this.sortedCiphersByUrl.clear();
         this.timeouts.clear();
@@ -57,14 +63,20 @@ class Ciphers {
     }
 
     getLastLaunched() {
-        const usedCiphers = this.ciphers.filter(cipher => cipher.localData?.lastLaunched)
+        const usedCiphers = this.ciphers.filter(cipher => cipher.localData?.lastLaunched);
         const sortedCiphers = usedCiphers.sort((x, y) => y.localData.lastLaunched.valueOf() - x.localData.lastLaunched.valueOf());
         return sortedCiphers[0];
     }
 
+    getNextIndex() {
+        return (this.lastUsedIndex + 1) % this.ciphers.length;
+    }
+
     getNext() {
-        const nextIndex = (this.lastUsedIndex + 1) % this.ciphers.length;
-        this.lastUsedIndex = nextIndex;
-        return this.ciphers[nextIndex];
+        return this.ciphers[this.getNextIndex()];
+    }
+
+    updateLastUsedIndex() {
+        this.lastUsedIndex = this.getNextIndex();
     }
 }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -456,6 +456,10 @@ export class CipherService implements CipherServiceAbstraction {
         return this.getCipherForUrl(url, false, false);
     }
 
+    updateLastUsedIndexForUrl(url: string) {
+        this.sortedCiphersCache.updateLastUsedIndex(url);
+    }
+
     async updateLastUsedDate(id: string): Promise<void> {
         let ciphersLocalData = await this.storageService.get<any>(Keys.localData);
         if (!ciphersLocalData) {
@@ -1055,8 +1059,7 @@ export class CipherService implements CipherServiceAbstraction {
             return this.sortedCiphersCache.getLastLaunched(url);
         } else if (lastUsed) {
             return this.sortedCiphersCache.getLastUsed(url);
-        }
-        else {
+        } else {
             return this.sortedCiphersCache.getNext(url);
         }
     }


### PR DESCRIPTION
Instead of updating it every time you call getNext(), it will be updated in a separate call, to avoid updating the index when the cipher did not auto-fill correctly (e.g wrong frame)
Fixes https://github.com/bitwarden/browser/issues/1392