### PR TITLE
Bump https-proxy-agent dep. to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "electron-store": "1.3.0",
     "electron-updater": "4.3.5",
     "form-data": "2.3.2",
-    "https-proxy-agent": "4.0.0",
+    "https-proxy-agent": "5.0.0",
     "inquirer": "6.2.0",
     "jsdom": "13.2.0",
     "keytar": "4.13.0",


### PR DESCRIPTION
Hi,

As per requested by @cscharf - This PR is raised to bump a NodeJS dependency (`https-proxy-agent`) which solves an upstream bug in the [CLI repo](https://github.com/bitwarden/cli/issues/181). 

The bug in question prevents you from log in successfully when running CLI commands behind an HTTP proxy.
