### PR TITLE
Start cipher numbering at 1 in import error messages

### DIFF
--- a/src/services/import.service.ts
+++ b/src/services/import.service.ts
@@ -378,7 +378,7 @@ export class ImportService implements ImportServiceAbstraction {
             }
 
             if (itemType !== 'Folder' && itemType !== 'Collection') {
-                errorMessage += '[' + i + '] ';
+                errorMessage += '[' + (i + 1) + '] ';
             }
 
             errorMessage += '[' + itemType + '] "' + item.name + '": ' + value;


### PR DESCRIPTION
## Objective
Minor amendment to #280. @clayadams5226 suggested adding +1 to the cipher index when displaying the error message to the user. In other words, start counting at 1 instead of 0. This should be easier for non-technical users to understand. It also matches the numbering of lines in CSV files when opening them in Excel or Google Sheets.
