### PR TITLE
Move LogService to static singleton

### DIFF
--- a/spec/common/services/consoleLog.service.spec.ts
+++ b/spec/common/services/consoleLog.service.spec.ts
@@ -58,18 +58,18 @@ describe('ConsoleLogService', () => {
 
     it('writes debug/info messages to console.log', () => {
         logService.debug('this is a debug message');
-        expect(caughtMessage).toEqual({ log: jasmine.arrayWithExactContents(['this is a debug message']) });
+        expect(caughtMessage).toEqual({ log: jasmine.arrayWithExactContents(['this is a debug message', []]) });
 
         logService.info('this is an info message');
-        expect(caughtMessage).toEqual({ log: jasmine.arrayWithExactContents(['this is an info message']) });
+        expect(caughtMessage).toEqual({ log: jasmine.arrayWithExactContents(['this is an info message', []]) });
     });
     it('writes warning messages to console.warn', () => {
         logService.warning('this is a warning message');
-        expect(caughtMessage).toEqual({ warn: jasmine.arrayWithExactContents(['this is a warning message']) });
+        expect(caughtMessage).toEqual({ warn: jasmine.arrayWithExactContents(['this is a warning message', []]) });
     });
     it('writes error messages to console.error', () => {
         logService.error('this is an error message');
-        expect(caughtMessage).toEqual({ error: jasmine.arrayWithExactContents(['this is an error message']) });
+        expect(caughtMessage).toEqual({ error: jasmine.arrayWithExactContents(['this is an error message', []]) });
     });
 
     it('times with output to info', async () => {
@@ -81,8 +81,9 @@ describe('ConsoleLogService', () => {
         expect(duration[1]).toBeLessThan(500 * 10e6);
 
         expect(caughtMessage).toEqual(jasmine.arrayContaining([]));
-        expect(caughtMessage.log.length).toBe(1);
+        expect(caughtMessage.log.length).toBe(2);
         expect(caughtMessage.log[0]).toEqual(jasmine.stringMatching(/^default: \d+\.?\d*ms$/));
+        expect(caughtMessage.log[1]).toEqual([]);
     });
 
     it('filters time output', async () => {

--- a/spec/node/cli/consoleLog.service.spec.ts
+++ b/spec/node/cli/consoleLog.service.spec.ts
@@ -32,9 +32,9 @@ describe('CLI Console log service', () => {
         logService.error('error');
 
         expect(caughtMessage).toEqual({
-            log: jasmine.arrayWithExactContents(['info']),
-            warn: jasmine.arrayWithExactContents(['warning']),
-            error: jasmine.arrayWithExactContents(['error']),
+            log: jasmine.arrayWithExactContents(['info', []]),
+            warn: jasmine.arrayWithExactContents(['warning', []]),
+            error: jasmine.arrayWithExactContents(['error', []]),
         });
 
     });

--- a/src/abstractions/log.service.ts
+++ b/src/abstractions/log.service.ts
@@ -4,7 +4,7 @@ import { ConsoleLogService } from '../services/consoleLog.service';
 export abstract class LogService {
 
     private static get instance() {
-        if (this._instance) {
+        if (this._instance == null) {
             this._instance = new ConsoleLogService(false);
         }
         return this._instance;

--- a/src/abstractions/log.service.ts
+++ b/src/abstractions/log.service.ts
@@ -1,11 +1,49 @@
 import { LogLevelType } from '../enums/logLevelType';
+import { ConsoleLogService } from '../services/consoleLog.service';
 
 export abstract class LogService {
-    debug: (message: string) => void;
-    info: (message: string) => void;
-    warning: (message: string) => void;
-    error: (message: string) => void;
-    write: (level: LogLevelType, message: string) => void;
+
+    private static get instance() {
+        if (this._instance) {
+            this._instance = new ConsoleLogService(false);
+        }
+        return this._instance;
+    }
+
+    static set(logService: LogService) {
+        this._instance = logService;
+    }
+
+    static debug(message?: any, ...optionalParams: any[]) {
+        this.instance.debug(message, optionalParams);
+    }
+
+    static info(message?: any, ...optionalParams: any[]) {
+        this.instance.info(message, optionalParams);
+    }
+
+    static warning(message?: any, ...optionalParams: any[]) {
+        this.instance.warning(message, optionalParams);
+    }
+
+    static error(message?: any, ...optionalParams: any[]) {
+        this.instance.error(message, optionalParams);
+    }
+
+    static time(label: string) {
+        this.instance.time(label);
+    }
+
+    static timeEnd(label: string) {
+        return this.instance.timeEnd(label);
+    }
+    private static _instance: LogService = null;
+
+    debug: (message?: any, ...optionalParams: any[]) => void;
+    info: (message?: any, ...optionalParams: any[]) => void;
+    warning: (message?: any, ...optionalParams: any[]) => void;
+    error: (message?: any, ...optionalParams: any[]) => void;
+    write: (level: LogLevelType, message?: any, ...optionalParams: any[]) => void;
     time: (label: string) => void;
     timeEnd: (label: string) => [number, number];
 }

--- a/src/angular/components/add-edit.component.ts
+++ b/src/angular/components/add-edit.component.ts
@@ -24,6 +24,7 @@ import { CollectionService } from '../../abstractions/collection.service';
 import { EventService } from '../../abstractions/event.service';
 import { FolderService } from '../../abstractions/folder.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { MessagingService } from '../../abstractions/messaging.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { PolicyService } from '../../abstractions/policy.service';
@@ -292,7 +293,9 @@ export class AddEditComponent implements OnInit {
             this.onSavedCipher.emit(this.cipher);
             this.messagingService.send(this.editMode && !this.cloneMode ? 'editedCipher' : 'addedCipher');
             return true;
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return false;
     }
@@ -374,7 +377,9 @@ export class AddEditComponent implements OnInit {
                 this.i18nService.t(this.cipher.isDeleted ? 'permanentlyDeletedItem' : 'deletedItem'));
             this.onDeletedCipher.emit(this.cipher);
             this.messagingService.send(this.cipher.isDeleted ? 'permanentlyDeletedCipher' : 'deletedCipher');
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return true;
     }
@@ -398,7 +403,9 @@ export class AddEditComponent implements OnInit {
             this.platformUtilsService.showToast('success', null, this.i18nService.t('restoredItem'));
             this.onRestoredCipher.emit(this.cipher);
             this.messagingService.send('restoredCipher');
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return true;
     }

--- a/src/angular/components/attachments.component.ts
+++ b/src/angular/components/attachments.component.ts
@@ -9,6 +9,7 @@ import {
 import { CipherService } from '../../abstractions/cipher.service';
 import { CryptoService } from '../../abstractions/crypto.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { UserService } from '../../abstractions/user.service';
 
@@ -68,7 +69,9 @@ export class AttachmentsComponent implements OnInit {
             this.platformUtilsService.eventTrack('Added Attachment');
             this.platformUtilsService.showToast('success', null, this.i18nService.t('attachmentSaved'));
             this.onUploadedAttachment.emit();
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         // reset file input
         // ref: https://stackoverflow.com/a/20552042
@@ -98,7 +101,9 @@ export class AttachmentsComponent implements OnInit {
             if (i > -1) {
                 this.cipher.attachments.splice(i, 1);
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         this.deletePromises[attachment.id] = null;
         this.onDeletedAttachment.emit();
@@ -210,7 +215,9 @@ export class AttachmentsComponent implements OnInit {
                 a.downloading = false;
             });
             await this.reuploadPromises[attachment.id];
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     protected loadCipher() {

--- a/src/angular/components/collections.component.ts
+++ b/src/angular/components/collections.component.ts
@@ -9,6 +9,7 @@ import {
 import { CipherService } from '../../abstractions/cipher.service';
 import { CollectionService } from '../../abstractions/collection.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 
 import { CipherView } from '../../models/view/cipherView';
@@ -66,7 +67,9 @@ export class CollectionsComponent implements OnInit {
             this.onSavedCollections.emit();
             this.platformUtilsService.eventTrack('Edited Cipher Collections');
             this.platformUtilsService.showToast('success', null, this.i18nService.t('editedItem'));
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     protected loadCipher() {

--- a/src/angular/components/export.component.ts
+++ b/src/angular/components/export.component.ts
@@ -8,6 +8,7 @@ import { CryptoService } from '../../abstractions/crypto.service';
 import { EventService } from '../../abstractions/event.service';
 import { ExportService } from '../../abstractions/export.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { EventType } from '../../enums/eventType';
 
@@ -54,7 +55,9 @@ export class ExportComponent {
                 this.downloadFile(data);
                 this.saved();
                 await this.collectEvent();
-            } catch { }
+            } catch (e) {
+                LogService.error(e);
+            }
         } else {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('invalidMasterPassword'));

--- a/src/angular/components/folder-add-edit.component.ts
+++ b/src/angular/components/folder-add-edit.component.ts
@@ -8,6 +8,7 @@ import {
 
 import { FolderService } from '../../abstractions/folder.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 
 import { FolderView } from '../../models/view/folderView';
@@ -47,7 +48,9 @@ export class FolderAddEditComponent implements OnInit {
                 this.i18nService.t(this.editMode ? 'editedFolder' : 'addedFolder'));
             this.onSavedFolder.emit(this.folder);
             return true;
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return false;
     }
@@ -66,7 +69,9 @@ export class FolderAddEditComponent implements OnInit {
             this.platformUtilsService.eventTrack('Deleted Folder');
             this.platformUtilsService.showToast('success', null, this.i18nService.t('deletedFolder'));
             this.onDeletedFolder.emit(this.folder);
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return true;
     }

--- a/src/angular/components/hint.component.ts
+++ b/src/angular/components/hint.component.ts
@@ -4,6 +4,7 @@ import { PasswordHintRequest } from '../../models/request/passwordHintRequest';
 
 import { ApiService } from '../../abstractions/api.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 
 export class HintComponent {
@@ -38,6 +39,8 @@ export class HintComponent {
             } else if (this.router != null) {
                 this.router.navigate([this.successRoute]);
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 }

--- a/src/angular/components/icon.component.ts
+++ b/src/angular/components/icon.component.ts
@@ -9,6 +9,7 @@ import { CipherType } from '../../enums/cipherType';
 import { CipherView } from '../../models/view/cipherView';
 
 import { EnvironmentService } from '../../abstractions/environment.service';
+import { LogService } from '../../abstractions/log.service';
 import { StateService } from '../../abstractions/state.service';
 
 import { ConstantsService } from '../../services/constants.service';
@@ -99,7 +100,9 @@ export class IconComponent implements OnChanges {
                 try {
                     this.image = this.iconsUrl + '/' + Utils.getHostname(hostnameUri) + '/icon.png';
                     this.fallbackImage = 'images/fa-globe.png';
-                } catch (e) { }
+                } catch (e) {
+                    LogService.error(e);
+                }
             }
         } else {
             this.image = null;

--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -5,6 +5,7 @@ import { ApiService } from '../../abstractions/api.service';
 import { CryptoService } from '../../abstractions/crypto.service';
 import { EnvironmentService } from '../../abstractions/environment.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { MessagingService } from '../../abstractions/messaging.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { StateService } from '../../abstractions/state.service';
@@ -93,7 +94,8 @@ export class LockComponent implements OnInit {
                     failed = false;
                     await this.setKeyAndContinue(key);
                 }
-            } catch {
+            } catch (e) {
+                LogService.error(e);
                 failed = true;
             }
 
@@ -124,7 +126,9 @@ export class LockComponent implements OnInit {
                         await this.formPromise;
                         passwordValid = true;
                         await this.cryptoService.setKeyHash(keyHash);
-                    } catch { }
+                    } catch (e) {
+                        LogService.error(e);
+                    }
                 }
             }
 

--- a/src/angular/components/login.component.ts
+++ b/src/angular/components/login.component.ts
@@ -12,6 +12,7 @@ import { AuthService } from '../../abstractions/auth.service';
 import { CryptoFunctionService } from '../../abstractions/cryptoFunction.service';
 import { EnvironmentService } from '../../abstractions/environment.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { StateService } from '../../abstractions/state.service';
@@ -109,7 +110,9 @@ export class LoginComponent implements OnInit {
                     this.router.navigate([this.successRoute]);
                 }
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     togglePassword() {

--- a/src/angular/components/premium.component.ts
+++ b/src/angular/components/premium.component.ts
@@ -2,6 +2,7 @@ import { OnInit } from '@angular/core';
 
 import { ApiService } from '../../abstractions/api.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { TokenService } from '../../abstractions/token.service';
 
@@ -23,7 +24,9 @@ export class PremiumComponent implements OnInit {
             await this.refreshPromise;
             this.platformUtilsService.showToast('success', null, this.i18nService.t('refreshComplete'));
             this.isPremium = this.tokenService.getPremium();
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     async purchase() {

--- a/src/angular/components/register.component.ts
+++ b/src/angular/components/register.component.ts
@@ -8,6 +8,7 @@ import { ApiService } from '../../abstractions/api.service';
 import { AuthService } from '../../abstractions/auth.service';
 import { CryptoService } from '../../abstractions/crypto.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { StateService } from '../../abstractions/state.service';
@@ -141,7 +142,9 @@ export class RegisterComponent {
             this.platformUtilsService.eventTrack('Registered');
             this.platformUtilsService.showToast('success', null, this.i18nService.t('newAccountCreated'));
             this.router.navigate([this.successRoute], { queryParams: { email: this.email } });
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     togglePassword(confirmField: boolean) {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -13,6 +13,7 @@ import { SendType } from '../../../enums/sendType';
 
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
+import { LogService } from '../../../abstractions/log.service';
 import { MessagingService } from '../../../abstractions/messaging.service';
 import { PlatformUtilsService } from '../../../abstractions/platformUtils.service';
 import { PolicyService } from '../../../abstractions/policy.service';
@@ -201,7 +202,9 @@ export class AddEditComponent implements OnInit {
                 this.copyLinkToClipboard(this.link);
             }
             return true;
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return false;
     }
@@ -234,7 +237,9 @@ export class AddEditComponent implements OnInit {
             this.platformUtilsService.showToast('success', null, this.i18nService.t('deletedSend'));
             await this.load();
             this.onDeletedSend.emit(this.send);
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     typeChanged() {
@@ -254,12 +259,14 @@ export class AddEditComponent implements OnInit {
         // Parse dates
         try {
             sendData[0].deletionDate = this.deletionDate == null ? null : new Date(this.deletionDate);
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             sendData[0].deletionDate = null;
         }
         try {
             sendData[0].expirationDate = this.expirationDate == null ? null : new Date(this.expirationDate);
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             sendData[0].expirationDate = null;
         }
 

--- a/src/angular/components/send/send.component.ts
+++ b/src/angular/components/send/send.component.ts
@@ -11,6 +11,7 @@ import { SendView } from '../../../models/view/sendView';
 
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
+import { LogService } from '../../../abstractions/log.service';
 import { PlatformUtilsService } from '../../../abstractions/platformUtils.service';
 import { PolicyService } from '../../../abstractions/policy.service';
 import { SearchService } from '../../../abstractions/search.service';
@@ -154,7 +155,9 @@ export class SendComponent implements OnInit {
                 this.platformUtilsService.showToast('success', null, this.i18nService.t('removedPassword'));
                 await this.load();
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
         this.actionPromise = null;
     }
 
@@ -181,7 +184,9 @@ export class SendComponent implements OnInit {
                 this.platformUtilsService.showToast('success', null, this.i18nService.t('deletedSend'));
                 await this.refresh();
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
         this.actionPromise = null;
         return true;
     }

--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -6,6 +6,7 @@ import {
 import { ApiService } from '../../abstractions/api.service';
 import { CryptoService } from '../../abstractions/crypto.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { MessagingService } from '../../abstractions/messaging.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
@@ -93,7 +94,8 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
             } else {
                 this.router.navigate([this.successRoute]);
             }
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             this.platformUtilsService.showToast('error', null, this.i18nService.t('errorOccurred'));
         }
     }

--- a/src/angular/components/share.component.ts
+++ b/src/angular/components/share.component.ts
@@ -11,6 +11,7 @@ import { OrganizationUserStatusType } from '../../enums/organizationUserStatusTy
 import { CipherService } from '../../abstractions/cipher.service';
 import { CollectionService } from '../../abstractions/collection.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { UserService } from '../../abstractions/user.service';
 
@@ -87,7 +88,9 @@ export class ShareComponent implements OnInit {
                 });
             await this.formPromise;
             return true;
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
         return false;
     }
 

--- a/src/angular/components/sso.component.ts
+++ b/src/angular/components/sso.component.ts
@@ -7,6 +7,7 @@ import { ApiService } from '../../abstractions/api.service';
 import { AuthService } from '../../abstractions/auth.service';
 import { CryptoFunctionService } from '../../abstractions/cryptoFunction.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { StateService } from '../../abstractions/state.service';
@@ -173,7 +174,9 @@ export class SsoComponent {
                     this.router.navigate([this.successRoute]);
                 }
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
         this.loggingIn = false;
     }
 

--- a/src/angular/components/two-factor.component.ts
+++ b/src/angular/components/two-factor.component.ts
@@ -18,6 +18,7 @@ import { ApiService } from '../../abstractions/api.service';
 import { AuthService } from '../../abstractions/auth.service';
 import { EnvironmentService } from '../../abstractions/environment.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { StateService } from '../../abstractions/state.service';
 import { StorageService } from '../../abstractions/storage.service';
@@ -209,7 +210,8 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
                     },
                 });
             }
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             if (this.selectedProviderType === TwoFactorProviderType.U2f && this.u2f != null) {
                 this.u2f.start();
             }
@@ -233,7 +235,9 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
                 this.platformUtilsService.showToast('success', null,
                     this.i18nService.t('verificationCodeEmailSent', this.twoFactorEmail));
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         this.emailPromise = null;
     }

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -18,6 +18,7 @@ import { CipherService } from '../../abstractions/cipher.service';
 import { CryptoService } from '../../abstractions/crypto.service';
 import { EventService } from '../../abstractions/event.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { TokenService } from '../../abstractions/token.service';
 import { TotpService } from '../../abstractions/totp.service';
@@ -133,7 +134,9 @@ export class ViewComponent implements OnDestroy, OnInit {
             this.platformUtilsService.showToast('success', null,
                 this.i18nService.t(this.cipher.isDeleted ? 'permanentlyDeletedItem' : 'deletedItem'));
             this.onDeletedCipher.emit(this.cipher);
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return true;
     }
@@ -155,7 +158,9 @@ export class ViewComponent implements OnDestroy, OnInit {
             this.platformUtilsService.eventTrack('Restored Cipher');
             this.platformUtilsService.showToast('success', null, this.i18nService.t('restoredItem'));
             this.onRestoredCipher.emit(this.cipher);
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return true;
     }

--- a/src/cli/commands/login.command.ts
+++ b/src/cli/commands/login.command.ts
@@ -12,6 +12,7 @@ import { AuthService } from '../../abstractions/auth.service';
 import { CryptoFunctionService } from '../../abstractions/cryptoFunction.service';
 import { EnvironmentService } from '../../abstractions/environment.service';
 import { I18nService } from '../../abstractions/i18n.service';
+import { LogService } from '../../abstractions/log.service';
 import { PasswordGenerationService } from '../../abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 
@@ -92,7 +93,8 @@ export class LoginCommand {
             const codeChallenge = Utils.fromBufferToUrlB64(codeVerifierHash);
             try {
                 ssoCode = await this.getSsoCode(codeChallenge, state);
-            } catch {
+            } catch (e) {
+                LogService.error(e);
                 return Response.badRequest('Something went wrong. Try again.');
             }
         } else {
@@ -293,7 +295,9 @@ export class LoginCommand {
                     });
                     foundPort = true;
                     break;
-                } catch { }
+                } catch (e) {
+                    LogService.error(e);
+                }
             }
             if (!foundPort) {
                 reject();

--- a/src/electron/biometric.darwin.main.ts
+++ b/src/electron/biometric.darwin.main.ts
@@ -1,8 +1,11 @@
-import { I18nService, StorageService } from '../abstractions';
-
 import { ipcMain, systemPreferences } from 'electron';
+
 import { BiometricMain } from '../abstractions/biometric.main';
-import { ConstantsService } from '../services';
+import { I18nService } from '../abstractions/i18n.service';
+import { LogService } from '../abstractions/log.service';
+import { StorageService } from '../abstractions/storage.service';
+
+import { ConstantsService } from '../services/constants.service';
 import { ElectronConstants } from './electronConstants';
 
 export default class BiometricDarwinMain implements BiometricMain {
@@ -27,7 +30,8 @@ export default class BiometricDarwinMain implements BiometricMain {
         try {
             await systemPreferences.promptTouchID(this.i18nservice.t('touchIdConsentMessage'));
             return true;
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             return false;
         }
     }

--- a/src/electron/biometric.windows.main.ts
+++ b/src/electron/biometric.windows.main.ts
@@ -6,7 +6,9 @@ import { WindowMain } from './window.main';
 
 import { BiometricMain } from '../abstractions/biometric.main';
 import { I18nService } from '../abstractions/i18n.service';
+import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
+
 import { ConstantsService } from '../services/constants.service';
 
 export default class BiometricWindowsMain implements BiometricMain {
@@ -21,7 +23,8 @@ export default class BiometricWindowsMain implements BiometricMain {
         let supportsBiometric = false;
         try {
             supportsBiometric = await this.supportsBiometric();
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             // store error state so we can let the user know on the settings page
             this.isError = true;
         }
@@ -56,7 +59,8 @@ export default class BiometricWindowsMain implements BiometricMain {
                 this.windowsSecurityCredentialsUiModule = require('@nodert-win10-rs4/windows.security.credentials.ui');
             }
             return this.windowsSecurityCredentialsUiModule;
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             this.isError = true;
         }
         return null;
@@ -73,7 +77,8 @@ export default class BiometricWindowsMain implements BiometricMain {
                         }
                         return resolve(result);
                     });
-                } catch {
+                } catch (e) {
+                    LogService.error(e);
                     this.isError = true;
                     return resolve(null);
                 }
@@ -113,7 +118,10 @@ export default class BiometricWindowsMain implements BiometricMain {
                     module.UserConsentVerifierAvailability.deviceBusy,
                 ];
             }
-        } catch { /*Ignore error*/ }
+        } catch (e) {
+            LogService.error(e);
+            /*Ignore error*/
+        }
         return [];
     }
 
@@ -125,7 +133,9 @@ export default class BiometricWindowsMain implements BiometricMain {
             const version = require('os').release();
             return Number.parseInt(version.split('.')[0], 10);
         }
-        catch { }
+        catch (e) {
+            LogService.error(e);
+        }
         return -1;
     }
 }

--- a/src/electron/keytarStorageListener.ts
+++ b/src/electron/keytarStorageListener.ts
@@ -6,6 +6,8 @@ import {
     setPassword,
 } from 'keytar';
 
+import { LogService } from '../abstractions/log.service';
+
 export class KeytarStorageListener {
     constructor(private serviceName: string) { }
 
@@ -24,7 +26,8 @@ export class KeytarStorageListener {
                 }
 
                 event.returnValue = val;
-            } catch {
+            } catch (e) {
+                LogService.error(e);
                 event.returnValue = null;
             }
         });

--- a/src/electron/window.main.ts
+++ b/src/electron/window.main.ts
@@ -6,6 +6,7 @@ import * as url from 'url';
 
 import { isDev, isMacAppStore, isSnapStore } from './utils';
 
+import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
 
 const WindowEventHandlingDelay = 100;
@@ -219,7 +220,9 @@ export class WindowMain {
             }
 
             await this.storageService.save(configKey, this.windowStates[configKey]);
-        } catch (e) { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     private async getWindowState(configKey: string, defaultWidth: number, defaultHeight: number) {

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -19,13 +19,8 @@ import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
 
-import { ConsoleLogService } from '../services/consoleLog.service';
-
 export abstract class BaseImporter {
     organizationId: string = null;
-
-    protected logService: LogService = new ConsoleLogService(false);
-
     protected newLineRegex = /(?:\r\n|\r|\n)/;
 
     protected passwordFieldNames = [
@@ -94,7 +89,7 @@ export abstract class BaseImporter {
             result.errors.forEach(e => {
                 if (e.row != null) {
                     // tslint:disable-next-line
-                    this.logService.warning('Error parsing row ' + e.row + ': ' + e.message);
+                    LogService.warning('Error parsing row ' + e.row + ': ' + e.message);
                 }
             });
         }

--- a/src/importers/passpackCsvImporter.ts
+++ b/src/importers/passpackCsvImporter.ts
@@ -1,6 +1,8 @@
 import { BaseImporter } from './baseImporter';
 import { Importer } from './importer';
 
+import { LogService } from '../abstractions';
+
 import { ImportResult } from '../models/domain/importResult';
 
 import { CollectionView } from '../models/view/collectionView';
@@ -21,7 +23,9 @@ export class PasspackCsvImporter extends BaseImporter implements Importer {
                     try {
                         const t = JSON.parse(tagJson);
                         return this.getValueOrDefault(t.tag);
-                    } catch { }
+                    } catch (e) {
+                        LogService.error(e);
+                    }
                     return null;
                 }).filter((t: string) => !this.isNullOrWhitespace(t)) : null;
 
@@ -72,7 +76,9 @@ export class PasspackCsvImporter extends BaseImporter implements Importer {
                 fieldsJson.extraFields.length > 0 ? fieldsJson.extraFields.map((fieldJson: string) => {
                     try {
                         return JSON.parse(fieldJson);
-                    } catch { }
+                    } catch (e) {
+                        LogService.error(e);
+                    }
                     return null;
                 }) : null;
             if (fields != null) {

--- a/src/importers/passwordBossJsonImporter.ts
+++ b/src/importers/passwordBossJsonImporter.ts
@@ -1,6 +1,8 @@
 import { BaseImporter } from './baseImporter';
 import { Importer } from './importer';
 
+import { LogService } from '../abstractions/log.service';
+
 import { ImportResult } from '../models/domain/importResult';
 
 import { CardView } from '../models/view/cardView';
@@ -84,7 +86,9 @@ export class PasswordBossJsonImporter extends BaseImporter implements Importer {
                             const expDate = new Date(val);
                             cipher.card.expYear = expDate.getFullYear().toString();
                             cipher.card.expMonth = (expDate.getMonth() + 1).toString();
-                        } catch { }
+                        } catch (e) {
+                            LogService.error(e);
+                        }
                         continue;
                     } else if (property === 'cardType') {
                         continue;

--- a/src/importers/rememBearCsvImporter.ts
+++ b/src/importers/rememBearCsvImporter.ts
@@ -1,6 +1,8 @@
 import { BaseImporter } from './baseImporter';
 import { Importer } from './importer';
 
+import { LogService } from '../abstractions/log.service';
+
 import { CipherType } from '../enums/cipherType';
 
 import { ImportResult } from '../models/domain/importResult';
@@ -43,7 +45,9 @@ export class RememBearCsvImporter extends BaseImporter implements Importer {
                             cipher.card.expMonth = expMonthNumber.toString();
                         }
                     }
-                } catch { }
+                } catch (e) {
+                    LogService.error(e);
+                }
                 try {
                     const expYear = this.getValueOrDefault(value.expiryYear);
                     if (expYear != null) {
@@ -52,7 +56,9 @@ export class RememBearCsvImporter extends BaseImporter implements Importer {
                             cipher.card.expYear = expYearNumber.toString();
                         }
                     }
-                } catch { }
+                } catch (e) {
+                    LogService.error(e);
+                }
 
                 const pin = this.getValueOrDefault(value.pin);
                 if (pin != null) {

--- a/src/importers/truekeyCsvImporter.ts
+++ b/src/importers/truekeyCsvImporter.ts
@@ -1,6 +1,8 @@
 import { BaseImporter } from './baseImporter';
 import { Importer } from './importer';
 
+import { LogService } from '../abstractions/log.service';
+
 import { ImportResult } from '../models/domain/importResult';
 
 import { CardView } from '../models/view/cardView';
@@ -47,7 +49,9 @@ export class TrueKeyCsvImporter extends BaseImporter implements Importer {
                         const expDate = new Date(value.expiryDate);
                         cipher.card.expYear = expDate.getFullYear().toString();
                         cipher.card.expMonth = (expDate.getMonth() + 1).toString();
-                    } catch { }
+                    } catch (e) {
+                        LogService.error(e);
+                    }
                 }
             } else if (value.kind !== 'login') {
                 cipher.type = CipherType.SecureNote;

--- a/src/misc/utils.ts
+++ b/src/misc/utils.ts
@@ -1,5 +1,7 @@
 import * as tldjs from 'tldjs';
 
+import { LogService } from '../abstractions/log.service';
+
 import { I18nService } from '../abstractions/i18n.service';
 
 // tslint:disable-next-line
@@ -176,7 +178,8 @@ export class Utils {
         const url = Utils.getUrl(uriString);
         try {
             return url != null && url.hostname !== '' ? url.hostname : null;
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             return null;
         }
     }
@@ -185,7 +188,8 @@ export class Utils {
         const url = Utils.getUrl(uriString);
         try {
             return url != null && url.host !== '' ? url.host : null;
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             return null;
         }
     }
@@ -219,7 +223,9 @@ export class Utils {
 
                 const urlDomain = tldjs != null && tldjs.getDomain != null ? tldjs.getDomain(url.hostname) : null;
                 return urlDomain != null ? urlDomain : url.hostname;
-            } catch (e) { }
+            } catch (e) {
+                LogService.error(e);
+            }
         }
 
         try {
@@ -228,7 +234,8 @@ export class Utils {
             if (domain != null) {
                 return domain;
             }
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             return null;
         }
 
@@ -339,7 +346,9 @@ export class Utils {
                 anchor.href = uriString;
                 return anchor as any;
             }
-        } catch (e) { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         return null;
     }

--- a/src/models/domain/attachment.ts
+++ b/src/models/domain/attachment.ts
@@ -7,6 +7,7 @@ import Domain from './domainBase';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 import { CryptoService } from '../../abstractions/crypto.service';
+import { LogService } from '../../abstractions/log.service';
 
 import { Utils } from '../../misc/utils';
 
@@ -53,6 +54,7 @@ export class Attachment extends Domain {
                 const decValue = await cryptoService.decryptToBytes(this.key, orgKey ?? encKey);
                 view.key = new SymmetricCryptoKey(decValue);
             } catch (e) {
+                LogService.error(e);
                 // TODO: error?
             }
         }

--- a/src/models/domain/cipherString.ts
+++ b/src/models/domain/cipherString.ts
@@ -1,6 +1,7 @@
 import { EncryptionType } from '../../enums/encryptionType';
 
 import { CryptoService } from '../../abstractions/crypto.service';
+import { LogService } from '../../abstractions/log.service';
 
 import { Utils } from '../../misc/utils';
 
@@ -51,6 +52,7 @@ export class CipherString {
                 this.encryptionType = parseInt(headerPieces[0], null);
                 encPieces = headerPieces[1].split('|');
             } catch (e) {
+                LogService.error(e);
                 return;
             }
         } else {
@@ -110,6 +112,7 @@ export class CipherString {
             }
             this.decryptedValue = await cryptoService.decryptToUtf8(this, key);
         } catch (e) {
+            LogService.error(e);
             this.decryptedValue = '[error: cannot decrypt]';
         }
         return this.decryptedValue;

--- a/src/models/domain/send.ts
+++ b/src/models/domain/send.ts
@@ -1,4 +1,5 @@
 import { CryptoService } from '../../abstractions/crypto.service';
+import { LogService } from '../../abstractions/log.service';
 
 import { SendType } from '../../enums/sendType';
 
@@ -82,6 +83,7 @@ export class Send extends Domain {
             model.key = await cryptoService.decryptToBytes(this.key, null);
             model.cryptoKey = await cryptoService.makeSendKey(model.key);
         } catch (e) {
+            LogService.error(e);
             // TODO: error?
         }
 

--- a/src/models/view/attachmentView.ts
+++ b/src/models/view/attachmentView.ts
@@ -1,5 +1,7 @@
 import { View } from './view';
 
+import { LogService } from '../../abstractions/log.service';
+
 import { Attachment } from '../domain/attachment';
 import { SymmetricCryptoKey } from '../domain/symmetricCryptoKey';
 
@@ -27,7 +29,9 @@ export class AttachmentView implements View {
             if (this.size != null) {
                 return parseInt(this.size, null);
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
         return 0;
     }
 }

--- a/src/models/view/sendFileView.ts
+++ b/src/models/view/sendFileView.ts
@@ -1,5 +1,7 @@
 import { View } from './view';
 
+import { LogService } from '../../abstractions/log.service';
+
 import { SendFile } from '../domain/sendFile';
 
 export class SendFileView implements View {
@@ -25,7 +27,9 @@ export class SendFileView implements View {
             if (this.size != null) {
                 return parseInt(this.size, null);
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
         return 0;
     }
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -2,6 +2,7 @@ import { DeviceType } from '../enums/deviceType';
 import { PolicyType } from '../enums/policyType';
 
 import { ApiService as ApiServiceAbstraction } from '../abstractions/api.service';
+import { LogService } from '../abstractions/log.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { TokenService } from '../abstractions/token.service';
 
@@ -221,6 +222,7 @@ export class ApiService implements ApiServiceAbstraction {
         try {
             await this.doRefreshToken();
         } catch (e) {
+            LogService.error(e);
             return Promise.reject(null);
         }
     }

--- a/src/services/audit.service.ts
+++ b/src/services/audit.service.ts
@@ -1,6 +1,7 @@
 import { ApiService } from '../abstractions/api.service';
 import { AuditService as AuditServiceAbstraction } from '../abstractions/audit.service';
 import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
+import { LogService } from '../abstractions/log.service';
 
 import { throttle } from '../misc/throttle';
 import { Utils } from '../misc/utils';
@@ -33,6 +34,7 @@ export class AuditService implements AuditServiceAbstraction {
         try {
             return await this.apiService.getHibpBreach(username);
         } catch (e) {
+            LogService.error(e);
             const error = e as ErrorResponse;
             if (error.statusCode === 404) {
                 return [];

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -92,7 +92,7 @@ export class AuthService implements AuthServiceAbstraction {
         private userService: UserService, private tokenService: TokenService,
         private appIdService: AppIdService, private i18nService: I18nService,
         private platformUtilsService: PlatformUtilsService, private messagingService: MessagingService,
-        private vaultTimeoutService: VaultTimeoutService, private logService: LogService,
+        private vaultTimeoutService: VaultTimeoutService,
         private setCryptoKeys = true) {
     }
 
@@ -248,6 +248,7 @@ export class AuthService implements AuthServiceAbstraction {
             if (e == null || e.statusCode !== 404) {
                 throw e;
             }
+            LogService.error(e);
         }
         return this.cryptoService.makeKey(masterPassword, email, kdf, kdfIterations);
     }
@@ -353,8 +354,7 @@ export class AuthService implements AuthServiceAbstraction {
                         await this.apiService.postAccountKeys(new KeysRequest(keyPair[0], keyPair[1].encryptedString));
                         tokenResponse.privateKey = keyPair[1].encryptedString;
                     } catch (e) {
-                        // tslint:disable-next-line
-                        this.logService.error(e);
+                        LogService.error(e);
                     }
                 }
 

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -41,6 +41,7 @@ import { ApiService } from '../abstractions/api.service';
 import { CipherService as CipherServiceAbstraction } from '../abstractions/cipher.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { I18nService } from '../abstractions/i18n.service';
+import { LogService } from '../abstractions/log.service';
 import { SearchService } from '../abstractions/search.service';
 import { SettingsService } from '../abstractions/settings.service';
 import { StorageService } from '../abstractions/storage.service';
@@ -414,7 +415,9 @@ export class CipherService implements CipherServiceAbstraction {
                                 if (regex.test(url)) {
                                     return true;
                                 }
-                            } catch { }
+                            } catch (e) {
+                                LogService.error(e);
+                            }
                             break;
                         case UriMatchType.Never:
                         default:

--- a/src/services/consoleLog.service.ts
+++ b/src/services/consoleLog.service.ts
@@ -9,26 +9,26 @@ export class ConsoleLogService implements LogServiceAbstraction {
 
     constructor(protected isDev: boolean, protected filter: (level: LogLevelType) => boolean = null) { }
 
-    debug(message: string) {
+    debug(message?: any, ...optionalParams: any[]) {
         if (!this.isDev) {
             return;
         }
         this.write(LogLevelType.Debug, message);
     }
 
-    info(message: string) {
+    info(message?: any, ...optionalParams: any[]) {
         this.write(LogLevelType.Info, message);
     }
 
-    warning(message: string) {
+    warning(message?: any, ...optionalParams: any[]) {
         this.write(LogLevelType.Warning, message);
     }
 
-    error(message: string) {
+    error(message?: any, ...optionalParams: any[]) {
         this.write(LogLevelType.Error, message);
     }
 
-    write(level: LogLevelType, message: string) {
+    write(level: LogLevelType, message?: any, ...optionalParams: any[]) {
         if (this.filter != null && this.filter(level)) {
             return;
         }
@@ -36,19 +36,19 @@ export class ConsoleLogService implements LogServiceAbstraction {
         switch (level) {
             case LogLevelType.Debug:
                 // tslint:disable-next-line
-                console.log(message);
+                console.log(message, optionalParams);
                 break;
             case LogLevelType.Info:
                 // tslint:disable-next-line
-                console.log(message);
+                console.log(message, optionalParams);
                 break;
             case LogLevelType.Warning:
                 // tslint:disable-next-line
-                console.warn(message);
+                console.warn(message, optionalParams);
                 break;
             case LogLevelType.Error:
                 // tslint:disable-next-line
-                console.error(message);
+                console.error(message, optionalParams);
                 break;
             default:
                 break;

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -38,8 +38,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     private orgKeys: Map<string, SymmetricCryptoKey>;
 
     constructor(private storageService: StorageService, private secureStorageService: StorageService,
-        private cryptoFunctionService: CryptoFunctionService, private platformUtilService: PlatformUtilsService,
-        private logService: LogService) {
+        private cryptoFunctionService: CryptoFunctionService, private platformUtilService: PlatformUtilsService) {
     }
 
     async setKey(key: SymmetricCryptoKey): Promise<any> {
@@ -448,7 +447,9 @@ export class CryptoService implements CryptoServiceAbstraction {
             try {
                 encType = parseInt(headerPieces[0], null);
                 encPieces = headerPieces[1].split('|');
-            } catch (e) { }
+            } catch (e) {
+                LogService.error(e);
+            }
         }
 
         switch (encType) {
@@ -603,12 +604,12 @@ export class CryptoService implements CryptoServiceAbstraction {
         const theKey = this.resolveLegacyKey(encType, keyForEnc);
 
         if (theKey.macKey != null && mac == null) {
-            this.logService.error('mac required.');
+            LogService.error('mac required.');
             return null;
         }
 
         if (theKey.encType !== encType) {
-            this.logService.error('encType unavailable.');
+            LogService.error('encType unavailable.');
             return null;
         }
 
@@ -618,7 +619,7 @@ export class CryptoService implements CryptoServiceAbstraction {
                 fastParams.macKey, 'sha256');
             const macsEqual = await this.cryptoFunctionService.compareFast(fastParams.mac, computedMac);
             if (!macsEqual) {
-                this.logService.error('mac failed.');
+                LogService.error('mac failed.');
                 return null;
             }
         }
@@ -650,7 +651,7 @@ export class CryptoService implements CryptoServiceAbstraction {
 
             const macsMatch = await this.cryptoFunctionService.compare(mac, computedMac);
             if (!macsMatch) {
-                this.logService.error('mac failed.');
+                LogService.error('mac failed.');
                 return null;
             }
         }

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -7,6 +7,7 @@ import { EventRequest } from '../models/request/eventRequest';
 import { ApiService } from '../abstractions/api.service';
 import { CipherService } from '../abstractions/cipher.service';
 import { EventService as EventServiceAbstraction } from '../abstractions/event.service';
+import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
 import { UserService } from '../abstractions/user.service';
 
@@ -83,7 +84,9 @@ export class EventService implements EventServiceAbstraction {
         try {
             await this.apiService.postEventsCollect(request);
             this.clearEvents();
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
     }
 
     async clearEvents(): Promise<any> {

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -1,4 +1,5 @@
 import { I18nService as I18nServiceAbstraction } from '../abstractions/i18n.service';
+import { LogService } from '../abstractions/log.service';
 
 export class I18nService implements I18nServiceAbstraction {
     locale: string;
@@ -73,7 +74,8 @@ export class I18nService implements I18nServiceAbstraction {
 
         try {
             this.collator = new Intl.Collator(this.locale, { numeric: true, sensitivity: 'base' });
-        } catch {
+        } catch (e) {
+            LogService.error(e);
             this.collator = null;
         }
 

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -30,7 +30,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
     constructor(private userService: UserService, private syncService: SyncService,
         private appIdService: AppIdService, private apiService: ApiService,
         private vaultTimeoutService: VaultTimeoutService,
-        private logoutCallback: () => Promise<void>, private logService: LogService) {
+        private logoutCallback: () => Promise<void>) {
     }
 
     async init(environmentService: EnvironmentService): Promise<void> {
@@ -91,7 +91,7 @@ export class NotificationsService implements NotificationsServiceAbstraction {
                 await this.signalrConnection.stop();
             }
         } catch (e) {
-            this.logService.error(e.toString());
+            LogService.error(e.toString());
         }
     }
 
@@ -191,7 +191,9 @@ export class NotificationsService implements NotificationsServiceAbstraction {
             if (sync) {
                 await this.syncService.fullSync(false);
             }
-        } catch { }
+        } catch (e) {
+            LogService.error(e);
+        }
 
         if (!this.connected) {
             this.reconnectTimer = setTimeout(() => this.reconnect(sync), this.random(120000, 300000));

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -15,7 +15,7 @@ export class SearchService implements SearchServiceAbstraction {
     private indexing = false;
     private index: lunr.Index = null;
 
-    constructor(private cipherService: CipherService, private logService: LogService) {
+    constructor(private cipherService: CipherService) {
     }
 
     clearIndex(): void {
@@ -33,7 +33,7 @@ export class SearchService implements SearchServiceAbstraction {
             return;
         }
 
-        this.logService.time('search indexing');
+        LogService.time('search indexing');
         this.indexing = true;
         this.index = null;
         const builder = new lunr.Builder();
@@ -65,7 +65,7 @@ export class SearchService implements SearchServiceAbstraction {
         this.index = builder.build();
         this.indexing = false;
 
-        this.logService.timeEnd('search indexing');
+        LogService.timeEnd('search indexing');
     }
 
     async searchCiphers(query: string,
@@ -115,7 +115,9 @@ export class SearchService implements SearchServiceAbstraction {
         if (isQueryString) {
             try {
                 searchResults = index.search(query.substr(1).trim());
-            } catch { }
+            } catch (e) {
+                LogService.error(e);
+            }
         } else {
             // tslint:disable-next-line
             const soWild = lunr.Query.wildcard.LEADING | lunr.Query.wildcard.TRAILING;

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -3,6 +3,7 @@ import { CipherService } from '../abstractions/cipher.service';
 import { CollectionService } from '../abstractions/collection.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { FolderService } from '../abstractions/folder.service';
+import { LogService } from '../abstractions/log.service';
 import { MessagingService } from '../abstractions/messaging.service';
 import { PolicyService } from '../abstractions/policy.service';
 import { SendService } from '../abstractions/send.service';
@@ -129,7 +130,9 @@ export class SyncService implements SyncServiceAbstraction {
                         return this.syncCompleted(true);
                     }
                 }
-            } catch { }
+            } catch (e) {
+                LogService.error(e);
+            }
         }
         return this.syncCompleted(false);
     }
@@ -198,6 +201,7 @@ export class SyncService implements SyncServiceAbstraction {
                     this.messagingService.send('syncedDeletedCipher', { cipherId: notification.id });
                     return this.syncCompleted(true);
                 }
+                LogService.error(e);
             }
         }
         return this.syncCompleted(false);
@@ -228,7 +232,9 @@ export class SyncService implements SyncServiceAbstraction {
                         return this.syncCompleted(true);
                     }
                 }
-            } catch { }
+            } catch (e) {
+                LogService.error(e);
+            }
         }
         return this.syncCompleted(false);
     }

--- a/src/services/totp.service.ts
+++ b/src/services/totp.service.ts
@@ -1,6 +1,7 @@
 import { ConstantsService } from './constants.service';
 
 import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
+import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
 import { TotpService as TotpServiceAbstraction } from '../abstractions/totp.service';
 
@@ -32,7 +33,9 @@ export class TotpService implements TotpServiceAbstraction {
                     } else if (digitParams > 0) {
                         digits = digitParams;
                     }
-                } catch { }
+                } catch (e) {
+                    LogService.error(e);
+                }
             }
             if (params.has('period') && params.get('period') != null) {
                 try {
@@ -40,7 +43,9 @@ export class TotpService implements TotpServiceAbstraction {
                     if (periodParam > 0) {
                         period = periodParam;
                     }
-                } catch { }
+                } catch (e) {
+                    LogService.error(e);
+                }
             }
             if (params.has('secret') && params.get('secret') != null) {
                 keyB32 = params.get('secret');
@@ -99,7 +104,9 @@ export class TotpService implements TotpServiceAbstraction {
             if (params.has('period') && params.get('period') != null) {
                 try {
                     period = parseInt(params.get('period').trim(), null);
-                } catch { }
+                } catch (e) {
+                    LogService.error(e);
+                }
             }
         }
         return period;


### PR DESCRIPTION
Use LogService to output all caught errors to console

# Overview

We have a lot of locations we are silently swallowing Errors. This PR is a first step toward better surfacing of those errors.

I've moved LogService to a static construct that is initialized with other Services to a singleton. If a client does not initialize, a default `ConsoleLogService` is instantiated.

Typescript client PRs incoming to use static `LogService` methods

# Files Changed

* **abstract/log.service.ts**: method signatures are changed to match `console` signatures and static methods are provided. Clients should use the `LogService.set()` method to set the LogService instance to use during whatever service instantiation they do.
* **auth.service/crypto.service/notifications.service/search.service**: Removed logService parameter dependency in favor of static methods.

Other file changes are adding log errors for caught exceptions of converting to static LogService methods