### PR TITLE
Use logService for console messages

### DIFF
--- a/src/abstractions/log.service.ts
+++ b/src/abstractions/log.service.ts
@@ -6,4 +6,6 @@ export abstract class LogService {
     warning: (message: string) => void;
     error: (message: string) => void;
     write: (level: LogLevelType, message: string) => void;
+    time: (label: string) => void;
+    timeEnd: (label: string) => bigint;
 }

--- a/src/cli/baseProgram.ts
+++ b/src/cli/baseProgram.ts
@@ -18,7 +18,7 @@ export abstract class BaseProgram {
         if (!response.success) {
             if (process.env.BW_QUIET !== 'true') {
                 if (process.env.BW_RESPONSE === 'true') {
-                    this.writeLn(this.getJson(response), true, true);
+                    this.writeLn(this.getJson(response), true, false);
                 } else {
                     this.writeLn(chalk.redBright(response.message), true, true);
                 }

--- a/src/cli/services/consoleLog.service.ts
+++ b/src/cli/services/consoleLog.service.ts
@@ -1,29 +1,10 @@
 import { LogLevelType } from '../../enums/logLevelType';
 
-import { LogService as LogServiceAbstraction } from '../../abstractions/log.service';
+import { ConsoleLogService as BaseConsoleLogService } from '../../services/consoleLog.service';
 
-export class ConsoleLogService implements LogServiceAbstraction {
-    private timersMap: Map<string, bigint> = new Map();
-
-    constructor(private isDev: boolean, private filter: (level: LogLevelType) => boolean = null) { }
-
-    debug(message: string) {
-        if (!this.isDev) {
-            return;
-        }
-        this.write(LogLevelType.Debug, message);
-    }
-
-    info(message: string) {
-        this.write(LogLevelType.Info, message);
-    }
-
-    warning(message: string) {
-        this.write(LogLevelType.Warning, message);
-    }
-
-    error(message: string) {
-        this.write(LogLevelType.Error, message);
+export class ConsoleLogService extends BaseConsoleLogService {
+    constructor(isDev: boolean, filter: (level: LogLevelType) => boolean = null) {
+        super(isDev, filter);
     }
 
     write(level: LogLevelType, message: string) {
@@ -37,38 +18,6 @@ export class ConsoleLogService implements LogServiceAbstraction {
             return;
         }
 
-        switch (level) {
-            case LogLevelType.Debug:
-                // tslint:disable-next-line
-                console.log(message);
-                break;
-            case LogLevelType.Info:
-                // tslint:disable-next-line
-                console.log(message);
-                break;
-            case LogLevelType.Warning:
-                // tslint:disable-next-line
-                console.warn(message);
-                break;
-            case LogLevelType.Error:
-                // tslint:disable-next-line
-                console.error(message);
-                break;
-            default:
-                break;
-        }
-    }
-
-    time(label: string = 'default') {
-        if (!this.timersMap.has(label)) {
-            this.timersMap.set(label, process.hrtime.bigint());
-        }
-    }
-
-    timeEnd(label: string = 'default'): bigint {
-        const elapsed = (process.hrtime.bigint() - this.timersMap.get(label)) / BigInt(1000000);
-        this.timersMap.delete(label);
-        this.write(LogLevelType.Info, `${label}: ${elapsed}ms`);
-        return elapsed;
+        super.write(level, message);
     }
 }

--- a/src/electron/services/electronLog.service.ts
+++ b/src/electron/services/electronLog.service.ts
@@ -8,6 +8,8 @@ import { LogLevelType } from '../../enums/logLevelType';
 import { LogService as LogServiceAbstraction } from '../../abstractions/log.service';
 
 export class ElectronLogService implements LogServiceAbstraction {
+    private timersMap: Map<string, bigint> = new Map();
+
     constructor(private filter: (level: LogLevelType) => boolean = null, logDir: string = null) {
         if (log.transports == null) {
             return;
@@ -60,5 +62,18 @@ export class ElectronLogService implements LogServiceAbstraction {
             default:
                 break;
         }
+    }
+
+    time(label: string = 'default') {
+        if (!this.timersMap.has(label)) {
+            this.timersMap.set(label, process.hrtime.bigint());
+        }
+    }
+
+    timeEnd(label: string = 'default'): bigint {
+        const elapsed = (process.hrtime.bigint() - this.timersMap.get(label)) / BigInt(1000000);
+        this.timersMap.delete(label);
+        this.write(LogLevelType.Info, `${label}: ${elapsed}ms`);
+        return elapsed;
     }
 }

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -16,9 +16,13 @@ import { SecureNoteView } from '../models/view/secureNoteView';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { LogService } from '../abstractions';
 
 export abstract class BaseImporter {
     organization = false;
+
+    protected logService: LogService = new ConsoleLogService(false);
 
     protected newLineRegex = /(?:\r\n|\r|\n)/;
 
@@ -82,7 +86,7 @@ export abstract class BaseImporter {
             result.errors.forEach((e) => {
                 if (e.row != null) {
                     // tslint:disable-next-line
-                    console.warn('Error parsing row ' + e.row + ': ' + e.message);
+                    this.logService.warning('Error parsing row ' + e.row + ': ' + e.message);
                 }
             });
         }

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -13,11 +13,11 @@ import { FolderView } from '../models/view/folderView';
 import { LoginView } from '../models/view/loginView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
+import { LogService } from '../abstractions';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
-import { LogService } from '../abstractions';
 
 export abstract class BaseImporter {
     organization = false;

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -13,7 +13,7 @@ import { FolderView } from '../models/view/folderView';
 import { LoginView } from '../models/view/loginView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
-import { LogService } from '../abstractions';
+import { LogService } from '../abstractions/log.service';
 import { ConsoleLogService } from '../cli/services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -14,7 +14,7 @@ import { LoginView } from '../models/view/loginView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
 import { LogService } from '../abstractions/log.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { ConsoleLogService } from '../services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -14,10 +14,10 @@ import { LoginView } from '../models/view/loginView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
 import { LogService } from '../abstractions/log.service';
-import { ConsoleLogService } from '../services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
+import { ConsoleLogService } from '../services/consoleLog.service';
 
 export abstract class BaseImporter {
     organization = false;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -17,11 +17,13 @@ import { AppIdService } from '../abstractions/appId.service';
 import { AuthService as AuthServiceAbstraction } from '../abstractions/auth.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { I18nService } from '../abstractions/i18n.service';
+import { LogService } from '../abstractions/log.service';
 import { MessagingService } from '../abstractions/messaging.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { TokenService } from '../abstractions/token.service';
 import { UserService } from '../abstractions/user.service';
 import { VaultTimeoutService } from '../abstractions/vaultTimeout.service';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
 
 export const TwoFactorProviders = {
     [TwoFactorProviderType.Authenticator]: {
@@ -91,7 +93,12 @@ export class AuthService implements AuthServiceAbstraction {
         private userService: UserService, private tokenService: TokenService,
         private appIdService: AppIdService, private i18nService: I18nService,
         private platformUtilsService: PlatformUtilsService, private messagingService: MessagingService,
-        private vaultTimeoutService: VaultTimeoutService, private setCryptoKeys = true) { }
+        private vaultTimeoutService: VaultTimeoutService, private logService?: LogService,
+        private setCryptoKeys = true) { 
+        if (!logService) {
+            this.logService = new ConsoleLogService(false);
+        }
+    }
 
     init() {
         TwoFactorProviders[TwoFactorProviderType.Email].name = this.i18nService.t('emailTitle');
@@ -351,7 +358,7 @@ export class AuthService implements AuthServiceAbstraction {
                         tokenResponse.privateKey = keyPair[1].encryptedString;
                     } catch (e) {
                         // tslint:disable-next-line
-                        console.error(e);
+                        this.logService.error(e);
                     }
                 }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -23,7 +23,7 @@ import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { TokenService } from '../abstractions/token.service';
 import { UserService } from '../abstractions/user.service';
 import { VaultTimeoutService } from '../abstractions/vaultTimeout.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { ConsoleLogService } from '../services/consoleLog.service';
 
 export const TwoFactorProviders = {
     [TwoFactorProviderType.Authenticator]: {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -94,7 +94,7 @@ export class AuthService implements AuthServiceAbstraction {
         private appIdService: AppIdService, private i18nService: I18nService,
         private platformUtilsService: PlatformUtilsService, private messagingService: MessagingService,
         private vaultTimeoutService: VaultTimeoutService, private logService?: LogService,
-        private setCryptoKeys = true) { 
+        private setCryptoKeys = true) {
         if (!logService) {
             this.logService = new ConsoleLogService(false);
         }

--- a/src/services/consoleLog.service.ts
+++ b/src/services/consoleLog.service.ts
@@ -1,0 +1,68 @@
+import { LogLevelType } from '../enums/logLevelType';
+
+import { LogService as LogServiceAbstraction } from '../abstractions/log.service';
+
+export class ConsoleLogService implements LogServiceAbstraction {
+    private timersMap: Map<string, bigint> = new Map();
+
+    constructor(protected isDev: boolean, protected filter: (level: LogLevelType) => boolean = null) { }
+
+    debug(message: string) {
+        if (!this.isDev) {
+            return;
+        }
+        this.write(LogLevelType.Debug, message);
+    }
+
+    info(message: string) {
+        this.write(LogLevelType.Info, message);
+    }
+
+    warning(message: string) {
+        this.write(LogLevelType.Warning, message);
+    }
+
+    error(message: string) {
+        this.write(LogLevelType.Error, message);
+    }
+
+    write(level: LogLevelType, message: string) {
+        if (this.filter != null && this.filter(level)) {
+            return;
+        }
+
+        switch (level) {
+            case LogLevelType.Debug:
+                // tslint:disable-next-line
+                console.log(message);
+                break;
+            case LogLevelType.Info:
+                // tslint:disable-next-line
+                console.log(message);
+                break;
+            case LogLevelType.Warning:
+                // tslint:disable-next-line
+                console.warn(message);
+                break;
+            case LogLevelType.Error:
+                // tslint:disable-next-line
+                console.error(message);
+                break;
+            default:
+                break;
+        }
+    }
+
+    time(label: string = 'default') {
+        if (!this.timersMap.has(label)) {
+            this.timersMap.set(label, process.hrtime.bigint());
+        }
+    }
+
+    timeEnd(label: string = 'default'): bigint {
+        const elapsed = (process.hrtime.bigint() - this.timersMap.get(label)) / BigInt(1000000);
+        this.timersMap.delete(label);
+        this.write(LogLevelType.Info, `${label}: ${elapsed}ms`);
+        return elapsed;
+    }
+}

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -5,21 +5,21 @@ import { KdfType } from '../enums/kdfType';
 
 import { CipherString } from '../models/domain/cipherString';
 import { EncryptedObject } from '../models/domain/encryptedObject';
-import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
+import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
 
+import { LogService } from '..//abstractions/log.service';
 import { CryptoService as CryptoServiceAbstraction } from '../abstractions/crypto.service';
 import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
-import { LogService } from '..//abstractions/log.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { StorageService } from '../abstractions/storage.service';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
 
 import { ConstantsService } from './constants.service';
 
-import { EEFLongWordList } from '../misc/wordlist';
 import { sequentialize } from '../misc/sequentialize';
 import { Utils } from '../misc/utils';
+import { EEFLongWordList } from '../misc/wordlist';
 
 const Keys = {
     key: 'key', // Master Key

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -8,9 +8,9 @@ import { EncryptedObject } from '../models/domain/encryptedObject';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
 
-import { LogService } from '..//abstractions/log.service';
 import { CryptoService as CryptoServiceAbstraction } from '../abstractions/crypto.service';
 import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
+import { LogService } from '../abstractions/log.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { StorageService } from '../abstractions/storage.service';
 import { ConsoleLogService } from '../services/consoleLog.service';

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -13,7 +13,7 @@ import { CryptoService as CryptoServiceAbstraction } from '../abstractions/crypt
 import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { StorageService } from '../abstractions/storage.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { ConsoleLogService } from '../services/consoleLog.service';
 
 import { ConstantsService } from './constants.service';
 

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -3,10 +3,10 @@ import * as signalRMsgPack from '@microsoft/signalr-protocol-msgpack';
 
 import { NotificationType } from '../enums/notificationType';
 
-import { LogService } from '../abstractions/log.service'
 import { ApiService } from '../abstractions/api.service';
 import { AppIdService } from '../abstractions/appId.service';
 import { EnvironmentService } from '../abstractions/environment.service';
+import { LogService } from '../abstractions/log.service'
 import { NotificationsService as NotificationsServiceAbstraction } from '../abstractions/notifications.service';
 import { SyncService } from '../abstractions/sync.service';
 import { UserService } from '../abstractions/user.service';

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -3,7 +3,7 @@ import * as signalRMsgPack from '@microsoft/signalr-protocol-msgpack';
 
 import { NotificationType } from '../enums/notificationType';
 
-import { LogService } from '../abstractions'
+import { LogService } from '../abstractions/log.service'
 import { ApiService } from '../abstractions/api.service';
 import { AppIdService } from '../abstractions/appId.service';
 import { EnvironmentService } from '../abstractions/environment.service';

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -5,7 +5,9 @@ import { NotificationType } from '../enums/notificationType';
 
 import { ApiService } from '../abstractions/api.service';
 import { AppIdService } from '../abstractions/appId.service';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
 import { EnvironmentService } from '../abstractions/environment.service';
+import { LogService } from '../abstractions'
 import { NotificationsService as NotificationsServiceAbstraction } from '../abstractions/notifications.service';
 import { SyncService } from '../abstractions/sync.service';
 import { UserService } from '../abstractions/user.service';
@@ -27,7 +29,12 @@ export class NotificationsService implements NotificationsServiceAbstraction {
 
     constructor(private userService: UserService, private syncService: SyncService,
         private appIdService: AppIdService, private apiService: ApiService,
-        private vaultTimeoutService: VaultTimeoutService, private logoutCallback: () => Promise<void>) { }
+        private vaultTimeoutService: VaultTimeoutService,
+        private logoutCallback: () => Promise<void>, private logService?: LogService) { 
+        if (!logService) {
+            this.logService = new ConsoleLogService(false);
+        }
+    }
 
     async init(environmentService: EnvironmentService): Promise<void> {
         this.inited = false;
@@ -87,8 +94,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
                 await this.signalrConnection.stop();
             }
         } catch (e) {
-            // tslint:disable-next-line
-            console.error(e.toString());
+            this.logService.error(e.toString())
         }
     }
 

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -3,15 +3,15 @@ import * as signalRMsgPack from '@microsoft/signalr-protocol-msgpack';
 
 import { NotificationType } from '../enums/notificationType';
 
+import { LogService } from '../abstractions'
 import { ApiService } from '../abstractions/api.service';
 import { AppIdService } from '../abstractions/appId.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
 import { EnvironmentService } from '../abstractions/environment.service';
-import { LogService } from '../abstractions'
 import { NotificationsService as NotificationsServiceAbstraction } from '../abstractions/notifications.service';
 import { SyncService } from '../abstractions/sync.service';
 import { UserService } from '../abstractions/user.service';
 import { VaultTimeoutService } from '../abstractions/vaultTimeout.service';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
 
 import {
     NotificationResponse,
@@ -30,7 +30,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
     constructor(private userService: UserService, private syncService: SyncService,
         private appIdService: AppIdService, private apiService: ApiService,
         private vaultTimeoutService: VaultTimeoutService,
-        private logoutCallback: () => Promise<void>, private logService?: LogService) { 
+        private logoutCallback: () => Promise<void>, private logService?: LogService) {
         if (!logService) {
             this.logService = new ConsoleLogService(false);
         }

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -11,7 +11,7 @@ import { NotificationsService as NotificationsServiceAbstraction } from '../abst
 import { SyncService } from '../abstractions/sync.service';
 import { UserService } from '../abstractions/user.service';
 import { VaultTimeoutService } from '../abstractions/vaultTimeout.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { ConsoleLogService } from '../services/consoleLog.service';
 
 import {
     NotificationResponse,

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -6,14 +6,19 @@ import { CipherService } from '../abstractions/cipher.service';
 import { SearchService as SearchServiceAbstraction } from '../abstractions/search.service';
 
 import { CipherType } from '../enums/cipherType';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
 import { FieldType } from '../enums/fieldType';
+import { LogService } from '../abstractions';
 import { UriMatchType } from '../enums/uriMatchType';
 
 export class SearchService implements SearchServiceAbstraction {
     private indexing = false;
     private index: lunr.Index = null;
 
-    constructor(private cipherService: CipherService) {
+    constructor(private cipherService: CipherService, private logService?: LogService) {
+        if (!logService) {
+            this.logService = new ConsoleLogService(false);
+        }
     }
 
     clearIndex(): void {
@@ -30,8 +35,8 @@ export class SearchService implements SearchServiceAbstraction {
         if (this.indexing) {
             return;
         }
-        // tslint:disable-next-line
-        console.time('search indexing');
+
+        this.logService.time('search indexing');
         this.indexing = true;
         this.index = null;
         const builder = new lunr.Builder();
@@ -62,8 +67,8 @@ export class SearchService implements SearchServiceAbstraction {
         ciphers.forEach((c) => builder.add(c));
         this.index = builder.build();
         this.indexing = false;
-        // tslint:disable-next-line
-        console.timeEnd('search indexing');
+
+        this.logService.timeEnd('search indexing');
     }
 
     async searchCiphers(query: string,

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -5,10 +5,10 @@ import { CipherView } from '../models/view/cipherView';
 import { CipherService } from '../abstractions/cipher.service';
 import { SearchService as SearchServiceAbstraction } from '../abstractions/search.service';
 
-import { CipherType } from '../enums/cipherType';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
-import { FieldType } from '../enums/fieldType';
 import { LogService } from '../abstractions';
+import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { CipherType } from '../enums/cipherType';
+import { FieldType } from '../enums/fieldType';
 import { UriMatchType } from '../enums/uriMatchType';
 
 export class SearchService implements SearchServiceAbstraction {

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -5,7 +5,7 @@ import { CipherView } from '../models/view/cipherView';
 import { CipherService } from '../abstractions/cipher.service';
 import { SearchService as SearchServiceAbstraction } from '../abstractions/search.service';
 
-import { LogService } from '../abstractions';
+import { LogService } from '../abstractions/log.service';
 import { ConsoleLogService } from '../cli/services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -6,10 +6,10 @@ import { CipherService } from '../abstractions/cipher.service';
 import { SearchService as SearchServiceAbstraction } from '../abstractions/search.service';
 
 import { LogService } from '../abstractions/log.service';
-import { ConsoleLogService } from '../services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { UriMatchType } from '../enums/uriMatchType';
+import { ConsoleLogService } from '../services/consoleLog.service';
 
 export class SearchService implements SearchServiceAbstraction {
     private indexing = false;

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -6,7 +6,7 @@ import { CipherService } from '../abstractions/cipher.service';
 import { SearchService as SearchServiceAbstraction } from '../abstractions/search.service';
 
 import { LogService } from '../abstractions/log.service';
-import { ConsoleLogService } from '../cli/services/consoleLog.service';
+import { ConsoleLogService } from '../services/consoleLog.service';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { UriMatchType } from '../enums/uriMatchType';


### PR DESCRIPTION
# Objective

Establish a centralized means of handling console logging. Partially resolves bitwarden/cli/issues/188, which calls out the need to shunt all stdout to stderr when the --response flag is used. This is the first step toward that.

# Files changed

* **log.service.ts**: node's console.time is used to measure time taken handling Ciphers and so must be implemented on logService.
* **cli/baseProgram.ts**: `--response` flag is meant to **guarantee** json output to stdout.
* **consoleLogService.ts**: Implement console.time similar to node's library. Output is in ms rather than s+ms.
* **electronLogService.ts**: Same as **consoleLogService.ts**
* **baseImporter.ts**: provide a basic consoleLogService in non-dev mode for importer. We may want to look at determining dev mode here. Use the logService for error reporting as we were previously using console.log/warn.
* **auth.service.ts/crypto.service.ts/notification.service.ts/search.service.ts**: provide optional logService constructor parameter and default to  consoleLogService in non-dev mode. We may want to look into determining dev mode. Use LogService for error reporting as we were previously using console.log/warn. The reason to use an optional parameter is because only `CLI` and `Desktop` use logService at the moment, by defaulting to a consoleLogService, we maintain behavior for `web` and `browser` without requiring code changes.


This commit will require commensurate merges in https://github.com/bitwarden/cli and https://github.com/bitwarden/desktop
