### PR TITLE
Browser <-> desktop communication

### DIFF
--- a/src/abstractions/platformUtils.service.ts
+++ b/src/abstractions/platformUtils.service.ts
@@ -34,4 +34,5 @@ export abstract class PlatformUtilsService {
     readFromClipboard: (options?: any) => Promise<string>;
     supportsBiometric: () => Promise<boolean>;
     authenticateBiometric: () => Promise<boolean>;
+    supportsSecureStorage: () => boolean;
 }

--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -50,7 +50,7 @@ export class LockComponent implements OnInit {
         this.pinSet = await this.vaultTimeoutService.isPinLockSet();
         this.pinLock = (this.pinSet[0] && this.vaultTimeoutService.pinProtectedKey != null) || this.pinSet[1];
         this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
-        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() && (await this.cryptoService.hasKey() || this.platformUtilsService.identityClientId !== 'desktop');
+        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() && (await this.cryptoService.hasKey() || !this.platformUtilsService.supportsSecureStorage());
         this.biometricText = await this.storageService.get(ConstantsService.biometricText);
         this.email = await this.userService.getEmail();
         let vaultUrl = this.environmentService.getWebVaultUrl();

--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -158,7 +158,6 @@ export class LockComponent implements OnInit {
         }
         const success = await this.platformUtilsService.authenticateBiometric();
 
-        this.vaultTimeoutService.biometricLocked = !success;
         if (success) {
             await this.doContinue();
         }

--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -50,7 +50,7 @@ export class LockComponent implements OnInit {
         this.pinSet = await this.vaultTimeoutService.isPinLockSet();
         this.pinLock = (this.pinSet[0] && this.vaultTimeoutService.pinProtectedKey != null) || this.pinSet[1];
         this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
-        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() && await this.cryptoService.hasKey();
+        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() && (await this.cryptoService.hasKey() || this.platformUtilsService.identityClientId !== 'desktop');
         this.biometricText = await this.storageService.get(ConstantsService.biometricText);
         this.email = await this.userService.getEmail();
         let vaultUrl = this.environmentService.getWebVaultUrl();

--- a/src/cli/services/cliPlatformUtils.service.ts
+++ b/src/cli/services/cliPlatformUtils.service.ts
@@ -145,4 +145,8 @@ export class CliPlatformUtilsService implements PlatformUtilsService {
     authenticateBiometric(): Promise<boolean> {
         return Promise.resolve(false);
     }
+
+    supportsSecureStorage(): boolean {
+        return false;
+    }
 }

--- a/src/electron/electronConstants.ts
+++ b/src/electron/electronConstants.ts
@@ -6,4 +6,5 @@ export class ElectronConstants {
     static readonly enableAlwaysOnTopKey: string = 'enableAlwaysOnTopKey';
     static readonly minimizeOnCopyToClipboardKey: string = 'minimizeOnCopyToClipboardKey';
     static readonly enableBiometric: string = 'enabledBiometric';
+    static readonly enableBrowserIntegration: string = 'enableBrowserIntegration';
 }

--- a/src/electron/services/electronPlatformUtils.service.ts
+++ b/src/electron/services/electronPlatformUtils.service.ts
@@ -219,4 +219,8 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
             resolve(val);
         });
     }
+
+    supportsSecureStorage(): boolean {
+        return true;
+    }
 }

--- a/src/services/constants.service.ts
+++ b/src/services/constants.service.ts
@@ -27,6 +27,7 @@ export class ConstantsService {
     static readonly ssoStateKey: string = 'ssoState';
     static readonly biometricUnlockKey: string = 'biometric';
     static readonly biometricText: string = 'biometricText';
+    static readonly biometricAwaitingAcceptance: string = 'biometricAwaitingAcceptance';
 
     readonly environmentUrlsKey: string = ConstantsService.environmentUrlsKey;
     readonly disableGaKey: string = ConstantsService.disableGaKey;
@@ -55,4 +56,5 @@ export class ConstantsService {
     readonly ssoStateKey: string = ConstantsService.ssoStateKey;
     readonly biometricUnlockKey: string = ConstantsService.biometricUnlockKey;
     readonly biometricText: string = ConstantsService.biometricText;
+    readonly biometricAwaitingAcceptance: string = ConstantsService.biometricAwaitingAcceptance;
 }

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -10,8 +10,8 @@ import { ProfileOrganizationResponse } from '../models/response/profileOrganizat
 
 import { CryptoService as CryptoServiceAbstraction } from '../abstractions/crypto.service';
 import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
-import { StorageService } from '../abstractions/storage.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
+import { StorageService } from '../abstractions/storage.service';
 
 import { ConstantsService } from './constants.service';
 

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -44,7 +44,7 @@ export class CryptoService implements CryptoServiceAbstraction {
 
         const option = await this.storageService.get<number>(ConstantsService.vaultTimeoutKey);
         const biometric = await this.storageService.get<boolean>(ConstantsService.biometricUnlockKey);
-        if (option != null && !(biometric && this.platformUtilService.identityClientId === 'desktop')) {
+        if (option != null && !(biometric && this.platformUtilService.supportsSecureStorage())) {
             // if we have a lock option set, we do not store the key
             return;
         }
@@ -294,7 +294,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         const key = await this.getKey();
         const option = await this.storageService.get(ConstantsService.vaultTimeoutKey);
         const biometric = await this.storageService.get(ConstantsService.biometricUnlockKey);
-        if ((!biometric && this.platformUtilService.identityClientId === 'desktop') && (option != null || option === 0)) {
+        if ((!biometric && this.platformUtilService.supportsSecureStorage()) && (option != null || option === 0)) {
             // if we have a lock option set, clear the key
             await this.clearKey();
             this.key = key;

--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -100,7 +100,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         this.biometricLocked = true;
         if (allowSoftLock) {
             const biometricLocked = await this.isBiometricLockSet();
-            if (biometricLocked && this.platformUtilsService.identityClientId === 'desktop') {
+            if (biometricLocked && this.platformUtilsService.supportsSecureStorage()) {
                 this.messagingService.send('locked');
                 if (this.lockedCallback != null) {
                     await this.lockedCallback();

--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -100,7 +100,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         this.biometricLocked = true;
         if (allowSoftLock) {
             const biometricLocked = await this.isBiometricLockSet();
-            if (biometricLocked) {
+            if (biometricLocked && this.platformUtilsService.identityClientId === 'desktop') {
                 this.messagingService.send('locked');
                 if (this.lockedCallback != null) {
                     await this.lockedCallback();

--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -97,6 +97,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
             return;
         }
 
+        this.biometricLocked = true;
         if (allowSoftLock) {
             const biometricLocked = await this.isBiometricLockSet();
             if (biometricLocked) {


### PR DESCRIPTION
* Changed so that passwords are only stored in desktop (secure storage).
* Resolved a bug where `biometricLocked` was not set to true after manual lock (desktop), which provided access to some things from the lock screen (after first unlock).
* Added constants required for browser biometric unlock.

Required by https://github.com/bitwarden/desktop/pull/566 and https://github.com/bitwarden/browser/pull/1426