### PR TITLE
Write backup before deleting lowdb database

### DIFF
--- a/src/services/lowdbStorage.service.ts
+++ b/src/services/lowdbStorage.service.ts
@@ -47,6 +47,13 @@ export class LowdbStorageService implements StorageService {
         } catch (e) {
             if (e instanceof SyntaxError) {
                 this.logService.warning(`Error creating lowdb storage adapter, "${e.message}"; emptying data file.`);
+                if (fs.existsSync(this.dataFilePath)) {
+                    let backupPath = this.dataFilePath + '.bak';
+                    this.logService.warning(`Writing backup of data file to ${backupPath}`);
+                    await fs.copyFile(this.dataFilePath, backupPath, err => {
+                        this.logService.warning(`Error while creating data file backup, "${e.message}". No backup may have been created.`);
+                    });
+                }
                 adapter.write({});
                 this.db = lowdb(adapter);
             } else {

--- a/src/services/lowdbStorage.service.ts
+++ b/src/services/lowdbStorage.service.ts
@@ -48,7 +48,7 @@ export class LowdbStorageService implements StorageService {
             if (e instanceof SyntaxError) {
                 this.logService.warning(`Error creating lowdb storage adapter, "${e.message}"; emptying data file.`);
                 if (fs.existsSync(this.dataFilePath)) {
-                    let backupPath = this.dataFilePath + '.bak';
+                    const backupPath = this.dataFilePath + '.bak';
                     this.logService.warning(`Writing backup of data file to ${backupPath}`);
                     await fs.copyFile(this.dataFilePath, backupPath, err => {
                         this.logService.warning(`Error while creating data file backup, "${e.message}". No backup may have been created.`);


### PR DESCRIPTION
# Overview

A client just hit an issue with Directory-Connector where their lowdb file was wiped out due to being malformed. This makes sense for the most part since we don't expect clients to be editing that file directly _usually_. However, it does happen. A nicer thing to do is at least backup their data before blowing it out of the water.

# Files Changed
* **lowdbStorage.service.ts**: Create a backup on adapter creation error. known error is malformed json