### PR TITLE
Turned off background throttling for browserWindow

### DIFF
--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -114,6 +114,7 @@ export class WindowMain {
             webPreferences: {
                 nodeIntegration: true,
                 webviewTag: true,
+                backgroundThrottling: false,
             },
         });
 


### PR DESCRIPTION
This needs to be `false` so that chromium through electron doesn't suppress repaint/redraw needs when minimizing or altering window states. There are other aims and things this setting impacts, however should not be largely impactful for the remainder of Bitwarden's code base.

Note: If backgroundThrottling is disabled, the visibility state will remain `visible` even if the window is minimized, occluded, or hidden when testing through the Page Visibility API. `visibilityState` is not used/referenced anywhere in the electron world of Bitwarden today.