### PR TITLE
Safari Time Formatting

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -297,12 +297,12 @@ export class AddEditComponent implements OnInit {
             }
             if (this.nullOrWhiteSpaceCount([this.expirationDateFallback, this.expirationTimeFallback]) === 1) {
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-                    this.i18nService.t('dateAndTimeRequired'));
+                    this.i18nService.t('expirationDateAndTimeRequired'));
                 return;
             }
             if (this.editMode || this.expirationDateSelect === 0) {
                 this.expirationDate = this.expirationDateTimeFallback;
-            } 
+            }
         }
 
         if (this.disableSend) {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -11,8 +11,6 @@ import { OrganizationUserStatusType } from '../../../enums/organizationUserStatu
 import { PolicyType } from '../../../enums/policyType';
 import { SendType } from '../../../enums/sendType';
 
-import { ConsoleLogService } from '../../../services/consoleLog.service';
-
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
 import { MessagingService } from '../../../abstractions/messaging.service';
@@ -79,8 +77,7 @@ export class AddEditComponent implements OnInit {
     constructor(protected i18nService: I18nService, protected platformUtilsService: PlatformUtilsService,
         protected environmentService: EnvironmentService, protected datePipe: DatePipe,
         protected sendService: SendService, protected userService: UserService,
-        protected messagingService: MessagingService, protected policyService: PolicyService,
-        protected consoleLogService: ConsoleLogService) {
+        protected messagingService: MessagingService, protected policyService: PolicyService) {
         this.typeOptions = [
             { name: i18nService.t('sendTypeFile'), value: SendType.File },
             { name: i18nService.t('sendTypeText'), value: SendType.Text },

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -297,12 +297,12 @@ export class AddEditComponent implements OnInit {
             }
             if (this.nullOrWhiteSpaceCount([this.expirationDateFallback, this.expirationTimeFallback]) === 1) {
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-                    this.i18nService.t('expirationDateAndTimeRequired'));
+                    this.i18nService.t('dateAndTimeRequired'));
                 return;
             }
             if (this.editMode || this.expirationDateSelect === 0) {
                 this.expirationDate = this.expirationDateTimeFallback;
-            }
+            } 
         }
 
         if (this.disableSend) {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -11,6 +11,8 @@ import { OrganizationUserStatusType } from '../../../enums/organizationUserStatu
 import { PolicyType } from '../../../enums/policyType';
 import { SendType } from '../../../enums/sendType';
 
+import { ConsoleLogService } from '../../../services/consoleLog.service';
+
 import { EnvironmentService } from '../../../abstractions/environment.service';
 import { I18nService } from '../../../abstractions/i18n.service';
 import { MessagingService } from '../../../abstractions/messaging.service';
@@ -77,7 +79,8 @@ export class AddEditComponent implements OnInit {
     constructor(protected i18nService: I18nService, protected platformUtilsService: PlatformUtilsService,
         protected environmentService: EnvironmentService, protected datePipe: DatePipe,
         protected sendService: SendService, protected userService: UserService,
-        protected messagingService: MessagingService, protected policyService: PolicyService) {
+        protected messagingService: MessagingService, protected policyService: PolicyService,
+        protected consoleLogService: ConsoleLogService) {
         this.typeOptions = [
             { name: i18nService.t('sendTypeFile'), value: SendType.File },
             { name: i18nService.t('sendTypeText'), value: SendType.Text },


### PR DESCRIPTION
Found an issue with default formatting of the previous time value in Safari that was causing times like "17:00 PM" to display for the previous value. This PR addresses this by:

1. Moving the date option generation function to a protected method and checking it once: on load
2. Changing formatting of the time string from `HH:mm a` to `hh:mm a`.