### PR TITLE
Update revision date upon cipher restore

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -206,9 +206,9 @@ export abstract class ApiService {
     putDeleteCipherAdmin: (id: string) => Promise<any>;
     putDeleteManyCiphers: (request: CipherBulkDeleteRequest) => Promise<any>;
     putDeleteManyCiphersAdmin: (request: CipherBulkDeleteRequest) => Promise<any>;
-    putRestoreCipher: (id: string) => Promise<any>;
-    putRestoreCipherAdmin: (id: string) => Promise<any>;
-    putRestoreManyCiphers: (request: CipherBulkRestoreRequest) => Promise<any>;
+    putRestoreCipher: (id: string) => Promise<CipherResponse>;
+    putRestoreCipherAdmin: (id: string) => Promise<CipherResponse>;
+    putRestoreManyCiphers: (request: CipherBulkRestoreRequest) => Promise<ListResponse<CipherResponse>>;
 
     postCipherAttachment: (id: string, data: FormData) => Promise<CipherResponse>;
     postCipherAttachmentAdmin: (id: string, data: FormData) => Promise<CipherResponse>;

--- a/src/abstractions/cipher.service.ts
+++ b/src/abstractions/cipher.service.ts
@@ -53,7 +53,7 @@ export abstract class CipherService {
     softDelete: (id: string | string[]) => Promise<any>;
     softDeleteWithServer: (id: string) => Promise<any>;
     softDeleteManyWithServer: (ids: string[]) => Promise<any>;
-    restore: (id: string | string[]) => Promise<any>;
+    restore: (cipher: { id: string, revisionDate: string; } | { id: string, revisionDate: string; }[]) => Promise<any>;
     restoreWithServer: (id: string) => Promise<any>;
     restoreManyWithServer: (ids: string[]) => Promise<any>;
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -556,16 +556,19 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('PUT', '/ciphers/delete-admin', request, true, false);
     }
 
-    putRestoreCipher(id: string): Promise<any> {
-        return this.send('PUT', '/ciphers/' + id + '/restore', null, true, false);
+    async putRestoreCipher(id: string): Promise<CipherResponse> {
+        const r = await this.send('PUT', '/ciphers/' + id + '/restore', null, true, true);
+        return new CipherResponse(r);
     }
 
-    putRestoreCipherAdmin(id: string): Promise<any> {
-        return this.send('PUT', '/ciphers/' + id + '/restore-admin', null, true, false);
+    async putRestoreCipherAdmin(id: string): Promise<CipherResponse> {
+        const r = await this.send('PUT', '/ciphers/' + id + '/restore-admin', null, true, true);
+        return new CipherResponse(r);
     }
 
-    putRestoreManyCiphers(request: CipherBulkDeleteRequest): Promise<any> {
-        return this.send('PUT', '/ciphers/restore', request, true, false);
+    async putRestoreManyCiphers(request: CipherBulkDeleteRequest): Promise<ListResponse<CipherResponse>> {
+        const r = await this.send('PUT', '/ciphers/restore', request, true, true);
+        return new ListResponse<CipherResponse>(r, CipherResponse);
     }
 
     // Attachments APIs

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -904,17 +904,15 @@ export class CipherService implements CipherServiceAbstraction {
     }
 
     async restoreWithServer(id: string): Promise<any> {
-        await this.apiService.putRestoreCipher(id);
-        const response = await this.apiService.getCipher(id);
+        const response = await this.apiService.putRestoreCipher(id);
         await this.restore({ id: id, revisionDate: response.revisionDate });
     }
 
     async restoreManyWithServer(ids: string[]): Promise<any> {
-        await this.apiService.putRestoreManyCiphers(new CipherBulkRestoreRequest(ids));
+        const response = await this.apiService.putRestoreManyCiphers(new CipherBulkRestoreRequest(ids));
         const restores: { id: string, revisionDate: string; }[] = [];
-        for (const id of ids) {
-            const response = await this.apiService.getCipher(id);
-            restores.push({ id: id, revisionDate: response.revisionDate });
+        for (const cipher of response.data) {
+            restores.push({ id: cipher.id, revisionDate: cipher.revisionDate });
         }
         await this.restore(restores);
     }


### PR DESCRIPTION
# Overview

https://app.asana.com/0/1169444489336079/1199337616674667/f
related to bitwarden/web/issues/748

Cipher edit revision date validation is failing for ciphers which were restored from the trash. This is because restores update revisionDate on the server side, but do not send an updated cipher back to the client.

These changes force a call to the server after restore to get the new revisionDate of the cipher.

# Files Changed
* **api.service.ts**: Change signature to expect response from restore calls. (bitwarden/server#1072)
* **cipher.service.ts**: Update local cipher db to match ciphers returned from restore calls