### PR TITLE
encrypted import for bitwarden json

### DIFF
--- a/spec/common/importers/keepass2XmlImporter.spec.ts
+++ b/spec/common/importers/keepass2XmlImporter.spec.ts
@@ -192,7 +192,7 @@ line2</Value>
 describe('KeePass2 Xml Importer', () => {
     it('should parse XML data', async () => {
         const importer = new Importer();
-        const result = importer.parse(TestData);
+        const result = await importer.parse(TestData);
         expect(result != null).toBe(true);
     });
 });

--- a/spec/common/importers/lastpassCsvImporter.spec.ts
+++ b/spec/common/importers/lastpassCsvImporter.spec.ts
@@ -163,7 +163,7 @@ describe('Lastpass CSV Importer', () => {
     CipherData.forEach((data) => {
         it(data.title, async () => {
             const importer = new Importer();
-            const result = importer.parse(data.csv);
+            const result = await importer.parse(data.csv);
             expect(result != null).toBe(true);
             expect(result.ciphers.length).toBeGreaterThan(0);
 

--- a/spec/common/importers/onepassword1PifImporter.spec.ts
+++ b/spec/common/importers/onepassword1PifImporter.spec.ts
@@ -434,7 +434,7 @@ const IdentityTestData = JSON.stringify({
 describe('1Password 1Pif Importer', () => {
     it('should parse data', async () => {
         const importer = new Importer();
-        const result = importer.parse(TestData);
+        const result = await importer.parse(TestData);
         expect(result != null).toBe(true);
 
         const cipher = result.ciphers.shift();
@@ -447,7 +447,7 @@ describe('1Password 1Pif Importer', () => {
 
     it('should create concealed field as "hidden" type', async () => {
         const importer = new Importer();
-        const result = importer.parse(TestData);
+        const result = await importer.parse(TestData);
         expect(result != null).toBe(true);
 
         const ciphers = result.ciphers;
@@ -465,7 +465,7 @@ describe('1Password 1Pif Importer', () => {
 
     it('should create identity records', async () => {
         const importer = new Importer();
-        const result = importer.parse(IdentityTestData);
+        const result = await importer.parse(IdentityTestData);
         expect(result != null).toBe(true);
         const cipher = result.ciphers.shift();
         expect(cipher.name).toEqual('Test Identity');
@@ -488,7 +488,7 @@ describe('1Password 1Pif Importer', () => {
 
     it('should create password history', async () => {
         const importer = new Importer();
-        const result = importer.parse(TestData);
+        const result = await importer.parse(TestData);
         const cipher = result.ciphers.shift();
 
         expect(cipher.passwordHistory.length).toEqual(1);
@@ -499,7 +499,7 @@ describe('1Password 1Pif Importer', () => {
 
     it('should create password history from windows opvault 1pif format', async () => {
         const importer = new Importer();
-        const result = importer.parse(WindowsOpVaultTestData);
+        const result = await importer.parse(WindowsOpVaultTestData);
         const cipher = result.ciphers.shift();
 
         expect(cipher.passwordHistory.length).toEqual(5);

--- a/spec/common/importers/onepasswordCsvImporter.spec.ts
+++ b/spec/common/importers/onepasswordCsvImporter.spec.ts
@@ -6,9 +6,9 @@ import { data as creditCardData } from './testData/onePasswordCsv/creditCard.csv
 import { data as identityData } from './testData/onePasswordCsv/identity.csv'
 
 describe('1Password CSV Importer', () => {
-    it('should parse identity imports', () => {
+    it('should parse identity imports', async () => {
         const importer = new Importer();
-        const result = importer.parse(identityData);
+        const result = await importer.parse(identityData);
 
         expect(result).not.toBeNull();
         expect(result.success).toBe(true);
@@ -29,9 +29,9 @@ describe('1Password CSV Importer', () => {
         expect(cipher.notes).toContain('address\ncity state zip\nUnited States');
     });
 
-    it('should parse credit card imports', () => {
+    it('should parse credit card imports', async () => {
         const importer = new Importer();
-        const result = importer.parse(creditCardData);
+        const result = await importer.parse(creditCardData);
 
         expect(result).not.toBeNull();
         expect(result.success).toBe(true);

--- a/src/abstractions/import.service.ts
+++ b/src/abstractions/import.service.ts
@@ -9,5 +9,5 @@ export abstract class ImportService {
     regularImportOptions: ImportOption[];
     getImportOptions: () => ImportOption[];
     import: (importer: Importer, fileContents: string, organizationId?: string) => Promise<Error>;
-    getImporter: (format: string, organization?: boolean) => Importer;
+    getImporter: (format: string, organizationId: string) => Importer;
 }

--- a/src/importers/ascendoCsvImporter.ts
+++ b/src/importers/ascendoCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class AscendoCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -50,6 +50,6 @@ export class AscendoCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/avastCsvImporter.ts
+++ b/src/importers/avastCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class AvastCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -23,6 +23,6 @@ export class AvastCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/avastJsonImporter.ts
+++ b/src/importers/avastJsonImporter.ts
@@ -7,12 +7,12 @@ import { CipherType } from '../enums/cipherType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
 export class AvastJsonImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         if (results.logins != null) {
@@ -64,6 +64,6 @@ export class AvastJsonImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/aviraCsvImporter.ts
+++ b/src/importers/aviraCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class AviraCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -31,6 +31,6 @@ export class AviraCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -18,7 +18,7 @@ import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
 export abstract class BaseImporter {
-    organization = false;
+    organizationId: string = null;
 
     protected newLineRegex = /(?:\r\n|\r|\n)/;
 
@@ -68,6 +68,10 @@ export abstract class BaseImporter {
     protected parseCsvOptions = {
         encoding: 'UTF-8',
         skipEmptyLines: false,
+    }
+
+    protected organization() {
+        return this.organizationId != null;
     }
 
     protected parseXml(data: string): Document {

--- a/src/importers/bitwardenCsvImporter.ts
+++ b/src/importers/bitwardenCsvImporter.ts
@@ -15,12 +15,12 @@ import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
 export class BitwardenCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -105,6 +105,6 @@ export class BitwardenCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/blackBerryCsvImporter.ts
+++ b/src/importers/blackBerryCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class BlackBerryCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -31,6 +31,6 @@ export class BlackBerryCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/blurCsvImporter.ts
+++ b/src/importers/blurCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class BlurCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -34,6 +34,6 @@ export class BlurCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/buttercupCsvImporter.ts
+++ b/src/importers/buttercupCsvImporter.ts
@@ -8,12 +8,12 @@ const OfficialProps = [
 ];
 
 export class ButtercupCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -46,6 +46,6 @@ export class ButtercupCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/chromeCsvImporter.ts
+++ b/src/importers/chromeCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class ChromeCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -23,6 +23,6 @@ export class ChromeCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/clipperzHtmlImporter.ts
+++ b/src/importers/clipperzHtmlImporter.ts
@@ -4,19 +4,19 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class ClipperzHtmlImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const doc = this.parseXml(data);
         if (doc == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const textarea = doc.querySelector('textarea');
         if (textarea == null || this.isNullOrWhitespace(textarea.textContent)) {
             result.errorMessage = 'Missing textarea.';
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const entries = JSON.parse(textarea.textContent);
@@ -74,6 +74,6 @@ export class ClipperzHtmlImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/codebookCsvImporter.ts
+++ b/src/importers/codebookCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class CodebookCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -42,6 +42,6 @@ export class CodebookCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/dashlaneJsonImporter.ts
+++ b/src/importers/dashlaneJsonImporter.ts
@@ -17,12 +17,12 @@ const HandledResults = new Set(['ADDRESS', 'AUTHENTIFIANT', 'BANKSTATEMENT', 'ID
 export class DashlaneJsonImporter extends BaseImporter implements Importer {
     private result: ImportResult;
 
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         this.result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null || results.length === 0) {
             this.result.success = false;
-            return this.result;
+            return Promise.resolve(this.result);
         }
 
         if (results.ADDRESS != null) {
@@ -51,7 +51,7 @@ export class DashlaneJsonImporter extends BaseImporter implements Importer {
         }
 
         this.result.success = true;
-        return this.result;
+        return Promise.resolve(this.result);
     }
 
     private processAuth(results: any[]) {

--- a/src/importers/encryptrCsvImporter.ts
+++ b/src/importers/encryptrCsvImporter.ts
@@ -8,12 +8,12 @@ import { CardView } from '../models/view/cardView';
 import { CipherType } from '../enums/cipherType';
 
 export class EncryptrCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -57,6 +57,6 @@ export class EncryptrCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/enpassCsvImporter.ts
+++ b/src/importers/enpassCsvImporter.ts
@@ -10,12 +10,12 @@ import { CardView } from '../models/view/cardView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
 export class EnpassCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         let firstRow = true;
@@ -99,7 +99,7 @@ export class EnpassCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private containsField(fields: any[], name: string) {

--- a/src/importers/enpassJsonImporter.ts
+++ b/src/importers/enpassJsonImporter.ts
@@ -11,12 +11,12 @@ import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 
 export class EnpassJsonImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null || results.items == null || results.items.length === 0) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const foldersMap = new Map<string, string>();
@@ -59,7 +59,7 @@ export class EnpassJsonImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private processLogin(cipher: CipherView, fields: any[]) {

--- a/src/importers/firefoxCsvImporter.ts
+++ b/src/importers/firefoxCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class FirefoxCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -24,6 +24,6 @@ export class FirefoxCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/fsecureFskImporter.ts
+++ b/src/importers/fsecureFskImporter.ts
@@ -8,12 +8,12 @@ import { CardView } from '../models/view/cardView';
 import { CipherType } from '../enums/cipherType';
 
 export class FSecureFskImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null || results.data == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         for (const key in results.data) {
@@ -55,6 +55,6 @@ export class FSecureFskImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/gnomeJsonImporter.ts
+++ b/src/importers/gnomeJsonImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class GnomeJsonImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null || Object.keys(results).length === 0) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         for (const keyRing in results) {
@@ -55,6 +55,6 @@ export class GnomeJsonImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/importer.ts
+++ b/src/importers/importer.ts
@@ -1,7 +1,6 @@
 import { ImportResult } from '../models/domain/importResult';
 
 export interface Importer {
-    organization: boolean;
-
-    parse(data: string): ImportResult;
+    organizationId: string;
+    parse(data: string): Promise<ImportResult>;
 }

--- a/src/importers/kasperskyTxtImporter.ts
+++ b/src/importers/kasperskyTxtImporter.ts
@@ -9,7 +9,7 @@ const WebsitesHeader = 'Websites\n\n';
 const Delimiter = '\n---\n';
 
 export class KasperskyTxtImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
 
         let notesData: string;
@@ -72,7 +72,7 @@ export class KasperskyTxtImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private parseDataCategory(data: string): Map<string, string>[] {

--- a/src/importers/keepass2XmlImporter.ts
+++ b/src/importers/keepass2XmlImporter.ts
@@ -10,18 +10,18 @@ import { FolderView } from '../models/view/folderView';
 export class KeePass2XmlImporter extends BaseImporter implements Importer {
     result = new ImportResult();
 
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const doc = this.parseXml(data);
         if (doc == null) {
             this.result.success = false;
-            return this.result;
+            return Promise.resolve(this.result);
         }
 
         const rootGroup = doc.querySelector('KeePassFile > Root > Group');
         if (rootGroup == null) {
             this.result.errorMessage = 'Missing `KeePassFile > Root > Group` node.';
             this.result.success = false;
-            return this.result;
+            return Promise.resolve(this.result);
         }
 
         this.traverse(rootGroup, true, '');
@@ -31,7 +31,7 @@ export class KeePass2XmlImporter extends BaseImporter implements Importer {
         }
 
         this.result.success = true;
-        return this.result;
+        return Promise.resolve(this.result);
     }
 
     traverse(node: Element, isRootNode: boolean, groupPrefixName: string) {

--- a/src/importers/keepassxCsvImporter.ts
+++ b/src/importers/keepassxCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class KeePassXCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -37,6 +37,6 @@ export class KeePassXCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/keeperCsvImporter.ts
+++ b/src/importers/keeperCsvImporter.ts
@@ -6,12 +6,12 @@ import { ImportResult } from '../models/domain/importResult';
 import { FolderView } from '../models/view/folderView';
 
 export class KeeperCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -43,6 +43,6 @@ export class KeeperCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/lastpassCsvImporter.ts
+++ b/src/importers/lastpassCsvImporter.ts
@@ -14,12 +14,12 @@ import { CipherType } from '../enums/cipherType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
 export class LastPassCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value, index) => {
@@ -84,7 +84,7 @@ export class LastPassCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private buildBaseCipher(value: any) {

--- a/src/importers/logMeOnceCsvImporter.ts
+++ b/src/importers/logMeOnceCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class LogMeOnceCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -26,6 +26,6 @@ export class LogMeOnceCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/meldiumCsvImporter.ts
+++ b/src/importers/meldiumCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class MeldiumCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -24,6 +24,6 @@ export class MeldiumCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/msecureCsvImporter.ts
+++ b/src/importers/msecureCsvImporter.ts
@@ -9,12 +9,12 @@ import { SecureNoteType } from '../enums/secureNoteType';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
 export class MSecureCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -57,6 +57,6 @@ export class MSecureCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/mykiCsvImporter.ts
+++ b/src/importers/mykiCsvImporter.ts
@@ -11,12 +11,12 @@ import { SecureNoteView } from '../models/view/secureNoteView';
 import { ImportResult } from '../models/domain/importResult';
 
 export class MykiCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -71,6 +71,6 @@ export class MykiCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/onepassword1PifImporter.ts
+++ b/src/importers/onepassword1PifImporter.ts
@@ -16,7 +16,7 @@ import { SecureNoteType } from '../enums/secureNoteType';
 export class OnePassword1PifImporter extends BaseImporter implements Importer {
     result = new ImportResult();
 
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         data.split(this.newLineRegex).forEach((line) => {
             if (this.isNullOrWhitespace(line) || line[0] !== '{') {
                 return;
@@ -39,7 +39,7 @@ export class OnePassword1PifImporter extends BaseImporter implements Importer {
         });
 
         this.result.success = true;
-        return this.result;
+        return Promise.resolve(this.result);
     }
 
     private processWinOpVaultItem(item: any, cipher: CipherView) {

--- a/src/importers/onepasswordWinCsvImporter.ts
+++ b/src/importers/onepasswordWinCsvImporter.ts
@@ -9,7 +9,7 @@ import { CardView, IdentityView } from '../models/view';
 const IgnoredProperties = ['ainfo', 'autosubmit', 'notesplain', 'ps', 'scope', 'tags', 'title', 'uuid', 'notes'];
 
 export class OnePasswordWinCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true, {
             quoteChar: '"',
@@ -17,7 +17,7 @@ export class OnePasswordWinCsvImporter extends BaseImporter implements Importer 
         });
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -155,7 +155,7 @@ export class OnePasswordWinCsvImporter extends BaseImporter implements Importer 
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private getProp(obj: any, name: string): any {

--- a/src/importers/padlockCsvImporter.ts
+++ b/src/importers/padlockCsvImporter.ts
@@ -7,12 +7,12 @@ import { CollectionView } from '../models/view/collectionView';
 import { FolderView } from '../models/view/folderView';
 
 export class PadlockCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         let headers: string[] = null;
@@ -82,6 +82,6 @@ export class PadlockCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passkeepCsvImporter.ts
+++ b/src/importers/passkeepCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class PassKeepCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -30,7 +30,7 @@ export class PassKeepCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private getValue(key: string, value: any) {

--- a/src/importers/passmanJsonImporter.ts
+++ b/src/importers/passmanJsonImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class PassmanJsonImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null || results.length === 0) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((credential: any) => {
@@ -56,6 +56,6 @@ export class PassmanJsonImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passpackCsvImporter.ts
+++ b/src/importers/passpackCsvImporter.ts
@@ -6,12 +6,12 @@ import { ImportResult } from '../models/domain/importResult';
 import { CollectionView } from '../models/view/collectionView';
 
 export class PasspackCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -88,6 +88,6 @@ export class PasspackCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passwordAgentCsvImporter.ts
+++ b/src/importers/passwordAgentCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class PasswordAgentCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         let newVersion = true;
@@ -47,6 +47,6 @@ export class PasswordAgentCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passwordBossJsonImporter.ts
+++ b/src/importers/passwordBossJsonImporter.ts
@@ -9,12 +9,12 @@ import { FolderView } from '../models/view/folderView';
 import { CipherType } from '../enums/cipherType';
 
 export class PasswordBossJsonImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = JSON.parse(data);
         if (results == null || results.items == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const foldersMap = new Map<string, string>();
@@ -116,6 +116,6 @@ export class PasswordBossJsonImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passwordDragonXmlImporter.ts
+++ b/src/importers/passwordDragonXmlImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class PasswordDragonXmlImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const doc = this.parseXml(data);
         if (doc == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const records = doc.querySelectorAll('PasswordManager > record');
@@ -52,6 +52,6 @@ export class PasswordDragonXmlImporter extends BaseImporter implements Importer 
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passwordSafeXmlImporter.ts
+++ b/src/importers/passwordSafeXmlImporter.ts
@@ -4,19 +4,19 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class PasswordSafeXmlImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const doc = this.parseXml(data);
         if (doc == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const passwordSafe = doc.querySelector('passwordsafe');
         if (passwordSafe == null) {
             result.errorMessage = 'Missing `passwordsafe` node.';
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const notesDelimiter = passwordSafe.getAttribute('delimiter');
@@ -57,6 +57,6 @@ export class PasswordSafeXmlImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/passwordWalletTxtImporter.ts
+++ b/src/importers/passwordWalletTxtImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class PasswordWalletTxtImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -42,6 +42,6 @@ export class PasswordWalletTxtImporter extends BaseImporter implements Importer 
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/rememBearCsvImporter.ts
+++ b/src/importers/rememBearCsvImporter.ts
@@ -8,12 +8,12 @@ import { ImportResult } from '../models/domain/importResult';
 import { CardView } from '../models/view/cardView';
 
 export class RememBearCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -68,6 +68,6 @@ export class RememBearCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/roboformCsvImporter.ts
+++ b/src/importers/roboformCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class RoboFormCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         let i = 1;
@@ -58,6 +58,6 @@ export class RoboFormCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/safeInCloudXmlImporter.ts
+++ b/src/importers/safeInCloudXmlImporter.ts
@@ -10,19 +10,19 @@ import { CipherType } from '../enums/cipherType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
 export class SafeInCloudXmlImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const doc = this.parseXml(data);
         if (doc == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const db = doc.querySelector('database');
         if (db == null) {
             result.errorMessage = 'Missing `database` node.';
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const foldersMap = new Map<string, number>();
@@ -96,6 +96,6 @@ export class SafeInCloudXmlImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/saferpassCsvImport.ts
+++ b/src/importers/saferpassCsvImport.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class SaferPassCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -24,6 +24,6 @@ export class SaferPassCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/secureSafeCsvImporter.ts
+++ b/src/importers/secureSafeCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class SecureSafeCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -24,6 +24,6 @@ export class SecureSafeCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/splashIdCsvImporter.ts
+++ b/src/importers/splashIdCsvImporter.ts
@@ -5,12 +5,12 @@ import { ImportResult } from '../models/domain/importResult';
 import { CipherView } from '../models/view/cipherView';
 
 export class SplashIdCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -42,7 +42,7 @@ export class SplashIdCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private parseFieldsToNotes(cipher: CipherView, startIndex: number, value: any) {

--- a/src/importers/stickyPasswordXmlImporter.ts
+++ b/src/importers/stickyPasswordXmlImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class StickyPasswordXmlImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const doc = this.parseXml(data);
         if (doc == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         const loginNodes = doc.querySelectorAll('root > Database > Logins > Login');
@@ -62,7 +62,7 @@ export class StickyPasswordXmlImporter extends BaseImporter implements Importer 
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     buildGroupText(doc: Document, groupId: string, groupText: string): string {

--- a/src/importers/truekeyCsvImporter.ts
+++ b/src/importers/truekeyCsvImporter.ts
@@ -14,12 +14,12 @@ const PropertiesToIgnore = ['kind', 'autologin', 'favorite', 'hexcolor', 'protec
 ];
 
 export class TrueKeyCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -69,6 +69,6 @@ export class TrueKeyCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/upmCsvImporter.ts
+++ b/src/importers/upmCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class UpmCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, false);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -27,6 +27,6 @@ export class UpmCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/yotiCsvImporter.ts
+++ b/src/importers/yotiCsvImporter.ts
@@ -4,12 +4,12 @@ import { Importer } from './importer';
 import { ImportResult } from '../models/domain/importResult';
 
 export class YotiCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -23,6 +23,6 @@ export class YotiCsvImporter extends BaseImporter implements Importer {
         });
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 }

--- a/src/importers/zohoVaultCsvImporter.ts
+++ b/src/importers/zohoVaultCsvImporter.ts
@@ -5,12 +5,12 @@ import { ImportResult } from '../models/domain/importResult';
 import { CipherView } from '../models/view';
 
 export class ZohoVaultCsvImporter extends BaseImporter implements Importer {
-    parse(data: string): ImportResult {
+    parse(data: string): Promise<ImportResult> {
         const result = new ImportResult();
         const results = this.parseCsv(data, true);
         if (results == null) {
             result.success = false;
-            return result;
+            return Promise.resolve(result);
         }
 
         results.forEach((value) => {
@@ -37,7 +37,7 @@ export class ZohoVaultCsvImporter extends BaseImporter implements Importer {
         }
 
         result.success = true;
-        return result;
+        return Promise.resolve(result);
     }
 
     private parseData(cipher: CipherView, data: string) {

--- a/src/models/export/card.ts
+++ b/src/models/export/card.ts
@@ -1,6 +1,7 @@
 import { CardView } from '../view/cardView';
 
 import { Card as CardDomain } from '../domain/card';
+import { CipherString } from '../domain/cipherString';
 
 export class Card {
     static template(): Card {
@@ -22,6 +23,16 @@ export class Card {
         view.expYear = req.expYear;
         view.code = req.code;
         return view;
+    }
+
+    static toDomain(req: Card, domain = new CardDomain()) {
+        domain.cardholderName = req.cardholderName != null ? new CipherString(req.cardholderName) : null;
+        domain.brand = req.brand != null ? new CipherString(req.brand) : null;
+        domain.number = req.number != null ? new CipherString(req.number) : null;
+        domain.expMonth = req.expMonth != null ? new CipherString(req.expMonth) : null;
+        domain.expYear = req.expYear != null ? new CipherString(req.expYear) : null;
+        domain.code = req.code != null ? new CipherString(req.code) : null;
+        return domain;
     }
 
     cardholderName: string;

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -3,6 +3,7 @@ import { CipherType } from '../../enums/cipherType';
 import { CipherView } from '../view/cipherView';
 
 import { Cipher as CipherDomain } from '../domain/cipher';
+import { CipherString } from '../domain/cipherString';
 
 import { Card } from './card';
 import { Field } from './field';
@@ -57,6 +58,38 @@ export class Cipher {
         }
 
         return view;
+    }
+
+    static toDomain(req: Cipher, domain = new CipherDomain()) {
+        domain.type = req.type;
+        domain.folderId = req.folderId;
+        if (domain.organizationId == null) {
+            domain.organizationId = req.organizationId;
+        }
+        domain.name = req.name != null ? new CipherString(req.name) : null;
+        domain.notes = req.notes != null ? new CipherString(req.notes) : null;
+        domain.favorite = req.favorite;
+
+        if (req.fields != null) {
+            domain.fields = req.fields.map((f) => Field.toDomain(f));
+        }
+
+        switch (req.type) {
+            case CipherType.Login:
+                domain.login = Login.toDomain(req.login);
+                break;
+            case CipherType.SecureNote:
+                domain.secureNote = SecureNote.toDomain(req.secureNote);
+                break;
+            case CipherType.Card:
+                domain.card = Card.toDomain(req.card);
+                break;
+            case CipherType.Identity:
+                domain.identity = Identity.toDomain(req.identity);
+                break;
+        }
+
+        return domain;
     }
 
     type: CipherType;

--- a/src/models/export/collection.ts
+++ b/src/models/export/collection.ts
@@ -1,5 +1,6 @@
 import { CollectionView } from '../view/collectionView';
 
+import { CipherString } from '../domain/cipherString';
 import { Collection as CollectionDomain } from '../domain/collection';
 
 export class Collection {
@@ -18,6 +19,15 @@ export class Collection {
             view.organizationId = req.organizationId;
         }
         return view;
+    }
+
+    static toDomain(req: Collection, domain = new CollectionDomain()) {
+        domain.name = req.name != null ? new CipherString(req.name) : null;
+        domain.externalId = req.externalId;
+        if (domain.organizationId == null) {
+            domain.organizationId = req.organizationId;
+        }
+        return domain;
     }
 
     organizationId: string;

--- a/src/models/export/field.ts
+++ b/src/models/export/field.ts
@@ -2,6 +2,7 @@ import { FieldType } from '../../enums/fieldType';
 
 import { FieldView } from '../view/fieldView';
 
+import { CipherString } from '../domain/cipherString';
 import { Field as FieldDomain } from '../domain/field';
 
 export class Field {
@@ -18,6 +19,13 @@ export class Field {
         view.value = req.value;
         view.name = req.name;
         return view;
+    }
+
+    static toDomain(req: Field, domain = new FieldDomain()) {
+        domain.type = req.type;
+        domain.value = req.value != null ? new CipherString(req.value) : null;
+        domain.name = req.name != null ? new CipherString(req.name) : null;
+        return domain;
     }
 
     name: string;

--- a/src/models/export/folder.ts
+++ b/src/models/export/folder.ts
@@ -1,5 +1,6 @@
 import { FolderView } from '../view/folderView';
 
+import { CipherString } from '../domain/cipherString';
 import { Folder as FolderDomain } from '../domain/folder';
 
 export class Folder {
@@ -12,6 +13,11 @@ export class Folder {
     static toView(req: Folder, view = new FolderView()) {
         view.name = req.name;
         return view;
+    }
+
+    static toDomain(req: Folder, domain = new FolderDomain()) {
+        domain.name = req.name != null ? new CipherString(req.name) : null;
+        return domain;
     }
 
     name: string;

--- a/src/models/export/identity.ts
+++ b/src/models/export/identity.ts
@@ -1,5 +1,6 @@
 import { IdentityView } from '../view/identityView';
 
+import { CipherString } from '../domain/cipherString';
 import { Identity as IdentityDomain } from '../domain/identity';
 
 export class Identity {
@@ -46,6 +47,28 @@ export class Identity {
         view.passportNumber = req.passportNumber;
         view.licenseNumber = req.licenseNumber;
         return view;
+    }
+
+    static toDomain(req: Identity, domain = new IdentityDomain()) {
+        domain.title = req.title != null ? new CipherString(req.title) : null;
+        domain.firstName = req.firstName != null ? new CipherString(req.firstName) : null;
+        domain.middleName = req.middleName != null ? new CipherString(req.middleName) : null;
+        domain.lastName = req.lastName != null ? new CipherString(req.lastName) : null;
+        domain.address1 = req.address1 != null ? new CipherString(req.address1) : null;
+        domain.address2 = req.address2 != null ? new CipherString(req.address2) : null;
+        domain.address3 = req.address3 != null ? new CipherString(req.address3) : null;
+        domain.city = req.city != null ? new CipherString(req.city) : null;
+        domain.state = req.state != null ? new CipherString(req.state) : null;
+        domain.postalCode = req.postalCode != null ? new CipherString(req.postalCode) : null;
+        domain.country = req.country != null ? new CipherString(req.country) : null;
+        domain.company = req.company != null ? new CipherString(req.company) : null;
+        domain.email = req.email != null ? new CipherString(req.email) : null;
+        domain.phone = req.phone != null ? new CipherString(req.phone) : null;
+        domain.ssn = req.ssn != null ? new CipherString(req.ssn) : null;
+        domain.username = req.username != null ? new CipherString(req.username) : null;
+        domain.passportNumber = req.passportNumber != null ? new CipherString(req.passportNumber) : null;
+        domain.licenseNumber = req.licenseNumber != null ? new CipherString(req.licenseNumber) : null;
+        return domain;
     }
 
     title: string;

--- a/src/models/export/login.ts
+++ b/src/models/export/login.ts
@@ -2,6 +2,7 @@ import { LoginUri } from './loginUri';
 
 import { LoginView } from '../view/loginView';
 
+import { CipherString } from '../domain/cipherString';
 import { Login as LoginDomain } from '../domain/login';
 
 export class Login {
@@ -22,6 +23,16 @@ export class Login {
         view.password = req.password;
         view.totp = req.totp;
         return view;
+    }
+
+    static toDomain(req: Login, domain = new LoginDomain()) {
+        if (req.uris != null) {
+            domain.uris = req.uris.map((u) => LoginUri.toDomain(u));
+        }
+        domain.username = req.username != null ? new CipherString(req.username) : null;
+        domain.password = req.password != null ? new CipherString(req.password) : null;
+        domain.totp = req.totp != null ? new CipherString(req.totp) : null;
+        return domain;
     }
 
     uris: LoginUri[];

--- a/src/models/export/loginUri.ts
+++ b/src/models/export/loginUri.ts
@@ -2,6 +2,7 @@ import { UriMatchType } from '../../enums/uriMatchType';
 
 import { LoginUriView } from '../view/loginUriView';
 
+import { CipherString } from '../domain/cipherString';
 import { LoginUri as LoginUriDomain } from '../domain/loginUri';
 
 export class LoginUri {
@@ -16,6 +17,12 @@ export class LoginUri {
         view.uri = req.uri;
         view.match = req.match;
         return view;
+    }
+
+    static toDomain(req: LoginUri, domain = new LoginUriDomain()) {
+        domain.uri = req.uri != null ? new CipherString(req.uri) : null;
+        domain.match = req.match;
+        return domain;
     }
 
     uri: string;

--- a/src/models/export/secureNote.ts
+++ b/src/models/export/secureNote.ts
@@ -16,6 +16,11 @@ export class SecureNote {
         return view;
     }
 
+    static toDomain(req: SecureNote, view = new SecureNoteDomain()) {
+        view.type = req.type;
+        return view;
+    }
+
     type: SecureNoteType;
 
     constructor(o?: SecureNoteView | SecureNoteDomain) {

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -98,6 +98,7 @@ export class ExportService implements ExportServiceAbstraction {
             return papa.unparse(exportCiphers);
         } else {
             const jsonDoc: any = {
+                encrypted: false,
                 folders: [],
                 items: [],
             };
@@ -130,6 +131,7 @@ export class ExportService implements ExportServiceAbstraction {
         const ciphers = await this.cipherService.getAll();
 
         const jsonDoc: any = {
+            encrypted: true,
             folders: [],
             items: [],
         };
@@ -215,6 +217,7 @@ export class ExportService implements ExportServiceAbstraction {
             return papa.unparse(exportCiphers);
         } else {
             const jsonDoc: any = {
+                encrypted: false,
                 collections: [],
                 items: [],
             };
@@ -264,6 +267,7 @@ export class ExportService implements ExportServiceAbstraction {
         await Promise.all(promises);
 
         const jsonDoc: any = {
+            encrypted: true,
             collections: [],
             items: [],
         };

--- a/src/services/import.service.ts
+++ b/src/services/import.service.ts
@@ -165,12 +165,12 @@ export class ImportService implements ImportServiceAbstraction {
         }
     }
 
-    getImporter(format: string, organization = false): Importer {
+    getImporter(format: string, organizationId: string = null): Importer {
         const importer = this.getImporterInstance(format);
         if (importer == null) {
             return null;
         }
-        importer.organization = organization;
+        importer.organizationId = organizationId;
         return importer;
     }
 


### PR DESCRIPTION
This PR adds support for importing encrypted JSON exports.

- Modify bitwarden json importer to support encrytped json files.
- Support turning export models `toDomain`
- Adjust importer interface to parse async (needed to call `decrypt()`)