### PR TITLE
Force update of tray menu if on linux

### DIFF
--- a/src/electron/tray.main.ts
+++ b/src/electron/tray.main.ts
@@ -130,6 +130,12 @@ export class TrayMain {
         }
     }
 
+    updateContextMenu() {
+        if (this.contextMenu != null && this.isLinux()) {
+            this.tray.setContextMenu(this.contextMenu);
+        }
+    }
+
     private hideDock() {
         app.dock.hide();
     }
@@ -140,6 +146,10 @@ export class TrayMain {
 
     private isDarwin() {
         return process.platform === 'darwin';
+    }
+
+    private isLinux() {
+        return process.platform === 'linux';
     }
 
     private async toggleWindow() {


### PR DESCRIPTION
# Overview

Related to bitwarden/desktop#493. Electron has an upstream issue/possible feature where tray click options are disabled and context menu is always displayed. This means our left and right click callbacks are being ignored and the stored context menu is being opened.

This is a workaround for the context menu, at least. `updateContextMenu` will be called upon updateTrayMenu and, if on Linux, the context object is updated.

# Files changed

* **tray.main.ts**: Helper methods to force update of context menu object if in Linux