### PR TITLE
Include revision date in cipher requests

### DIFF
--- a/src/models/request/cipherRequest.ts
+++ b/src/models/request/cipherRequest.ts
@@ -28,6 +28,7 @@ export class CipherRequest {
     // Deprecated, remove at some point and rename attachments2 to attachments
     attachments: { [id: string]: string; };
     attachments2: { [id: string]: AttachmentRequest; };
+    lastKnownRevisionDate: Date;
 
     constructor(cipher: Cipher) {
         this.type = cipher.type;
@@ -36,6 +37,7 @@ export class CipherRequest {
         this.name = cipher.name ? cipher.name.encryptedString : null;
         this.notes = cipher.notes ? cipher.notes.encryptedString : null;
         this.favorite = cipher.favorite;
+        this.lastKnownRevisionDate = cipher.revisionDate;
 
         switch (this.type) {
             case CipherType.Login:

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -143,6 +143,7 @@ export class CipherService implements CipherServiceAbstraction {
         cipher.organizationId = model.organizationId;
         cipher.type = model.type;
         cipher.collectionIds = model.collectionIds;
+        cipher.revisionDate = model.revisionDate;
 
         if (key == null && cipher.organizationId != null) {
             key = await this.cryptoService.getOrgKey(cipher.organizationId);


### PR DESCRIPTION
# Objective

This is a companion PR to API changes found in bitwarden/server#994

# Code Changes

* **cipherRequest.ts**: Add revision date to request model for validation.
* **cipher.service.ts**: Include revision date in encryption of ciphers so it can be included in the request model.

# Prereqs

- [ ] Merge in bitwarden/server#994
