### PR TITLE
Enable search for sends

### DIFF
--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -1,4 +1,5 @@
 import { CipherView } from '../models/view/cipherView';
+import { SendView } from '../models/view/sendView';
 
 export abstract class SearchService {
     clearIndex: () => void;
@@ -8,4 +9,5 @@ export abstract class SearchService {
         filter?: ((cipher: CipherView) => boolean) | (((cipher: CipherView) => boolean)[]),
         ciphers?: CipherView[]) => Promise<CipherView[]>;
     searchCiphersBasic: (ciphers: CipherView[], query: string, deleted?: boolean) => CipherView[];
+    searchSends: (sends: SendView[], query: string) => SendView[];
 }

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -9,6 +9,7 @@ import { SearchService as SearchServiceAbstraction } from '../abstractions/searc
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { UriMatchType } from '../enums/uriMatchType';
+import { SendView } from '../models/view/sendView';
 
 export class SearchService implements SearchServiceAbstraction {
     private indexing = false;
@@ -158,6 +159,28 @@ export class SearchService implements SearchServiceAbstraction {
                 return true;
             }
             return false;
+        });
+    }
+
+    searchSends(sends: SendView[], query: string) {
+        query = query.trim().toLocaleLowerCase();
+
+        return sends.filter(s => {
+            if (s.name != null && s.name.toLowerCase().indexOf(query) > -1) {
+                return true;
+            }
+            if (query.length >= 8 && (s.id.startsWith(query) || (s.file?.id != null && s.file.id.startsWith(query)))) {
+                return true;
+            }
+            if (s.notes != null && s.notes.toLowerCase().indexOf(query) > -1) {
+                return true;
+            }
+            if (s.text?.text != null && s.text.text.toLowerCase().indexOf(query) > -1) {
+                return true;
+            }
+            if (s.file?.fileName != null && s.file.fileName.toLowerCase().indexOf(query) > -1) {
+                return true;
+            }
         });
     }
 


### PR DESCRIPTION
# Overview

A simple search function for sends. Filters on Name, Notes, Text (for text sends), FileName (for file sends), and id for both send and file send attachment.

This is basically the same search functionality as implemented in `searchCiphersBasic`.

This code will be used in
 * Cli implementation of Send
 * To fix web send searches, which is currently non-functional

# Files Changed

* **search.service.ts**: Adds searchSends to service implementation and abstract.