### PR TITLE
Do not evaluate callback function when testing existence

### DIFF
--- a/src/angular/components/send/send.component.ts
+++ b/src/angular/components/send/send.component.ts
@@ -169,12 +169,12 @@ export class SendComponent implements OnInit {
             this.actionPromise = this.sendService.deleteWithServer(s.id);
             await this.actionPromise;
 
-            if (this.onSuccessfulDelete() != null) {
+            if (this.onSuccessfulDelete != null) {
                 this.onSuccessfulDelete();
             } else {
                 // Default actions
                 this.platformUtilsService.showToast('success', null, this.i18nService.t('deletedSend'));
-                await this.load();
+                await this.refresh();
             }
         } catch { }
         this.actionPromise = null;


### PR DESCRIPTION
# Overview

Lately we've had failures updating the Send list on delete. This PR fixes those issues.

# Files Changed

* **send.component**: The actual fix is removing the parenthesis. `load` => `refresh` is to match cipher.service behavior, but is not part of the fix