### PR TITLE
Lunr search bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,10 +1168,10 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
-    "browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    "browser-hrtime": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/browser-hrtime/-/browser-hrtime-1.1.8.tgz",
+      "integrity": "sha512-kzXheikaJsBtzUBlyVtPIY5r0soQePzjwVwT4IlDpU2RvfB5Py52gpU98M77rgqMCheoSSZvrcrdj3t6cZ3suA=="
     },
     "browser-resolve": {
       "version": "1.11.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@microsoft/signalr-protocol-msgpack": "3.1.0",
     "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
     "big-integer": "1.6.36",
-    "browser-process-hrtime": "1.0.0",
+    "browser-hrtime": "^1.1.8",
     "chalk": "2.4.1",
     "commander": "2.18.0",
     "core-js": "2.6.2",

--- a/src/services/consoleLog.service.ts
+++ b/src/services/consoleLog.service.ts
@@ -2,8 +2,7 @@ import { LogLevelType } from '../enums/logLevelType';
 
 import { LogService as LogServiceAbstraction } from '../abstractions/log.service';
 
-// @ts-ignore: import * as ns from "mod" error, need to do it this way
-import hrtime = require('browser-hrtime');
+import * as hrtime from 'browser-hrtime';
 
 export class ConsoleLogService implements LogServiceAbstraction {
     protected timersMap: Map<string, [number, number]> = new Map();

--- a/src/services/consoleLog.service.ts
+++ b/src/services/consoleLog.service.ts
@@ -3,7 +3,7 @@ import { LogLevelType } from '../enums/logLevelType';
 import { LogService as LogServiceAbstraction } from '../abstractions/log.service';
 
 // @ts-ignore: import * as ns from "mod" error, need to do it this way
-import hrtime = require('browser-process-hrtime');
+import hrtime = require('browser-hrtime');
 
 export class ConsoleLogService implements LogServiceAbstraction {
     protected timersMap: Map<string, [number, number]> = new Map();


### PR DESCRIPTION
Addresses https://app.asana.com/0/1199657392022597/1199665585962888

### Issue
Importing `browser-process-hrtime` breaks in different clients using various import styles. This is causing the search index to break in desktop and browser.

### Resolution
Changed to a different package for `hrtime` needs.

### Notes
All clients will need to be updated to the the new module & jslib after this is merged.