### PR TITLE
Add send to cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,24 +1680,32 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "aproba": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1708,12 +1716,16 @@
             },
             "balanced-match": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1724,36 +1736,48 @@
             },
             "chownr": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1763,24 +1787,32 @@
             },
             "deep-extend": {
               "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1790,12 +1822,16 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1812,6 +1848,8 @@
             },
             "glob": {
               "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1826,12 +1864,16 @@
             },
             "has-unicode": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1841,6 +1883,8 @@
             },
             "ignore-walk": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1850,6 +1894,8 @@
             },
             "inflight": {
               "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1860,18 +1906,24 @@
             },
             "inherits": {
               "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1881,12 +1933,16 @@
             },
             "isarray": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1896,12 +1952,16 @@
             },
             "minimist": {
               "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.3.5",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1912,6 +1972,8 @@
             },
             "minizlib": {
               "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1921,6 +1983,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1930,12 +1994,16 @@
             },
             "ms": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.2.4",
+              "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+              "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1947,6 +2015,8 @@
             },
             "node-pre-gyp": {
               "version": "0.10.3",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+              "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1965,6 +2035,8 @@
             },
             "nopt": {
               "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1975,12 +2047,16 @@
             },
             "npm-bundled": {
               "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+              "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+              "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -1991,6 +2067,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2003,18 +2081,24 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2024,18 +2108,24 @@
             },
             "os-homedir": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2046,18 +2136,24 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2070,6 +2166,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "bundled": true,
                   "dev": true,
                   "optional": true
@@ -2078,6 +2176,8 @@
             },
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2093,6 +2193,8 @@
             },
             "rimraf": {
               "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2102,42 +2204,67 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+              "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2147,17 +2274,10 @@
                 "strip-ansi": "^3.0.0"
               }
             },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
             "strip-ansi": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2167,12 +2287,16 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.8",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2188,12 +2312,16 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -2203,12 +2331,16 @@
             },
             "wrappy": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "bundled": true,
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -2405,9 +2537,9 @@
       }
     },
     "commander": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
-      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.0.0.tgz",
+      "integrity": "sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA=="
     },
     "compare-versions": {
       "version": "3.4.0",
@@ -3127,8 +3259,8 @@
       }
     },
     "duo_web_sdk": {
-      "version": "git+https://github.com/duosecurity/duo_web_sdk.git#410a9186cc34663c4913b17d6528067cd3331f1d",
-      "from": "git+https://github.com/duosecurity/duo_web_sdk.git"
+      "version": "git+ssh://git@github.com/duosecurity/duo_web_sdk.git#410a9186cc34663c4913b17d6528067cd3331f1d",
+      "from": "duo_web_sdk@git+https://github.com/duosecurity/duo_web_sdk.git"
     },
     "duplexer": {
       "version": "0.1.1",
@@ -5962,27 +6094,31 @@
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+                  "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "aproba": {
                   "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+                  "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "delegates": "^1.0.0",
                     "readable-stream": "^2.0.6"
@@ -5990,15 +6126,17 @@
                 },
                 "balanced-match": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                  "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                  "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -6006,81 +6144,93 @@
                 },
                 "chownr": {
                   "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+                  "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "code-point-at": {
                   "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "debug": {
                   "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                  "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "ms": "^2.1.1"
                   }
                 },
                 "deep-extend": {
                   "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+                  "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "delegates": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+                  "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "fs-minipass": {
                   "version": "1.2.5",
+                  "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+                  "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "minipass": "^2.2.1"
                   }
                 },
                 "fs.realpath": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "gauge": {
                   "version": "2.7.4",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "aproba": "^1.0.3",
                     "console-control-strings": "^1.0.0",
@@ -6094,9 +6244,10 @@
                 },
                 "glob": {
                   "version": "7.1.3",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                  "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "fs.realpath": "^1.0.0",
                     "inflight": "^1.0.4",
@@ -6108,33 +6259,37 @@
                 },
                 "has-unicode": {
                   "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                  "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                  "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "safer-buffer": ">= 2.1.2 < 3"
                   }
                 },
                 "ignore-walk": {
                   "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+                  "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "minimatch": "^3.0.4"
                   }
                 },
                 "inflight": {
                   "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "once": "^1.3.0",
                     "wrappy": "1"
@@ -6142,51 +6297,58 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "ini": {
                   "version": "1.3.5",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+                  "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
                 },
                 "isarray": {
                   "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
                 },
                 "minimist": {
                   "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "minipass": {
                   "version": "2.3.5",
+                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+                  "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
                     "yallist": "^3.0.0"
@@ -6194,33 +6356,37 @@
                 },
                 "minizlib": {
                   "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+                  "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "minipass": "^2.2.1"
                   }
                 },
                 "mkdirp": {
                   "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
                 },
                 "ms": {
                   "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                  "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "needle": {
                   "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+                  "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "debug": "^4.1.0",
                     "iconv-lite": "^0.4.4",
@@ -6229,9 +6395,10 @@
                 },
                 "node-pre-gyp": {
                   "version": "0.12.0",
+                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+                  "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "detect-libc": "^1.0.2",
                     "mkdirp": "^0.5.1",
@@ -6247,9 +6414,10 @@
                 },
                 "nopt": {
                   "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                  "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "abbrev": "1",
                     "osenv": "^0.1.4"
@@ -6257,15 +6425,17 @@
                 },
                 "npm-bundled": {
                   "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+                  "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
+                  "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+                  "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "ignore-walk": "^3.0.1",
                     "npm-bundled": "^1.0.1"
@@ -6273,9 +6443,10 @@
                 },
                 "npmlog": {
                   "version": "4.1.2",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+                  "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "are-we-there-yet": "~1.1.2",
                     "console-control-strings": "~1.1.0",
@@ -6285,42 +6456,48 @@
                 },
                 "number-is-nan": {
                   "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "once": {
                   "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "wrappy": "1"
                   }
                 },
                 "os-homedir": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "osenv": {
                   "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+                  "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "os-homedir": "^1.0.0",
                     "os-tmpdir": "^1.0.0"
@@ -6328,21 +6505,24 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                  "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "rc": {
                   "version": "1.2.8",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+                  "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "deep-extend": "^0.6.0",
                     "ini": "~1.3.0",
@@ -6352,17 +6532,19 @@
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                       "bundled": true,
-                      "dev": true,
-                      "optional": true
+                      "extraneous": true
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "2.3.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.3",
@@ -6375,89 +6557,101 @@
                 },
                 "rimraf": {
                   "version": "2.6.3",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                  "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "glob": "^7.1.3"
                   }
                 },
                 "safe-buffer": {
                   "version": "5.1.2",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+                  "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "sax": {
                   "version": "1.2.4",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+                  "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "semver": {
                   "version": "5.7.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                  "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "bundled": true,
+                  "extraneous": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
                 },
                 "string-width": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
                     "strip-ansi": "^3.0.0"
                   }
                 },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                },
                 "strip-ansi": {
                   "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
                 },
                 "strip-json-comments": {
                   "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "tar": {
                   "version": "4.4.8",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+                  "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "chownr": "^1.1.1",
                     "fs-minipass": "^1.2.5",
@@ -6470,30 +6664,34 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+                  "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true,
+                  "extraneous": true,
                   "requires": {
                     "string-width": "^1.0.2 || 2"
                   }
                 },
                 "wrappy": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 },
                 "yallist": {
                   "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                  "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                   "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "extraneous": true
                 }
               }
             },
@@ -8313,6 +8511,14 @@
         "lodash": "^4.17.10"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8321,14 +8527,6 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -8686,6 +8884,12 @@
         "tsutils": "^2.29.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "big-integer": "1.6.36",
     "browser-hrtime": "^1.1.8",
     "chalk": "2.4.1",
-    "commander": "2.18.0",
+    "commander": "7.0.0",
     "core-js": "2.6.2",
     "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
     "electron-log": "4.3.0",

--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -174,7 +174,7 @@ export abstract class ApiService {
     deleteFolder: (id: string) => Promise<any>;
 
     getSend: (id: string) => Promise<SendResponse>;
-    postSendAccess: (id: string, request: SendAccessRequest) => Promise<SendAccessResponse>;
+    postSendAccess: (id: string, request: SendAccessRequest, apiUrl?: string) => Promise<SendAccessResponse>;
     getSends: () => Promise<ListResponse<SendResponse>>;
     postSend: (request: SendRequest) => Promise<SendResponse>;
     postSendFile: (data: FormData) => Promise<SendResponse>;

--- a/src/abstractions/send.service.ts
+++ b/src/abstractions/send.service.ts
@@ -9,7 +9,7 @@ export abstract class SendService {
     decryptedSendCache: SendView[];
 
     clearCache: () => void;
-    encrypt: (model: SendView, file: File, password: string, key?: SymmetricCryptoKey) => Promise<[Send, ArrayBuffer]>;
+    encrypt: (model: SendView, file: File | ArrayBuffer, password: string, key?: SymmetricCryptoKey) => Promise<[Send, ArrayBuffer]>;
     get: (id: string) => Promise<Send>;
     getAll: () => Promise<Send[]>;
     getAllDecrypted: () => Promise<SendView[]>;

--- a/src/cli/commands/update.command.ts
+++ b/src/cli/commands/update.command.ts
@@ -15,7 +15,7 @@ export class UpdateCommand {
         this.inPkg = !!(process as any).pkg;
     }
 
-    async run(cmd: program.Command): Promise<Response> {
+    async run(): Promise<Response> {
         const currentVersion = this.platformUtilsService.getApplicationVersion();
 
         const response = await fetch.default('https://api.github.com/repos/bitwarden/' +

--- a/src/misc/nodeUtils.ts
+++ b/src/misc/nodeUtils.ts
@@ -26,4 +26,9 @@ export class NodeUtils {
                 .on('error', (err) => reject(err));
         });
     }
+
+    // https://stackoverflow.com/a/31394257
+    static bufferToArrayBuffer(buf: Buffer): ArrayBuffer {
+        return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    }
 }

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -273,6 +273,14 @@ export class Utils {
         return str == null || typeof str !== 'string' || str.trim() === '';
     }
 
+    static nameOf<T>(name: string & keyof T) {
+        return name;
+    }
+
+    static assign<T>(target: T, source: Partial<T>): T {
+        return Object.assign(target, source);
+    }
+
     private static validIpAddress(ipString: string): boolean {
         // tslint:disable-next-line
         const ipRegex = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -127,6 +127,7 @@ import {
 } from '../models/response/twoFactorU2fResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
+import { Utils } from '../misc/utils';
 
 export class ApiService implements ApiServiceAbstraction {
     urlsSet: boolean = false;
@@ -410,8 +411,8 @@ export class ApiService implements ApiServiceAbstraction {
         return new SendResponse(r);
     }
 
-    async postSendAccess(id: string, request: SendAccessRequest): Promise<SendAccessResponse> {
-        const r = await this.send('POST', '/sends/access/' + id, request, false, true);
+    async postSendAccess(id: string, request: SendAccessRequest, apiUrl?: string): Promise<SendAccessResponse> {
+        const r = await this.send('POST', '/sends/access/' + id, request, false, true, apiUrl);
         return new SendAccessResponse(r);
     }
 
@@ -1210,7 +1211,8 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     private async send(method: 'GET' | 'POST' | 'PUT' | 'DELETE', path: string, body: any,
-        authed: boolean, hasResponse: boolean): Promise<any> {
+        authed: boolean, hasResponse: boolean, apiUrl?: string): Promise<any> {
+        apiUrl = Utils.isNullOrWhitespace(apiUrl) ? this.apiBaseUrl : apiUrl;
         const headers = new Headers({
             'Device-Type': this.deviceType,
         });
@@ -1246,7 +1248,7 @@ export class ApiService implements ApiServiceAbstraction {
         }
 
         requestInit.headers = headers;
-        const response = await this.fetch(new Request(this.apiBaseUrl + path, requestInit));
+        const response = await this.fetch(new Request(apiUrl + path, requestInit));
 
         if (hasResponse && response.status === 200) {
             const responseJson = await response.json();

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -73,6 +73,7 @@ import { VerifyBankRequest } from '../models/request/verifyBankRequest';
 import { VerifyDeleteRecoverRequest } from '../models/request/verifyDeleteRecoverRequest';
 import { VerifyEmailRequest } from '../models/request/verifyEmailRequest';
 
+import { Utils } from '../misc/utils';
 import { ApiKeyResponse } from '../models/response/apiKeyResponse';
 import { BillingResponse } from '../models/response/billingResponse';
 import { BreachAccountResponse } from '../models/response/breachAccountResponse';
@@ -127,7 +128,6 @@ import {
 } from '../models/response/twoFactorU2fResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
-import { Utils } from '../misc/utils';
 
 export class ApiService implements ApiServiceAbstraction {
     urlsSet: boolean = false;

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -169,7 +169,7 @@ export class SearchService implements SearchServiceAbstraction {
             if (s.name != null && s.name.toLowerCase().indexOf(query) > -1) {
                 return true;
             }
-            if (query.length >= 8 && (s.id.startsWith(query) || (s.file?.id != null && s.file.id.startsWith(query)))) {
+            if (query.length >= 8 && (s.id.startsWith(query) || s.accessId.toLocaleLowerCase().startsWith(query) || (s.file?.id != null && s.file.id.startsWith(query)))) {
                 return true;
             }
             if (s.notes != null && s.notes.toLowerCase().indexOf(query) > -1) {

--- a/src/services/send.service.ts
+++ b/src/services/send.service.ts
@@ -126,7 +126,7 @@ export class SendService implements SendServiceAbstraction {
         return this.decryptedSendCache;
     }
 
-    async saveWithServer(sendData: [Send, ArrayBuffer | string]): Promise<any> {
+    async saveWithServer(sendData: [Send, ArrayBuffer]): Promise<any> {
         const request = new SendRequest(sendData[0]);
         let response: SendResponse;
         if (sendData[0].id == null) {


### PR DESCRIPTION
# Overview

These are changes related to Send in CLI (PR incoming). 

# Files Changed

* **api.service.ts**: CLI needs to be able to access api's other than those configured for it, so ApiService's PostSendAccess accepts an outside url.
* **send.service.ts**: CLI does not have a file object, so instead sends in an ArrayBuffer directly as the contents of any files uploaded.
* **login.command.ts/update.command.ts**: A result of upgrading CLI to commander 7.0.0, options are no longer on a command object, but an OptionsValues object. This is just a refactor and shouldn't have any impact.
* **Utils.ts**: These helpers allow for compile-time errors in case of property renames. It emulates what you get from c#'s `nameof(property)`. The assign helper limits possible assignments to overriding values already on the given object template, which is a very common use.
* **search.service.ts**: Add the ability to find sends by access id
* **nodeUtils.ts**: helper to conver Node Buffer to javascript BufferArray

# Testing Considerations

Testing will largely be handled in CLI PR, but It will be prudent to run basic testing on web vault Sends to ensure these are all benign changes there.