### PR TITLE
detect dark theme based on system theme

### DIFF
--- a/src/electron/services/electronPlatformUtils.service.ts
+++ b/src/electron/services/electronPlatformUtils.service.ts
@@ -3,7 +3,6 @@ import {
     ipcRenderer,
     remote,
     shell,
-    // nativeTheme,
 } from 'electron';
 import * as fs from 'fs';
 
@@ -222,14 +221,13 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
     }
 
     getDefaultSystemTheme() {
-        return 'light' as 'light' | 'dark';
-        // return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+        return remote.nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
     }
 
     onDefaultSystemThemeChange(callback: ((theme: 'light' | 'dark') => unknown)) {
-        // nativeTheme.on('updated', () => {
-        //     callback(this.getDefaultSystemTheme());
-        // });
+        remote.nativeTheme.on('updated', () => {
+            callback(this.getDefaultSystemTheme());
+        });
     }
 
     supportsSecureStorage(): boolean {


### PR DESCRIPTION
Now that we are on electron 11, it is possible to detect the system theme on both Windows and macOS using `nativeTheme.shouldUseDarkColors` (previously it only worked on macOS).

This PR implements this into `electronPlatformUtils` service so that the desktop app can consumer it (future PR).