### PR TITLE
set default expiration time on date input for Sends

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -353,6 +353,12 @@ export class AddEditComponent implements OnInit {
         this.showOptions = !this.showOptions;
     }
 
+    expirationDateFallbackChanged() {
+        this.isSafari ?
+            this.safariExpirationTime = this.safariExpirationTime ?? '00:00' :
+            this.expirationTimeFallback = this.expirationTimeFallback ?? this.datePipe.transform(new Date(), 'HH:mm');
+    }
+
     protected async loadSend(): Promise<Send> {
         return this.sendService.get(this.sendId);
     }
@@ -473,13 +479,13 @@ export class AddEditComponent implements OnInit {
 
         // determine if an unsupported value already exists on the send & add that to the top of the option list
         // example: if the Send was created with a different client
-        if (field === DateField.ExpriationDate && this.expirationDateTimeFallback != null) {
+        if (field === DateField.ExpriationDate && this.expirationDateTimeFallback != null && this.editMode) {
             const previousValue: TimeOption = {
                 standard: this.datePipe.transform(this.expirationDateTimeFallback, 'hh:mm a'),
                 military: this.datePipe.transform(this.expirationDateTimeFallback, 'HH:mm'),
             };
             return [previousValue, {standard: null, military: null}, ...validTimes];
-        } else if (field === DateField.DeletionDate && this.deletionDateTimeFallback != null) {
+        } else if (field === DateField.DeletionDate && this.deletionDateTimeFallback != null && this.editMode) {
             const previousValue: TimeOption = {
                 standard: this.datePipe.transform(this.deletionDateTimeFallback, 'hh:mm a'),
                 military: this.datePipe.transform(this.deletionDateTimeFallback, 'HH:mm'),


### PR DESCRIPTION
https://github.com/bitwarden/web/pull/879
https://github.com/bitwarden/browser/pull/1672

QA requested a few fix ups to the send date fallbacks.

1. The calendar popup for `<input type="date">` doesn't work in the Firefox browser plugin. This is for the same reason `<input type="file">` popups don't work, and has been handled in a similar way by adding some subtext telling users to pop out the extension to use the picker. The text based date input works as expected regardless of being in a popup or not.
2. Better error messages for input validation. Placeholders were created for messages in jslib but they didn't get added to clients.
3. We should auto populate `expirationTime` if `expirationDate` is set and no time is already present. Not doing so was causing confusion when trying to just set a date and click submit.  

The main point relevant to `jslib` is (3). This PR creates a function that clients can use to set time automatically when date is changed. It uses current time for Firefox, and midnight for Safari since we don't always have a select option for the exact current time.