### PR TITLE
[Send] Updated delete function for add/edit component

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -239,6 +239,8 @@ export class AddEditComponent implements OnInit {
             this.onDeletedSend.emit(this.send);
             return true;
         } catch { }
+
+        return false;
     }
 
     typeChanged() {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -219,16 +219,16 @@ export class AddEditComponent implements OnInit {
         }
     }
 
-    async delete(): Promise<void> {
+    async delete(): Promise<boolean> {
         if (this.deletePromise != null) {
-            return;
+            return false;
         }
         const confirmed = await this.platformUtilsService.showDialog(
             this.i18nService.t('deleteSendConfirmation'),
             this.i18nService.t('deleteSend'),
             this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
         if (!confirmed) {
-            return;
+            return false;
         }
 
         try {
@@ -237,6 +237,7 @@ export class AddEditComponent implements OnInit {
             this.platformUtilsService.showToast('success', null, this.i18nService.t('deletedSend'));
             await this.load();
             this.onDeletedSend.emit(this.send);
+            return true;
         } catch { }
     }
 


### PR DESCRIPTION
## Objective
> Calling the `delete` function from the browser extension during the add/edit flow cannot be handled properly in the current state. Make the `delete` function more flexible by mirroring the return state of the `submit` function.

## Code Changes
- **send/add-edit.component**: `delete` now returns `Promise<boolean>` so that the child class can properly handle navigation changes after a successful deletion (if necessary).

## Breaking Changes
- `Browser` -> Yes, the child's `delete` signature/operations will need to be updated.
- `Desktop` -> No
- `Web` -> No