### PR TITLE
fixed up the send date fallbacks again

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -114,7 +114,9 @@ export class AddEditComponent implements OnInit {
     }
 
     get expirationDateTimeFallback() {
-        return `${this.expirationDateFallback}T${this.expirationTimeFallback}`;
+        return this.nullOrWhiteSpaceCount([this.expirationDateFallback, this.expirationTimeFallback]) > 0 ?
+            null :
+            `${this.expirationDateFallback}T${this.expirationTimeFallback}`;
     }
 
     get deletionDateTimeFallback() {
@@ -175,9 +177,14 @@ export class AddEditComponent implements OnInit {
     async submit(): Promise<boolean> {
         if (!this.isDateTimeLocalSupported) {
             this.deletionDate = this.deletionDateTimeFallback;
-            if ((this.editMode && this.expirationDateFallback != null) || this.expirationDateSelect === 0) {
-                this.expirationDate = this.expirationDateTimeFallback;
+            if (this.nullOrWhiteSpaceCount([this.expirationDateFallback, this.expirationTimeFallback]) === 1) {
+                this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                    this.i18nService.t('dateAndTimeRequired'));
+                return;
             }
+            if (this.editMode || this.expirationDateSelect === 0) {
+                this.expirationDate = this.expirationDateTimeFallback;
+            } 
         }
 
         if (this.disableSend) {
@@ -332,5 +339,9 @@ export class AddEditComponent implements OnInit {
     protected togglePasswordVisible() {
         this.showPassword = !this.showPassword;
         document.getElementById('password').focus();
+    }
+
+    protected nullOrWhiteSpaceCount(strarray: string[]): number {
+        return strarray.filter(str => str == null || str.trim() === '').length;
     }
 }

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -179,12 +179,12 @@ export class AddEditComponent implements OnInit {
             this.deletionDate = this.deletionDateTimeFallback;
             if (this.nullOrWhiteSpaceCount([this.expirationDateFallback, this.expirationTimeFallback]) === 1) {
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-                    this.i18nService.t('dateAndTimeRequired'));
+                    this.i18nService.t('expirationDateAndTimeRequired'));
                 return;
             }
             if (this.editMode || this.expirationDateSelect === 0) {
                 this.expirationDate = this.expirationDateTimeFallback;
-            } 
+            }
         }
 
         if (this.disableSend) {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -259,6 +259,8 @@ export class AddEditComponent implements OnInit {
 
     clearExpiration() {
         this.expirationDate = null;
+        this.expirationDateFallback = null;
+        this.expirationTimeFallback = null;
     }
 
     copyLinkToClipboard(link: string) {


### PR DESCRIPTION
**Addresses:** 
> for a Send with an expiration, you can go in there and clear that out, but you can’t save because expirationDateFallback will never be null again. Should probably also check expirationTimeFallback since they’re both required.
> last issue is the clear <a> tag doesn’t work and it’d be nice if we could hide the clear out buttons in the input or link the two fields

1. Check if either expiration date or time is null in `expirationDateTimeFallback()` and return null if true are instead of "T"
2. Throw an error if only one of the two is null informing the user to add both.
3. Added expirationDate and Time fallbacks to `clearExpiration()`