### PR TITLE
Chmod exported file permissions

### DIFF
--- a/src/electron/services/electronPlatformUtils.service.ts
+++ b/src/electron/services/electronPlatformUtils.service.ts
@@ -120,7 +120,7 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
             showsTagField: false,
         }).then(ret => {
             if (ret.filePath != null) {
-                fs.writeFile(ret.filePath, Buffer.from(blobData), err => {
+                fs.writeFile(ret.filePath, Buffer.from(blobData), { mode: 0o600 }, err => {
                     // error check?
                 });
             }


### PR DESCRIPTION
# Overview

Linked to bitwarden/desktop/issues/705. The original complain is on export, but this change is for all saved files for Desktop. 

The default should be for any file downloaded from Bitwarden to grant permissions to only the current User (permissions = 600).

# Files Changed

* **utils.ts**: This is the save method for all of Desktop. We open up the saved file in user read/write only mode (600)

# Testing

Need to test for all downloaded items
* Attachments
* Exports
Need to test for all OS
* Windows
* Linux
* Mac

The expected behavior is that the logged in user can read and write to the downloaded file, but any other (non-super) user cannot.