### PR TITLE
Upload Directly to Azure or Local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,195 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-9.1.12.tgz",
       "integrity": "sha512-+qCaXa9y0nsRhzjAYBqmGoQ2YkrdXgftZwuFDf6t4qEi30EXa0oS97KrlFq0M5GKdLIDGrbUm9PcdHSTOI+ZhA=="
     },
+    "@azure/abort-controller": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.2.tgz",
+      "integrity": "sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.2.0.tgz",
+      "integrity": "sha512-KUl+Nwn/Sm6Lw5d3U90m1jZfNSL087SPcqHLxwn2T6PupNKmcgsEbDjHB25gDvHO4h7pBsTlrdJAY7dz+Qk8GA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.3.tgz",
+      "integrity": "sha512-g5C1zUJO5dehP2Riv+vy9iCYoS1UwKnZsBVCzanScz9A83LbnXKpZDa9wie26G9dfXUhQoFZoFT8LYWhPKmwcg==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.1.3",
+        "@azure/core-tracing": "1.0.0-preview.9",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.0.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.3.tgz",
+      "integrity": "sha512-Py2crJ84qx1rXkzIwfKw5Ni4WJuzVU7KAF6i1yP3ce8fbynUeu8eEWS4JGtSQgU7xv02G55iPDROifmSDbxeHA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+      "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.9.tgz",
+      "integrity": "sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.10.2",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.1.tgz",
+      "integrity": "sha512-QYQeaJ+A5x6aMNu8BG5qdsVBnYBop9UMwgUvGihSjf1PdZZXB+c/oMdM2ajKwzobLBh9e9QuMQkN9iL+IxLBLA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.4.1.tgz",
+      "integrity": "sha512-RH6ru8LbnCC+m1rlVLon6mYUXdHsTcyUXFCJAWRQQM7p0XOwVKPS+UiVk2tZXfvMWd3q/qT/meOrEbHEcp/c4g==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.9",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -352,6 +541,24 @@
         }
       }
     },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
+      "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.10.2"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
+      "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -425,16 +632,35 @@
     "@types/node": {
       "version": "10.17.28",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
-      "dev": true
+      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
     },
     "@types/node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha512-XroxUzLpKuL+CVkQqXlffRkEPi4Gh3Oui/mWyS7ztKiyqVxiU+h3imCW5I2NQmde5jK+3q++36/Q96cyRWsweg==",
-      "dev": true,
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/node-forge": {
@@ -600,6 +826,14 @@
       "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-2.3.0.tgz",
       "integrity": "sha512-+gqspH/N6YjpApp96/XzM2AZK4R0Bk2qb4e5o16indSvgblfFaAIxNV8BdJmbqfSAYUyZubLzvrmpvdVEmBq3A==",
       "dev": true
+    },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/webcrypto": {
       "version": "0.0.28",
@@ -3596,8 +3830,7 @@
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
-      "dev": true
+      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
     },
     "eventsource": {
       "version": "1.0.7",
@@ -6097,28 +6330,32 @@
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
                   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ansi-regex": {
                   "version": "2.1.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
                   "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
                   "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "are-we-there-yet": {
                   "version": "1.1.5",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
                   "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "delegates": "^1.0.0",
                     "readable-stream": "^2.0.6"
@@ -6129,14 +6366,16 @@
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                   "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -6147,42 +6386,48 @@
                   "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
                   "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "code-point-at": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "debug": {
                   "version": "4.1.1",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                   "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "ms": "^2.1.1"
                   }
@@ -6192,28 +6437,32 @@
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
                   "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                   "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "detect-libc": {
                   "version": "1.0.3",
                   "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
                   "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "fs-minipass": {
                   "version": "1.2.5",
                   "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
                   "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "minipass": "^2.2.1"
                   }
@@ -6223,14 +6472,16 @@
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "gauge": {
                   "version": "2.7.4",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                   "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "aproba": "^1.0.3",
                     "console-control-strings": "^1.0.0",
@@ -6247,7 +6498,8 @@
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
                   "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "fs.realpath": "^1.0.0",
                     "inflight": "^1.0.4",
@@ -6262,14 +6514,16 @@
                   "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                   "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "iconv-lite": {
                   "version": "0.4.24",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
                   "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "safer-buffer": ">= 2.1.2 < 3"
                   }
@@ -6279,7 +6533,8 @@
                   "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
                   "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimatch": "^3.0.4"
                   }
@@ -6289,7 +6544,8 @@
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "once": "^1.3.0",
                     "wrappy": "1"
@@ -6300,21 +6556,24 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
                   "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -6324,14 +6583,16 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -6341,14 +6602,16 @@
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
                   "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
                   "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
                     "yallist": "^3.0.0"
@@ -6359,7 +6622,8 @@
                   "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
                   "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "minipass": "^2.2.1"
                   }
@@ -6369,7 +6633,8 @@
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -6379,14 +6644,16 @@
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                   "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "needle": {
                   "version": "2.3.0",
                   "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
                   "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "debug": "^4.1.0",
                     "iconv-lite": "^0.4.4",
@@ -6398,7 +6665,8 @@
                   "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
                   "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "detect-libc": "^1.0.2",
                     "mkdirp": "^0.5.1",
@@ -6417,7 +6685,8 @@
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
                   "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "abbrev": "1",
                     "osenv": "^0.1.4"
@@ -6428,14 +6697,16 @@
                   "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
                   "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "npm-packlist": {
                   "version": "1.4.1",
                   "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
                   "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "ignore-walk": "^3.0.1",
                     "npm-bundled": "^1.0.1"
@@ -6446,7 +6717,8 @@
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
                   "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "are-we-there-yet": "~1.1.2",
                     "console-control-strings": "~1.1.0",
@@ -6459,21 +6731,24 @@
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                   "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "once": {
                   "version": "1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -6483,21 +6758,24 @@
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                   "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                   "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "osenv": {
                   "version": "0.1.5",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
                   "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "os-homedir": "^1.0.0",
                     "os-tmpdir": "^1.0.0"
@@ -6508,21 +6786,24 @@
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "process-nextick-args": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
                   "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "rc": {
                   "version": "1.2.8",
                   "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
                   "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "deep-extend": "^0.6.0",
                     "ini": "~1.3.0",
@@ -6535,7 +6816,8 @@
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                       "bundled": true,
-                      "extraneous": true
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 },
@@ -6544,7 +6826,8 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                   "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.3",
@@ -6560,7 +6843,8 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
                   "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "glob": "^7.1.3"
                   }
@@ -6570,49 +6854,56 @@
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
                   "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                   "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "sax": {
                   "version": "1.2.4",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                   "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "semver": {
                   "version": "5.7.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
                   "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                   "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
                   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                   "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "string_decoder": {
                   "version": "1.1.1",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                   "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
                   }
@@ -6622,7 +6913,8 @@
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -6634,7 +6926,8 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -6644,14 +6937,16 @@
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                   "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "tar": {
                   "version": "4.4.8",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
                   "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "chownr": "^1.1.1",
                     "fs-minipass": "^1.2.5",
@@ -6667,14 +6962,16 @@
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "wide-align": {
                   "version": "1.1.3",
                   "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
                   "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                   "bundled": true,
-                  "extraneous": true,
+                  "dev": true,
+                  "optional": true,
                   "requires": {
                     "string-width": "^1.0.2 || 2"
                   }
@@ -6684,14 +6981,16 @@
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
                   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
                   "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                   "bundled": true,
-                  "extraneous": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -7480,8 +7779,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -7517,9 +7815,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -8931,9 +9229,7 @@
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -9066,8 +9362,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -9497,6 +9792,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@angular/platform-browser": "9.1.12",
     "@angular/platform-browser-dynamic": "9.1.12",
     "@angular/router": "9.1.12",
+    "@azure/storage-blob": "^12.4.1",
     "@microsoft/signalr": "3.1.0",
     "@microsoft/signalr-protocol-msgpack": "3.1.0",
     "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",

--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -185,7 +185,7 @@ export abstract class ApiService {
     putSend: (id: string, request: SendRequest) => Promise<SendResponse>;
     putSendRemovePassword: (id: string) => Promise<SendResponse>;
     deleteSend: (id: string) => Promise<any>;
-    getSendFileDownloadData: (send: SendAccessView) => Promise<SendFileDownloadDataResponse>;
+    getSendFileDownloadData: (send: SendAccessView, accessRequest: SendAccessRequest) => Promise<SendFileDownloadDataResponse>;
     postFileTypeSend: (request: SendRequest) => Promise<SendFileUploadDataResponse>;
 
 

--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -106,6 +106,8 @@ import { PreloginResponse } from '../models/response/preloginResponse';
 import { ProfileResponse } from '../models/response/profileResponse';
 import { SelectionReadOnlyResponse } from '../models/response/selectionReadOnlyResponse';
 import { SendAccessResponse } from '../models/response/sendAccessResponse';
+import { SendFileDownloadDataResponse } from '../models/response/sendFileDownloadDataResponse';
+import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 import { SendResponse } from '../models/response/sendResponse';
 import { SubscriptionResponse } from '../models/response/subscriptionResponse';
 import { SyncResponse } from '../models/response/syncResponse';
@@ -122,6 +124,8 @@ import {
 } from '../models/response/twoFactorU2fResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
+
+import { SendAccessView } from '../models/view/sendAccessView';
 
 export abstract class ApiService {
     urlsSet: boolean;
@@ -177,10 +181,13 @@ export abstract class ApiService {
     postSendAccess: (id: string, request: SendAccessRequest, apiUrl?: string) => Promise<SendAccessResponse>;
     getSends: () => Promise<ListResponse<SendResponse>>;
     postSend: (request: SendRequest) => Promise<SendResponse>;
-    postSendFile: (data: FormData) => Promise<SendResponse>;
+    postSendFile: (sendId: string, fileId: string, data: FormData) => Promise<any>;
     putSend: (id: string, request: SendRequest) => Promise<SendResponse>;
     putSendRemovePassword: (id: string) => Promise<SendResponse>;
     deleteSend: (id: string) => Promise<any>;
+    getSendFileDownloadData: (send: SendAccessView) => Promise<SendFileDownloadDataResponse>;
+    postFileTypeSend: (request: SendRequest) => Promise<SendFileUploadDataResponse>;
+
 
     getCipher: (id: string) => Promise<CipherResponse>;
     getCipherAdmin: (id: string) => Promise<CipherResponse>;

--- a/src/enums/fileUploadType.ts
+++ b/src/enums/fileUploadType.ts
@@ -1,0 +1,4 @@
+export enum FileUploadType {
+    Direct = 0,
+    Azure = 1,
+}

--- a/src/models/api/sendFileApi.ts
+++ b/src/models/api/sendFileApi.ts
@@ -2,7 +2,6 @@ import { BaseResponse } from '../response/baseResponse';
 
 export class SendFileApi extends BaseResponse {
     id: string;
-    url: string;
     fileName: string;
     key: string;
     size: string;
@@ -14,7 +13,6 @@ export class SendFileApi extends BaseResponse {
             return;
         }
         this.id = this.getResponseProperty('Id');
-        this.url = this.getResponseProperty('Url');
         this.fileName = this.getResponseProperty('FileName');
         this.key = this.getResponseProperty('Key');
         this.size = this.getResponseProperty('Size');

--- a/src/models/data/sendFileData.ts
+++ b/src/models/data/sendFileData.ts
@@ -2,7 +2,6 @@ import { SendFileApi } from '../api/sendFileApi';
 
 export class SendFileData {
     id: string;
-    url: string;
     fileName: string;
     key: string;
     size: string;
@@ -14,7 +13,6 @@ export class SendFileData {
         }
 
         this.id = data.id;
-        this.url = data.url;
         this.fileName = data.fileName;
         this.key = data.key;
         this.size = data.size;

--- a/src/models/domain/sendFile.ts
+++ b/src/models/domain/sendFile.ts
@@ -8,7 +8,6 @@ import { SendFileView } from '../view/sendFileView';
 
 export class SendFile extends Domain {
     id: string;
-    url: string;
     size: string;
     sizeName: string;
     fileName: CipherString;
@@ -22,7 +21,6 @@ export class SendFile extends Domain {
         this.size = obj.size;
         this.buildDomainModel(this, obj, {
             id: null,
-            url: null,
             sizeName: null,
             fileName: null,
         }, alreadyEncrypted, ['id', 'url', 'sizeName']);

--- a/src/models/request/sendRequest.ts
+++ b/src/models/request/sendRequest.ts
@@ -7,6 +7,7 @@ import { Send } from '../domain/send';
 
 export class SendRequest {
     type: SendType;
+    fileLength?: number = null;
     name: string;
     notes: string;
     key: string;
@@ -18,8 +19,9 @@ export class SendRequest {
     password: string;
     disabled: boolean;
 
-    constructor(send: Send) {
+    constructor(send: Send, fileLength: number = null) {
         this.type = send.type;
+        this.fileLength = fileLength;
         this.name = send.name ? send.name.encryptedString : null;
         this.notes = send.notes ? send.notes.encryptedString : null;
         this.maxAccessCount = send.maxAccessCount;

--- a/src/models/response/sendFileDownloadDataResponse.ts
+++ b/src/models/response/sendFileDownloadDataResponse.ts
@@ -1,4 +1,3 @@
-import { FileUploadType } from '../../enums/FileUploadType';
 import { BaseResponse } from './baseResponse';
 
 export class SendFileDownloadDataResponse extends BaseResponse {

--- a/src/models/response/sendFileDownloadDataResponse.ts
+++ b/src/models/response/sendFileDownloadDataResponse.ts
@@ -1,0 +1,13 @@
+import { FileUploadType } from '../../enums/FileUploadType';
+import { BaseResponse } from './baseResponse';
+
+export class SendFileDownloadDataResponse extends BaseResponse {
+
+    id: string = null;
+    url: string = null;
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.url = this.getResponseProperty('Url');
+    }
+}

--- a/src/models/response/sendFileUploadDataResponse.ts
+++ b/src/models/response/sendFileUploadDataResponse.ts
@@ -1,4 +1,4 @@
-import { FileUploadType } from '../../enums/FileUploadType';
+import { FileUploadType } from '../../enums/fileUploadType';
 import { BaseResponse } from './baseResponse';
 import { SendResponse } from './sendResponse';
 

--- a/src/models/response/sendFileUploadDataResponse.ts
+++ b/src/models/response/sendFileUploadDataResponse.ts
@@ -1,0 +1,17 @@
+import { FileUploadType } from '../../enums/FileUploadType';
+import { BaseResponse } from './baseResponse';
+import { SendResponse } from './sendResponse';
+
+export class SendFileUploadDataResponse extends BaseResponse {
+
+    fileUploadType: FileUploadType = null;
+    sendResponse: SendResponse = null;
+    url: string = null;
+
+    constructor(response: any) {
+        super(response);
+        this.fileUploadType = this.getResponseProperty('FileUploadType');
+        this.sendResponse = this.getResponseProperty('SendResponse');
+        this.url = this.getResponseProperty('Url');
+    }
+}

--- a/src/models/view/sendFileView.ts
+++ b/src/models/view/sendFileView.ts
@@ -4,7 +4,6 @@ import { SendFile } from '../domain/sendFile';
 
 export class SendFileView implements View {
     id: string = null;
-    url: string = null;
     size: string = null;
     sizeName: string = null;
     fileName: string = null;
@@ -15,7 +14,6 @@ export class SendFileView implements View {
         }
 
         this.id = f.id;
-        this.url = f.url;
         this.size = f.size;
         this.sizeName = f.sizeName;
     }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -112,6 +112,8 @@ import { PreloginResponse } from '../models/response/preloginResponse';
 import { ProfileResponse } from '../models/response/profileResponse';
 import { SelectionReadOnlyResponse } from '../models/response/selectionReadOnlyResponse';
 import { SendAccessResponse } from '../models/response/sendAccessResponse';
+import { SendFileDownloadDataResponse } from '../models/response/sendFileDownloadDataResponse';
+import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 import { SendResponse } from '../models/response/sendResponse';
 import { SubscriptionResponse } from '../models/response/subscriptionResponse';
 import { SyncResponse } from '../models/response/syncResponse';
@@ -128,6 +130,7 @@ import {
 } from '../models/response/twoFactorU2fResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
+import { SendAccessView } from '../models/view/sendAccessView';
 
 export class ApiService implements ApiServiceAbstraction {
     urlsSet: boolean = false;
@@ -416,6 +419,12 @@ export class ApiService implements ApiServiceAbstraction {
         return new SendAccessResponse(r);
     }
 
+    async getSendFileDownloadData(send: SendAccessView): Promise<SendFileDownloadDataResponse> {
+        const r = await this.send('GET', '/sends/' + send.id + '/access/file/' + send.file.id, null, false, true);
+        return new SendFileDownloadDataResponse(r);
+    }
+
+
     async getSends(): Promise<ListResponse<SendResponse>> {
         const r = await this.send('GET', '/sends', null, true, true);
         return new ListResponse(r, SendResponse);
@@ -426,9 +435,13 @@ export class ApiService implements ApiServiceAbstraction {
         return new SendResponse(r);
     }
 
-    async postSendFile(data: FormData): Promise<SendResponse> {
-        const r = await this.send('POST', '/sends/file', data, true, true);
-        return new SendResponse(r);
+    async postFileTypeSend(request: SendRequest): Promise<SendFileUploadDataResponse> {
+        const r = await this.send('POST', '/sends/file', request, true, true);
+        return new SendFileUploadDataResponse(r);
+    }
+
+    postSendFile(sendId: string, fileId: string, data: FormData): Promise<any> {
+        return this.send('POST', '/sends/' + sendId + '/file/' + fileId, data, true, false);
     }
 
     async putSend(id: string, request: SendRequest): Promise<SendResponse> {

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -419,8 +419,8 @@ export class ApiService implements ApiServiceAbstraction {
         return new SendAccessResponse(r);
     }
 
-    async getSendFileDownloadData(send: SendAccessView): Promise<SendFileDownloadDataResponse> {
-        const r = await this.send('GET', '/sends/' + send.id + '/access/file/' + send.file.id, null, false, true);
+    async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest, apiUrl?: string): Promise<SendFileDownloadDataResponse> {
+        const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true, apiUrl);
         return new SendFileDownloadDataResponse(r);
     }
 

--- a/src/services/send.service.ts
+++ b/src/services/send.service.ts
@@ -11,7 +11,7 @@ import { SendFile } from '../models/domain/sendFile';
 import { SendText } from '../models/domain/sendText';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
-import { FileUploadType } from '../enums/FileUploadType';
+import { FileUploadType } from '../enums/fileUploadType';
 import { SendType } from '../enums/sendType';
 
 import { SendView } from '../models/view/sendView';

--- a/src/services/send.service.ts
+++ b/src/services/send.service.ts
@@ -274,6 +274,6 @@ export class SendService implements SendServiceAbstraction {
     }
 
     private async azureUploadFileToServer(url: string, data: ArrayBuffer) {
-        const r = await new BlockBlobClient(url).uploadData(data);
+        await new BlockBlobClient(url).uploadData(data);
     }
 }


### PR DESCRIPTION
# Overview

Companion PR to Bitwarden/server#1167 and Bitwarden/web#853
Receives Send file upload and download URLs from Server to directly upload to a specified endpoint. This allows for directly uploading to Azure.

# Files Changed
* **package.json/package-lock.json**: Included azure/storage-blob to handle upload to an azure url
* **api.service.ts**: Separates Api tasks from posting a Send that is of type file to Posting a send without data, receiving Identifiers and upload URLs and a post endpoint to allow for direct upload to a local storage service (PostSendFile). Also creates a GetDownloadURL method that returns the appropriate URL to download a blob/file from.
* **FileUploadType**: Enum defining the way to upload a file. Direct upload to Bitwarden requires encapsulating in FormData, Blob upload is handled by Azure code.
* **SendFileApi/SendFileData/SendFile/SendFileView**: these models no longer contain a download URL since we can require calling the getSendFileDownloadData endpoint.
* **SendRequest**: Now includes a trust-based hint on the file size we will be uploading. Required and checked only for File type sends. This file size hint is verified post file upload and the send is deleted if it is incorrect within 1MB.
* **SendFileDownloadDataResponse**: Download information. Useful bit is the URL to fetch from
* **SendFileUploadDataResponse**: Upload information. Holds:
  1. The generated Send as a SendResponse
  2. The URL to upload a file to
  3. The type of upload required (see FileUploadType)
* **SendService**: Implement the above changes. Direct uploads use form data and upload only the file content. Azure code handles blob upload. SendRequest is popuplated with a file size. 