### PR TITLE
Add logging to lowdb storage service

### DIFF
--- a/src/services/lowdbStorage.service.ts
+++ b/src/services/lowdbStorage.service.ts
@@ -3,6 +3,7 @@ import * as lowdb from 'lowdb';
 import * as FileSync from 'lowdb/adapters/FileSync';
 import * as path from 'path';
 
+import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
 
 import { NodeUtils } from '../misc/nodeUtils';
@@ -13,28 +14,37 @@ export class LowdbStorageService implements StorageService {
     private defaults: any;
     private dataFilePath: string;
 
-    constructor(defaults?: any, dir?: string, private allowCache = false) {
+    constructor(private logService: LogService, defaults?: any, dir?: string, private allowCache = false) {
         this.defaults = defaults;
 
+        this.logService.info('Initializing lowdb storage service.');
         let adapter: lowdb.AdapterSync<any>;
         if (Utils.isNode && dir != null) {
             if (!fs.existsSync(dir)) {
+                this.logService.warning(`Could not find dir, "${dir}"; creating it instead.`);
                 NodeUtils.mkdirpSync(dir, '700');
+                this.logService.info(`Created dir "${dir}".`);
             }
             this.dataFilePath = path.join(dir, 'data.json');
             if (!fs.existsSync(this.dataFilePath)) {
+                this.logService.warning(`Could not find data file, "${this.dataFilePath}"; creating it instead.`);
                 fs.writeFileSync(this.dataFilePath, '', { mode: 0o600 });
                 fs.chmodSync(this.dataFilePath, 0o600);
+                this.logService.info(`Created data file "${this.dataFilePath}" with chmod 600.`);
             }
             adapter = new FileSync(this.dataFilePath);
         }
         try {
+            this.logService.info('Attempting to create lowdb storage adapter.');
             this.db = lowdb(adapter);
+            this.logService.info('Successfuly created lowdb storage adapter.');
         } catch (e) {
             if (e instanceof SyntaxError) {
+                this.logService.warning(`Error creating lowdb storage adapter, "${e.message}"; emptying data file.`);
                 adapter.write({});
                 this.db = lowdb(adapter);
             } else {
+                this.logService.error(`Error creating lowdb storage adapter, "${e.message}".`);
                 throw e;
             }
         }
@@ -42,8 +52,10 @@ export class LowdbStorageService implements StorageService {
 
     init() {
         if (this.defaults != null) {
+            this.logService.info('Writing defaults.');
             this.readForNoCache();
             this.db.defaults(this.defaults).write();
+            this.logService.info('Successfully wrote defaults to db.');
         }
     }
 


### PR DESCRIPTION
Adds ability to get to next steps on https://github.com/bitwarden/directory-connector/issues/41

## Overview
Add logging to the bwdc when initializing it's lowdb storage service so any failures, issues, warning, etc. which may result in wiping of the data file (`data.json`) will get appropriately logged for further troubleshooting.

## Example
The resulting output, for example, if there's a syntax error (or other error) with the existing `data.json` file may look like this:

```bash
$ node bwdc.js login
Error creating lowdb storage adapter, "Malformed JSON in file: /Users/<user>/Library/Application Support/Bitwarden Directory Connector/data.json
Unexpected token h in JSON at position 303"; emptying data file.
```