### PR TITLE
Send Sync Notifications

### DIFF
--- a/src/abstractions/sync.service.ts
+++ b/src/abstractions/sync.service.ts
@@ -1,6 +1,7 @@
 import {
     SyncCipherNotification,
     SyncFolderNotification,
+    SyncSendNotification,
 } from '../models/response/notificationResponse';
 
 export abstract class SyncService {
@@ -13,4 +14,6 @@ export abstract class SyncService {
     syncDeleteFolder: (notification: SyncFolderNotification) => Promise<boolean>;
     syncUpsertCipher: (notification: SyncCipherNotification, isEdit: boolean) => Promise<boolean>;
     syncDeleteCipher: (notification: SyncFolderNotification) => Promise<boolean>;
+    syncUpsertSend: (notification: SyncSendNotification, isEdit: boolean) => Promise<boolean>;
+    syncDeleteSend: (notification: SyncSendNotification) => Promise<boolean>;
 }

--- a/src/enums/notificationType.ts
+++ b/src/enums/notificationType.ts
@@ -13,4 +13,8 @@ export enum NotificationType {
     SyncSettings = 10,
 
     LogOut = 11,
+
+    SyncSendCreate = 12,
+    SyncSendUpdate = 13,
+    SyncSendDelete = 14,
 }

--- a/src/models/response/notificationResponse.ts
+++ b/src/models/response/notificationResponse.ts
@@ -32,6 +32,10 @@ export class NotificationResponse extends BaseResponse {
             case NotificationType.LogOut:
                 this.payload = new UserNotification(payload);
                 break;
+            case NotificationType.SyncSendCreate:
+            case NotificationType.SyncSendUpdate:
+            case NotificationType.SyncSendDelete:
+                this.payload = new SyncSendNotification(payload);
             default:
                 break;
         }
@@ -76,5 +80,18 @@ export class UserNotification extends BaseResponse {
         super(response);
         this.userId = this.getResponseProperty('UserId');
         this.date = new Date(this.getResponseProperty('Date'));
+    }
+}
+
+export class SyncSendNotification extends BaseResponse {
+    id: string;
+    userId: string;
+    revisionDate: Date;
+
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.userId = this.getResponseProperty('UserId');
+        this.revisionDate = new Date(this.getResponseProperty('RevisionDate'));
     }
 }

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -16,6 +16,7 @@ import {
     NotificationResponse,
     SyncCipherNotification,
     SyncFolderNotification,
+    SyncSendNotification,
 } from '../models/response/notificationResponse';
 
 export class NotificationsService implements NotificationsServiceAbstraction {
@@ -159,6 +160,13 @@ export class NotificationsService implements NotificationsServiceAbstraction {
                     this.logoutCallback();
                 }
                 break;
+            case NotificationType.SyncSendCreate:
+            case NotificationType.SyncSendUpdate:
+                await this.syncService.syncUpsertSend(notification.payload as SyncSendNotification,
+                    notification.type === NotificationType.SyncSendUpdate);
+                break;
+            case NotificationType.SyncSendDelete:
+                await this.syncService.syncDeleteSend(notification.payload as SyncSendNotification);
             default:
                 break;
         }


### PR DESCRIPTION
https://app.asana.com/0/1199659118818122/1199511462356833
https://github.com/bitwarden/server/pull/1106
https://github.com/bitwarden/web/pull/799

### Narrative 
As a Bitwarden Send user I would like my local Send storage to stay in sync across concurrent sessions.

### Code Changes
1. Added new `notificationType` enums to match their siblings in the Server PR.
2. Added new `syncService` methods for handling Sends.
3. Added a new NotificationResponse object for Send notifications.
4. Added logic to the `notificationService` for handling the new notification types by calling their sync methods.