### PR TITLE
Move share button to view page

### DIFF
--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -36,6 +36,7 @@ export class ViewComponent implements OnDestroy, OnInit {
     @Input() cipherId: string;
     @Output() onEditCipher = new EventEmitter<CipherView>();
     @Output() onCloneCipher = new EventEmitter<CipherView>();
+    @Output() onShareCipher = new EventEmitter<CipherView>();
     @Output() onDeletedCipher = new EventEmitter<CipherView>();
     @Output() onRestoredCipher = new EventEmitter<CipherView>();
 
@@ -112,6 +113,10 @@ export class ViewComponent implements OnDestroy, OnInit {
 
     clone() {
         this.onCloneCipher.emit(this.cipher);
+    }
+
+    share() {
+        this.onShareCipher.emit(this.cipher);
     }
 
     async delete(): Promise<boolean> {


### PR DESCRIPTION
It is not possible to edit and share at the same time. Browser extension
currently utilizes this layout and it is confusing. This change is in
conjunction with altering that UI.

# Overview

Relates to bitwarden/server/issues/976. Enables moving share button from the cipher edit page to the view page.


# Files changed

* **view.component.ts**: This is the parent class of browser's view component. These changes are to match existing functionality in the [add-edit.component.ts](https://github.com/bitwarden/jslib/blob/master/src/angular/components/add-edit.component.ts#L349)