### PR TITLE
fix org getter on import and export warning dialog

### DIFF
--- a/src/angular/components/export.component.ts
+++ b/src/angular/components/export.component.ts
@@ -35,6 +35,15 @@ export class ExportComponent {
             return;
         }
 
+        const acceptedWarning = await this.platformUtilsService.showDialog(
+            this.i18nService.t(this.encryptedFormat ? 'encExportWarningDesc' : 'exportWarningDesc'),
+            this.i18nService.t('confirmVaultExport'), this.i18nService.t('exportVault'),
+            this.i18nService.t('cancel'), 'warning');
+
+        if (!acceptedWarning) {
+            return;
+        }
+
         const keyHash = await this.cryptoService.hashPassword(this.masterPassword, null);
         const storedKeyHash = await this.cryptoService.getKeyHash();
         if (storedKeyHash != null && keyHash != null && storedKeyHash === keyHash) {

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -76,7 +76,7 @@ export abstract class BaseImporter {
         skipEmptyLines: false,
     };
 
-    protected organization() {
+    protected get organization() {
         return this.organizationId != null;
     }
 


### PR DESCRIPTION
This PR adds:

1. A fix to importing encryption json exports. We recently added the `organization` property to the base importer as a getter, but forgot to add the `get` keyword. This made it evaluate to a function, which always has a truthy value when trying to use it like a boolean.

2. Moves the warning messages to a dialog that prompts upon submitting the export.

Follow-up PRs will update the UI of each app and update to this jslib ref.