### PR TITLE
Prevent reloading browser extension when using biometric

### DIFF
--- a/src/services/system.service.ts
+++ b/src/services/system.service.ts
@@ -19,7 +19,7 @@ export class SystemService implements SystemServiceAbstraction {
     }
 
     startProcessReload(): void {
-        if (this.vaultTimeoutService.pinProtectedKey != null || this.reloadInterval != null) {
+        if (this.vaultTimeoutService.pinProtectedKey != null || this.vaultTimeoutService.biometricLocked || this.reloadInterval != null) {
             return;
         }
         this.cancelProcessReload();


### PR DESCRIPTION
Resolves an issue where the browser extension would reload, which disconnected the secure channel to the desktop application, forcing a re-setup.