### PR TITLE
Added missing member, showValue to Field

### DIFF
--- a/src/models/view/fieldView.ts
+++ b/src/models/view/fieldView.ts
@@ -9,6 +9,7 @@ export class FieldView implements View {
     value: string = null;
     type: FieldType = null;
     newField: boolean = false; // Marks if the field is new and hasn't been saved
+    showValue: boolean = false;
 
     constructor(f?: Field) {
         if (!f) {


### PR DESCRIPTION
This property was referenced in views and was being set in the Angular context, however was missing from the actual model type definition causing issues when needing to be referenced outside of the view and in other TypeScript files.