### PR TITLE
Desktop fit & finish bugfixes

### DIFF
--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -1,5 +1,6 @@
 import {
     app,
+    BrowserWindow,
     Menu,
     MenuItem,
     MenuItemConstructorOptions,
@@ -57,15 +58,17 @@ export class TrayMain {
         if (await this.storageService.get<boolean>(ElectronConstants.enableTrayKey)) {
             this.showTray();
         }
+    }
 
-        this.windowMain.win.on('minimize', async (e: Event) => {
+    setupWindowListeners(win: BrowserWindow) {
+        win.on('minimize', async (e: Event) => {
             if (await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey)) {
                 e.preventDefault();
                 this.hideToTray();
             }
         });
 
-        this.windowMain.win.on('close', async (e: Event) => {
+        win.on('close', async (e: Event) => {
             if (await this.storageService.get<boolean>(ElectronConstants.enableCloseToTrayKey)) {
                 if (!this.windowMain.isQuitting) {
                     e.preventDefault();
@@ -74,7 +77,7 @@ export class TrayMain {
             }
         });
 
-        this.windowMain.win.on('show', async (e: Event) => {
+        win.on('show', async (e: Event) => {
             const enableTray = await this.storageService.get<boolean>(ElectronConstants.enableTrayKey);
             if (!enableTray) {
                 setTimeout(() =>  this.removeTray(false), 100);

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -23,7 +23,8 @@ export class WindowMain {
 
     constructor(private storageService: StorageService, private hideTitleBar = false,
         private defaultWidth = 950, private defaultHeight = 600,
-        private argvCallback: (argv: string[]) => void = null) { }
+        private argvCallback: (argv: string[]) => void = null,
+        private createWindowCallback: (win: BrowserWindow) => void) { }
 
     init(): Promise<any> {
         return new Promise((resolve, reject) => {
@@ -82,6 +83,9 @@ export class WindowMain {
                     // dock icon is clicked and there are no other windows open.
                     if (this.win === null) {
                         await this.createWindow();
+                    } else {
+                        // Show the window when clicking on Dock icon
+                        this.win.show();
                     }
                 });
 
@@ -169,6 +173,9 @@ export class WindowMain {
             this.windowStateChangeHandler(Keys.mainWindowSize, this.win);
         });
 
+        if (this.createWindowCallback) {
+            this.createWindowCallback(this.win);
+        }
     }
 
     async toggleAlwaysOnTop() {


### PR DESCRIPTION
Resolves the bugs found during testing for #212.

* Fix dock icon not working when minimized to menu bar.
* Fix window listeners not working after closing the main window

Since the main window on Mac can be closed without quitting the application, this caused the Tray window listeners to disappear and not work until the application was restarted. Resolved by setting up a callback in `createWindow`.