### PR TITLE
Fixed import for HttpsProxyAgent

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "electron-store": "1.3.0",
     "electron-updater": "4.3.5",
     "form-data": "2.3.2",
-    "https-proxy-agent": "5.0.0",
+    "https-proxy-agent": "4.0.0",
     "inquirer": "6.2.0",
     "jsdom": "13.2.0",
     "keytar": "4.13.0",

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,5 +1,5 @@
 import * as FormData from 'form-data';
-let HttpsProxyAgent = require('https-proxy-agent');
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import * as fe from 'node-fetch';
 
 import { ApiService } from './api.service';

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,5 +1,5 @@
 import * as FormData from 'form-data';
-import * as HttpsProxyAgent from 'https-proxy-agent';
+import HttpsProxyAgent from 'https-proxy-agent';
 import * as fe from 'node-fetch';
 
 import { ApiService } from './api.service';

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,5 +1,5 @@
 import * as FormData from 'form-data';
-import * as HttpsProxyAgent from 'https-proxy-agent';
+var HttpsProxyAgent = require('https-proxy-agent');
 import * as fe from 'node-fetch';
 
 import { ApiService } from './api.service';

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,5 +1,5 @@
 import * as FormData from 'form-data';
-var HttpsProxyAgent = require('https-proxy-agent');
+let HttpsProxyAgent = require('https-proxy-agent');
 import * as fe from 'node-fetch';
 
 import { ApiService } from './api.service';
@@ -22,8 +22,7 @@ export class NodeApiService extends ApiService {
     nativeFetch(request: Request): Promise<Response> {
         const proxy = process.env.http_proxy || process.env.https_proxy;
         if (proxy) {
-            const proxyAgent = new HttpsProxyAgent(proxy);
-            (request as any).agent = proxyAgent;
+            (request as any).agent = new HttpsProxyAgent(proxy);
         }
         return fetch(request);
     }

--- a/src/services/nodeApi.service.ts
+++ b/src/services/nodeApi.service.ts
@@ -1,5 +1,5 @@
 import * as FormData from 'form-data';
-import HttpsProxyAgent from 'https-proxy-agent';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import * as fe from 'node-fetch';
 
 import { ApiService } from './api.service';
@@ -22,7 +22,8 @@ export class NodeApiService extends ApiService {
     nativeFetch(request: Request): Promise<Response> {
         const proxy = process.env.http_proxy || process.env.https_proxy;
         if (proxy) {
-            (request as any).agent = new HttpsProxyAgent(proxy);
+            const proxyAgent = new HttpsProxyAgent(proxy);
+            (request as any).agent = proxyAgent;
         }
         return fetch(request);
     }


### PR DESCRIPTION
I had prematurely accepted a package version update of https-proxy-agent which then broke the build via a TypeScript compile error on that dependency.