### PR TITLE
Fix/csv export note newline

### DIFF
--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -112,7 +112,7 @@ export class Cipher {
 
         if (o instanceof CipherView) {
             this.name = o.name;
-            this.notes = o.notes;
+            this.notes = o.notes.replace("\n","\\n");
         } else {
             this.name = o.name?.encryptedString;
             this.notes = o.notes?.encryptedString;

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -112,7 +112,7 @@ export class Cipher {
 
         if (o instanceof CipherView) {
             this.name = o.name;
-            this.notes = o.notes.replace("\n","\\n");
+            this.notes = o.notes.replace(/\n/g,"\\n");
         } else {
             this.name = o.name?.encryptedString;
             this.notes = o.notes?.encryptedString;


### PR DESCRIPTION
During CSV export, notes with new lines break the CSV structure.

This PR aims at escaping every newline in the notes during export.

https://github.com/bitwarden/web/issues/752