### PR TITLE
Update SSO component to parse state for comparison

### DIFF
--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -177,7 +177,7 @@ export class SsoComponent {
     }
 
     private getOrgIdentiferFromState(state: string): string {
-        if (state == null || state == undefined) {
+        if (state === null || state === undefined) {
             return null;
         }
 
@@ -186,10 +186,10 @@ export class SsoComponent {
     }
 
     private checkState(state: string, checkState: string): boolean {
-        if (state == null || state == undefined) {
+        if (state === null || state === undefined) {
             return false;
         }
-        if (checkState == null || checkState == undefined) {
+        if (checkState === null || checkState === undefined) {
             return false;
         }
 

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -177,7 +177,7 @@ export class SsoComponent {
     }
 
     private getOrgIdentiferFromState(state: string): string {
-        if (!state) {
+        if (state == null || state == undefined) {
             return null;
         }
 
@@ -186,7 +186,10 @@ export class SsoComponent {
     }
 
     private checkState(state: string, checkState: string): boolean {
-        if (!state || !checkState) {
+        if (state == null || state == undefined) {
+            return false;
+        }
+        if (checkState == null || checkState == undefined) {
             return false;
         }
 

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -51,8 +51,8 @@ export class SsoComponent {
                 const state = await this.storageService.get<string>(ConstantsService.ssoStateKey);
                 await this.storageService.remove(ConstantsService.ssoCodeVerifierKey);
                 await this.storageService.remove(ConstantsService.ssoStateKey);
-                if (qParams.code != null && codeVerifier != null && state != null && state === qParams.state) {
-                    await this.logIn(qParams.code, codeVerifier, this.getOrgIdentiferFromState(state));
+                if (qParams.code != null && codeVerifier != null && state != null && this.checkState(state, qParams.state)) {
+                    await this.logIn(qParams.code, codeVerifier, this.getOrgIdentiferFromState(qParams.state));
                 }
             } else if (qParams.clientId != null && qParams.redirectUri != null && qParams.state != null &&
                 qParams.codeChallenge != null) {
@@ -183,5 +183,15 @@ export class SsoComponent {
 
         const stateSplit = state.split('_identifier=');
         return stateSplit.length > 1 ? stateSplit[1] : null;
+    }
+
+    private checkState(state: string, checkState: string): boolean {
+        if (!state || !checkState) {
+            return false;
+        }
+
+        const stateSplit = state.split('_identifier=');
+        const checkStateSplit = checkState.split('_identifier=');
+        return stateSplit[0] === checkStateSplit[0];
     }
 }


### PR DESCRIPTION
This resolves: https://community.bitwarden.com/t/sso-issues-with-desktop-app-and-cli/15604 (for Desktop)

The issue was caused by the `state` being modified when parsing the query string parameters from the web vault back into the Desktop. The identifier is needed in this case and is passed at the end of the state, however the state comparison with what's in local-storage for the desktop app will not match because it's only the "base" `state` value (w/o the `_identifier=...` appended).

Since this is a shared component and needs to work across clients/types, I instead went for a comparison method, `checkState()` that would take both state values and encapsulate the parsing, splitting, cleaning them for true comparison, vs. hard-coding further up the chain.

I also found an issue where the `state` value from local storage was being passed into `getOrgIdentiferFromState()` however in the desktop application, that value would never actually have the identifier value in it, only the `qParams.state` value would. Assuming we've gotten this far because the state values match, we can "safely" rely on the `qParams.state` value to be passed here vs. the generated/locally stored `state` value which in some clients may be missing the appended `_identifier=...`.

First introduced with: https://github.com/bitwarden/jslib/pull/173