### PR TITLE
Add missing event type from server

### DIFF
--- a/src/enums/eventType.ts
+++ b/src/enums/eventType.ts
@@ -39,6 +39,7 @@ export enum EventType {
     OrganizationUser_Updated = 1502,
     OrganizationUser_Removed = 1503,
     OrganizationUser_UpdatedGroups = 1504,
+    OrganizationUser_UnlinkedSso = 1505,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,


### PR DESCRIPTION
# Overview

Related to bitwarden/web/issues/686. Include missing Server EventType to known EventTypes.

# Files changed

* **eventType.ts**: sync Server and jslib Event Type enums