### PR TITLE
Implemented tax collection for subscriptions

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -99,6 +99,7 @@ import { SendResponse } from '../models/response/sendResponse';
 import { SubscriptionResponse } from '../models/response/subscriptionResponse';
 import { SyncResponse } from '../models/response/syncResponse';
 import { TaxInfoResponse } from '../models/response/taxInfoResponse';
+import { TaxRateResponse } from '../models/response/taxRateResponse';
 import { TwoFactorAuthenticatorResponse } from '../models/response/twoFactorAuthenticatorResponse';
 import { TwoFactorDuoResponse } from '../models/response/twoFactorDuoResponse';
 import { TwoFactorEmailResponse } from '../models/response/twoFactorEmailResponse';
@@ -299,6 +300,7 @@ export abstract class ApiService {
     postOrganizationReinstate: (id: string) => Promise<any>;
     deleteOrganization: (id: string, request: PasswordVerificationRequest) => Promise<any>;
     getPlans: () => Promise<ListResponse<PlanResponse>>;
+    getTaxRates: () => Promise<ListResponse<TaxRateResponse>>;
 
     getEvents: (start: string, end: string, token: string) => Promise<ListResponse<EventResponse>>;
     getEventsCipher: (id: string, start: string, end: string, token: string) => Promise<ListResponse<EventResponse>>;

--- a/src/models/request/organizationUpgradeRequest.ts
+++ b/src/models/request/organizationUpgradeRequest.ts
@@ -6,4 +6,6 @@ export class OrganizationUpgradeRequest {
     additionalSeats: number;
     additionalStorageGb: number;
     premiumAccessAddon: boolean;
+    billingAddressCountry: string;
+    billingAddressPostalCode: string;
 }

--- a/src/models/response/taxRateResponse.ts
+++ b/src/models/response/taxRateResponse.ts
@@ -1,0 +1,18 @@
+import { BaseResponse } from './baseResponse';
+
+export class TaxRateResponse extends BaseResponse {
+    id: string;
+    country: string;
+    state: string;
+    postalCode: string;
+    rate: number;
+
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.country = this.getResponseProperty('Country');
+        this.state = this.getResponseProperty('State');
+        this.postalCode = this.getResponseProperty('PostalCode');
+        this.rate = this.getResponseProperty('Rate');
+    }
+}

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -104,6 +104,7 @@ import { SendResponse } from '../models/response/sendResponse';
 import { SubscriptionResponse } from '../models/response/subscriptionResponse';
 import { SyncResponse } from '../models/response/syncResponse';
 import { TaxInfoResponse } from '../models/response/taxInfoResponse';
+import { TaxRateResponse } from '../models/response/taxRateResponse';
 import { TwoFactorAuthenticatorResponse } from '../models/response/twoFactorAuthenticatorResponse';
 import { TwoFactorDuoResponse } from '../models/response/twoFactorDuoResponse';
 import { TwoFactorEmailResponse } from '../models/response/twoFactorEmailResponse';
@@ -758,6 +759,11 @@ export class ApiService implements ApiServiceAbstraction {
 
     async postImportDirectory(organizationId: string, request: ImportDirectoryRequest): Promise<any> {
         return this.send('POST', '/organizations/' + organizationId + '/import', request, true, false);
+    }
+
+    async getTaxRates(): Promise<ListResponse<TaxRateResponse>> {
+        const r = await this.send('GET', '/plans/sales-tax-rates/', null, true, true);
+        return new ListResponse(r, TaxRateResponse);
     }
 
     // Settings APIs


### PR DESCRIPTION
https://app.asana.com/0/1195018406457675/1178713563045098/f

### Narrative
As Steve I need Bitwarden to collect sales tax from a manually defined list of postal codes in order to save us from world governments.

### Code Changes
1. Added some simple billing fields to the orgUpgrade model to collect sales tax against.
2. Added API passthroughs for the GetAllActive TaxRate method to be used in the web vault
3. Created a model to use in (2)

### Sibling PRs
https://github.com/bitwarden/server/pull/1017
https://github.com/bitwarden/web/pull/723
