### PR TITLE
Enable subpixel antialiasing

### DIFF
--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -114,6 +114,7 @@ export class WindowMain {
             icon: process.platform === 'linux' ? path.join(__dirname, '/images/icon.png') : undefined,
             titleBarStyle: this.hideTitleBar && process.platform === 'darwin' ? 'hiddenInset' : undefined,
             show: false,
+            backgroundColor: '#fff',
             alwaysOnTop: this.enableAlwaysOnTop,
             webPreferences: {
                 nodeIntegration: true,


### PR DESCRIPTION
Enables subpixel font antialiasing by explicitly setting Electron background color.

https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do