### PR TITLE
Remove unused logout argument

### DIFF
--- a/src/cli/commands/logout.command.ts
+++ b/src/cli/commands/logout.command.ts
@@ -10,7 +10,7 @@ export class LogoutCommand {
     constructor(private authService: AuthService, private i18nService: I18nService,
         private logoutCallback: () => Promise<void>) { }
 
-    async run(cmd: program.Command) {
+    async run() {
         await this.logoutCallback();
         this.authService.logOut(() => { /* Do nothing */ });
         const res = new MessageResponse('You have logged out.', null);


### PR DESCRIPTION
# Overview

Removing unused CLI command run parameter

# File Changed
* **logout.command**: This command was missed during the Send CLI jslib updates. This parameter is unused and should be removed.