### PR TITLE
changed OnlyOrg enum to be SingleOrg

### DIFF
--- a/src/enums/policyType.ts
+++ b/src/enums/policyType.ts
@@ -2,6 +2,6 @@ export enum PolicyType {
     TwoFactorAuthentication = 0, // Requires users to have 2fa enabled
     MasterPassword = 1, // Sets minimum requirements for master password complexity
     PasswordGenerator = 2, // Sets minimum requirements/default type for generated passwords/passphrases
-    OnlyOrg = 3, // Allows users to only be apart of one organization
+    SingleOrg = 3, // Allows users to only be apart of one organization
     RequireSso = 4, // Requires users to authenticate with SSO
 }


### PR DESCRIPTION
It has been requested that we change the verbiage of the new OnlyOrg policy to be SingleOrg instead, this per fulfills that.

[Asana Ticket](https://app.asana.com/0/1195018406457675/1198564632123101)