### PR TITLE
Specify to 2fa we're coming from sso

### DIFF
--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -145,6 +145,7 @@ export class SsoComponent {
                     this.router.navigate([this.twoFactorRoute], {
                         queryParams: {
                             identifier: orgIdFromState,
+                            sso: 'true'
                         },
                     });
                 }


### PR DESCRIPTION
# Objective
SSO login for browser still leaves an extra hanging tab if 2fa is required to complete a login. This change passes an extra parameter specifying the 2fa request is for sso and clients can use that information as they may.

A companion PR, bitwarden/browser#1480, is submitted for Browser that uses this query parameter to close the 2fa window on successful login.

Closes bitwarden/browser/issues/1479

# Files Changed
* **sso.component.ts**: Add query parameter sso='true' to default 2fa redirect.