### PR TITLE
[Bug] Update Success Route before Navigate action

### DIFF
--- a/src/angular/components/two-factor.component.ts
+++ b/src/angular/components/two-factor.component.ts
@@ -197,12 +197,12 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
                 this.onSuccessfulLogin();
             }
             this.platformUtilsService.eventTrack('Logged In From Two-step');
+            if (response.resetMasterPassword) {
+                this.successRoute = 'set-password';
+            }
             if (this.onSuccessfulLoginNavigate != null) {
                 this.onSuccessfulLoginNavigate();
             } else {
-                if (response.resetMasterPassword) {
-                    this.successRoute = 'set-password';
-                }
                 this.router.navigate([this.successRoute], {
                     queryParams: {
                         identifier: this.identifier,


### PR DESCRIPTION
## Objective
> Based on the response from the server, the `successRoute` needs to be updated before any specific `Navigate` actions are called.

## Linked Issues
-  [Server - 996](https://github.com/bitwarden/server/issues/996)

## Code Changes
- **two-factor.component**: Adjusted timing of `successRoute` to happen before any router navigation.

## Fast Follower
- Update to `web` that includes these changes