### PR TITLE
Implement disable send policy

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -8,6 +8,8 @@ import {
 } from '@angular/core';
 
 import { SendType } from '../../../enums/sendType';
+import { PolicyType } from '../../../enums/policyType';
+import { OrganizationUserStatusType } from '../../../enums/organizationUserStatusType';
 
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
@@ -15,6 +17,7 @@ import { MessagingService } from '../../../abstractions/messaging.service';
 import { PlatformUtilsService } from '../../../abstractions/platformUtils.service';
 import { SendService } from '../../../abstractions/send.service';
 import { UserService } from '../../../abstractions/user.service';
+import { PolicyService } from '../../../abstractions/policy.service';
 
 import { SendFileView } from '../../../models/view/sendFileView';
 import { SendTextView } from '../../../models/view/sendTextView';
@@ -30,6 +33,7 @@ export class AddEditComponent implements OnInit {
     @Output() onDeletedSend = new EventEmitter<SendView>();
     @Output() onCancelled = new EventEmitter<SendView>();
 
+    disableSend = false;
     editMode: boolean = false;
     send: SendView;
     link: string;
@@ -52,7 +56,7 @@ export class AddEditComponent implements OnInit {
     constructor(protected i18nService: I18nService, protected platformUtilsService: PlatformUtilsService,
         protected environmentService: EnvironmentService, protected datePipe: DatePipe,
         protected sendService: SendService, protected userService: UserService,
-        protected messagingService: MessagingService) {
+        protected messagingService: MessagingService, protected policyService: PolicyService) {
         this.typeOptions = [
             { name: i18nService.t('sendTypeFile'), value: SendType.File },
             { name: i18nService.t('sendTypeText'), value: SendType.Text },
@@ -83,6 +87,16 @@ export class AddEditComponent implements OnInit {
         } else {
             this.title = this.i18nService.t('createSend');
         }
+
+        const policies = await this.policyService.getAll(PolicyType.DisableSend);
+        const organizations = await this.userService.getAllOrganizations();
+        this.disableSend = organizations.some(o => {
+            return o.enabled &&
+                o.status == OrganizationUserStatusType.Confirmed &&
+                o.usePolicies &&
+                !o.canManagePolicies &&
+                policies.some(p => p.organizationId == o.id && p.enabled);
+        });
 
         this.canAccessPremium = await this.userService.canAccessPremium();
         if (!this.canAccessPremium) {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -133,6 +133,12 @@ export class AddEditComponent implements OnInit {
     }
 
     async submit(): Promise<boolean> {
+        if (this.disableSend) {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                this.i18nService.t('sendDisabledWarning'));
+            return false;
+        }
+
         if (this.send.name == null || this.send.name === '') {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('nameRequired'));

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -7,17 +7,17 @@ import {
     Output,
 } from '@angular/core';
 
-import { SendType } from '../../../enums/sendType';
-import { PolicyType } from '../../../enums/policyType';
 import { OrganizationUserStatusType } from '../../../enums/organizationUserStatusType';
+import { PolicyType } from '../../../enums/policyType';
+import { SendType } from '../../../enums/sendType';
 
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
 import { MessagingService } from '../../../abstractions/messaging.service';
 import { PlatformUtilsService } from '../../../abstractions/platformUtils.service';
+import { PolicyService } from '../../../abstractions/policy.service';
 import { SendService } from '../../../abstractions/send.service';
 import { UserService } from '../../../abstractions/user.service';
-import { PolicyService } from '../../../abstractions/policy.service';
 
 import { SendFileView } from '../../../models/view/sendFileView';
 import { SendTextView } from '../../../models/view/sendTextView';
@@ -92,10 +92,10 @@ export class AddEditComponent implements OnInit {
         const organizations = await this.userService.getAllOrganizations();
         this.disableSend = organizations.some(o => {
             return o.enabled &&
-                o.status == OrganizationUserStatusType.Confirmed &&
+                o.status === OrganizationUserStatusType.Confirmed &&
                 o.usePolicies &&
                 !o.canManagePolicies &&
-                policies.some(p => p.organizationId == o.id && p.enabled);
+                policies.some(p => p.organizationId === o.id && p.enabled);
         });
 
         this.canAccessPremium = await this.userService.canAccessPremium();

--- a/src/angular/components/send/send.component.ts
+++ b/src/angular/components/send/send.component.ts
@@ -3,18 +3,18 @@ import {
     OnInit,
 } from '@angular/core';
 
-import { SendType } from '../../../enums/sendType';
-import { PolicyType } from '../../../enums/policyType';
 import { OrganizationUserStatusType } from '../../../enums/organizationUserStatusType';
+import { PolicyType } from '../../../enums/policyType';
+import { SendType } from '../../../enums/sendType';
 
 import { SendView } from '../../../models/view/sendView';
 
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
 import { PlatformUtilsService } from '../../../abstractions/platformUtils.service';
+import { PolicyService } from '../../../abstractions/policy.service';
 import { SearchService } from '../../../abstractions/search.service';
 import { SendService } from '../../../abstractions/send.service';
-import { PolicyService } from '../../../abstractions/policy.service';
 import { UserService } from '../../../abstractions/user.service';
 
 import { BroadcasterService } from '../../../angular/services/broadcaster.service';
@@ -56,10 +56,10 @@ export class SendComponent implements OnInit {
         const organizations = await this.userService.getAllOrganizations();
         this.disableSend = organizations.some(o => {
             return o.enabled &&
-                o.status == OrganizationUserStatusType.Confirmed &&
+                o.status === OrganizationUserStatusType.Confirmed &&
                 o.usePolicies &&
                 !o.canManagePolicies &&
-                policies.some(p => p.organizationId == o.id && p.enabled);
+                policies.some(p => p.organizationId === o.id && p.enabled);
         });
 
         this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {

--- a/src/enums/policyType.ts
+++ b/src/enums/policyType.ts
@@ -5,4 +5,5 @@ export enum PolicyType {
     SingleOrg = 3, // Allows users to only be apart of one organization
     RequireSso = 4, // Requires users to authenticate with SSO
     PersonalOwnership = 5, // Disables personal vault ownership for adding/cloning items
+    DisableSend = 6, // Disables the ability to create and edit Bitwarden Sends
 }


### PR DESCRIPTION
# Overview

Add disable send logic to Send components and define `DisableSend` policy type.

This policy will be used by organizations to disable organization users from creating or editing Bitwarden Sends. Delete is still allowed.

# Files Changed

* **add-edit.component.ts/send.component.ts**: If any policy on any organization the user belongs to is enabled and that user cannot manage policies on that organization, send is disabled.
* **policyType.ts**: Add enum number for DisableSend policy

# Testing concerns

Logic for the disable will be tested in the first client to implement this policy, which will be web.