### PR TITLE
Hide menu bar

### DIFF
--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -115,6 +115,7 @@ export class WindowMain {
             titleBarStyle: this.hideTitleBar && process.platform === 'darwin' ? 'hiddenInset' : undefined,
             show: false,
             alwaysOnTop: this.enableAlwaysOnTop,
+            autoHideMenuBar: true,
             webPreferences: {
                 nodeIntegration: true,
                 webviewTag: true,


### PR DESCRIPTION
Press `Alt` to toggle. Addresses https://github.com/bitwarden/desktop/issues/43 and https://community.bitwarden.com/t/hide-top-menu-bar-option/4423. Currently there's no way to hide the menu bar, taking up screen space for no purpose. [Documentation](https://www.electronjs.org/docs/api/browser-window#new-browserwindowoptions).