### PR TITLE
Remove unused toData methods

### DIFF
--- a/src/models/domain/send.ts
+++ b/src/models/domain/send.ts
@@ -103,38 +103,4 @@ export class Send extends Domain {
 
         return model;
     }
-
-    toSendData(userId: string): SendData {
-        const s = new SendData();
-        s.id = this.id;
-        s.accessId = this.accessId;
-        s.userId = userId;
-        s.maxAccessCount = this.maxAccessCount;
-        s.accessCount = this.accessCount;
-        s.disabled = this.disabled;
-        s.password = this.password;
-        s.revisionDate = this.revisionDate != null ? this.revisionDate.toISOString() : null;
-        s.deletionDate = this.deletionDate != null ? this.deletionDate.toISOString() : null;
-        s.expirationDate = this.expirationDate != null ? this.expirationDate.toISOString() : null;
-        s.type = this.type;
-
-        this.buildDataModel(this, s, {
-            name: null,
-            notes: null,
-            key: null,
-        });
-
-        switch (s.type) {
-            case SendType.File:
-                s.text = this.text.toSendTextData();
-                break;
-            case SendType.Text:
-                s.file = this.file.toSendFileData();
-                break;
-            default:
-                break;
-        }
-
-        return s;
-    }
 }

--- a/src/models/domain/sendFile.ts
+++ b/src/models/domain/sendFile.ts
@@ -34,16 +34,4 @@ export class SendFile extends Domain {
         }, null, key);
         return view;
     }
-
-    toSendFileData(): SendFileData {
-        const f = new SendFileData();
-        f.size = this.size;
-        this.buildDataModel(this, f, {
-            id: null,
-            url: null,
-            sizeName: null,
-            fileName: null,
-        }, ['id', 'url', 'sizeName']);
-        return f;
-    }
 }

--- a/src/models/domain/sendText.ts
+++ b/src/models/domain/sendText.ts
@@ -27,13 +27,4 @@ export class SendText extends Domain {
             text: null,
         }, null, key);
     }
-
-    toSendTextData(): SendTextData {
-        const t = new SendTextData();
-        this.buildDataModel(this, t, {
-            text: null,
-            hidden: null,
-        }, ['hidden']);
-        return t;
-    }
 }


### PR DESCRIPTION
# Overview

domain/Send.ts has a bug in its `toData` method and upon investigating it, the method is totally unused. This PR just removes these unused methods.