### PR TITLE
Direct download for send

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -184,7 +184,7 @@ export abstract class ApiService {
     putSend: (id: string, request: SendRequest) => Promise<SendResponse>;
     putSendRemovePassword: (id: string) => Promise<SendResponse>;
     deleteSend: (id: string) => Promise<any>;
-    getSendFileDownloadData: (send: SendAccessView) => Promise<SendFileDownloadDataResponse>; 
+    getSendFileDownloadData: (send: SendAccessView, request: SendAccessRequest) => Promise<SendFileDownloadDataResponse>; 
 
     getCipher: (id: string) => Promise<CipherResponse>;
     getCipherAdmin: (id: string) => Promise<CipherResponse>;

--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -106,6 +106,7 @@ import { PreloginResponse } from '../models/response/preloginResponse';
 import { ProfileResponse } from '../models/response/profileResponse';
 import { SelectionReadOnlyResponse } from '../models/response/selectionReadOnlyResponse';
 import { SendAccessResponse } from '../models/response/sendAccessResponse';
+import { SendFileDownloadDataResponse } from '../models/response/sendFileDownloadDataResponse'; 
 import { SendResponse } from '../models/response/sendResponse';
 import { SubscriptionResponse } from '../models/response/subscriptionResponse';
 import { SyncResponse } from '../models/response/syncResponse';
@@ -122,6 +123,8 @@ import {
 } from '../models/response/twoFactorU2fResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
+
+import { SendAccessView } from '../models/view/sendAccessView';
 
 export abstract class ApiService {
     urlsSet: boolean;
@@ -181,6 +184,7 @@ export abstract class ApiService {
     putSend: (id: string, request: SendRequest) => Promise<SendResponse>;
     putSendRemovePassword: (id: string) => Promise<SendResponse>;
     deleteSend: (id: string) => Promise<any>;
+    getSendFileDownloadData: (send: SendAccessView) => Promise<SendFileDownloadDataResponse>; 
 
     getCipher: (id: string) => Promise<CipherResponse>;
     getCipherAdmin: (id: string) => Promise<CipherResponse>;

--- a/src/models/api/sendFileApi.ts
+++ b/src/models/api/sendFileApi.ts
@@ -2,7 +2,6 @@ import { BaseResponse } from '../response/baseResponse';
 
 export class SendFileApi extends BaseResponse {
     id: string;
-    url: string;
     fileName: string;
     key: string;
     size: string;
@@ -14,7 +13,6 @@ export class SendFileApi extends BaseResponse {
             return;
         }
         this.id = this.getResponseProperty('Id');
-        this.url = this.getResponseProperty('Url');
         this.fileName = this.getResponseProperty('FileName');
         this.key = this.getResponseProperty('Key');
         this.size = this.getResponseProperty('Size');

--- a/src/models/data/sendFileData.ts
+++ b/src/models/data/sendFileData.ts
@@ -2,7 +2,6 @@ import { SendFileApi } from '../api/sendFileApi';
 
 export class SendFileData {
     id: string;
-    url: string;
     fileName: string;
     key: string;
     size: string;
@@ -14,7 +13,6 @@ export class SendFileData {
         }
 
         this.id = data.id;
-        this.url = data.url;
         this.fileName = data.fileName;
         this.key = data.key;
         this.size = data.size;

--- a/src/models/domain/sendFile.ts
+++ b/src/models/domain/sendFile.ts
@@ -8,7 +8,6 @@ import { SendFileView } from '../view/sendFileView';
 
 export class SendFile extends Domain {
     id: string;
-    url: string;
     size: string;
     sizeName: string;
     fileName: CipherString;
@@ -22,10 +21,9 @@ export class SendFile extends Domain {
         this.size = obj.size;
         this.buildDomainModel(this, obj, {
             id: null,
-            url: null,
             sizeName: null,
             fileName: null,
-        }, alreadyEncrypted, ['id', 'url', 'sizeName']);
+        }, alreadyEncrypted, ['id', 'sizeName']);
     }
 
     async decrypt(key: SymmetricCryptoKey): Promise<SendFileView> {

--- a/src/models/response/sendFileDownloadDataResponse.ts
+++ b/src/models/response/sendFileDownloadDataResponse.ts
@@ -1,0 +1,12 @@
+import { BaseResponse } from './baseResponse';
+
+export class SendFileDownloadDataResponse extends BaseResponse {
+
+    id: string = null;
+    url: string = null;
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.url = this.getResponseProperty('Url');
+    }
+} 

--- a/src/models/view/sendFileView.ts
+++ b/src/models/view/sendFileView.ts
@@ -4,7 +4,6 @@ import { SendFile } from '../domain/sendFile';
 
 export class SendFileView implements View {
     id: string = null;
-    url: string = null;
     size: string = null;
     sizeName: string = null;
     fileName: string = null;
@@ -15,7 +14,6 @@ export class SendFileView implements View {
         }
 
         this.id = f.id;
-        this.url = f.url;
         this.size = f.size;
         this.sizeName = f.sizeName;
     }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -420,8 +420,8 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
 
-    async getSendFileDownloadData(send: SendAccessView): Promise<SendFileDownloadDataResponse> {
-        const r = await this.send('GET', '/sends/' + send.id + '/access/file/' + send.file.id, null, false, true);
+    async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest): Promise<SendFileDownloadDataResponse> {
+        const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true);
         return new SendFileDownloadDataResponse(r);
     }
 

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -112,6 +112,7 @@ import { PreloginResponse } from '../models/response/preloginResponse';
 import { ProfileResponse } from '../models/response/profileResponse';
 import { SelectionReadOnlyResponse } from '../models/response/selectionReadOnlyResponse';
 import { SendAccessResponse } from '../models/response/sendAccessResponse';
+import { SendFileDownloadDataResponse } from '../models/response/sendFileDownloadDataResponse'; 
 import { SendResponse } from '../models/response/sendResponse';
 import { SubscriptionResponse } from '../models/response/subscriptionResponse';
 import { SyncResponse } from '../models/response/syncResponse';
@@ -128,6 +129,8 @@ import {
 } from '../models/response/twoFactorU2fResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
+
+import { SendAccessView } from '../models/view/sendAccessView'; 
 
 export class ApiService implements ApiServiceAbstraction {
     urlsSet: boolean = false;
@@ -414,6 +417,12 @@ export class ApiService implements ApiServiceAbstraction {
     async postSendAccess(id: string, request: SendAccessRequest, apiUrl?: string): Promise<SendAccessResponse> {
         const r = await this.send('POST', '/sends/access/' + id, request, false, true, apiUrl);
         return new SendAccessResponse(r);
+    }
+
+
+    async getSendFileDownloadData(send: SendAccessView): Promise<SendFileDownloadDataResponse> {
+        const r = await this.send('GET', '/sends/' + send.id + '/access/file/' + send.file.id, null, false, true);
+        return new SendFileDownloadDataResponse(r);
     }
 
     async getSends(): Promise<ListResponse<SendResponse>> {


### PR DESCRIPTION
# Overview 

Limits changes from #285 to download links only. Its companion is bitwarden/server#1174.

# Files changed
* **api.service.ts**: GetSendFileDownloadData. Request is re-sent to allow for reverification of access upon download of the file. This is a first step toward solving an access-count race and closes the issue of saving the request downlod link url and having unfettered downloads.
* **SendFileApi/SendFileData/SendFile/SendFileView**: Remove Url from models
* **SendFileDownloadDataResponse**: Response to download link reuquest. Currently holds SendResponse and url.