### PR TITLE
Handle text response errors

### DIFF
--- a/src/cli/models/response.ts
+++ b/src/cli/models/response.ts
@@ -7,7 +7,8 @@ export class Response {
         if (typeof (error) === 'string') {
             res.message = error;
         } else {
-            res.message = error.message != null ? error.message : error.toString();
+            res.message = error.message != null ? error.message :
+                error.toString() === '[object Object]' ? JSON.stringify(error) : error.toString();
         }
         res.data = data;
         return res;

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1282,6 +1282,8 @@ export class ApiService implements ApiServiceAbstraction {
         let responseJson: any = null;
         if (this.isJsonResponse(response)) {
             responseJson = await response.json();
+        } else if (this.isTextResponse(response)) {
+            responseJson = {Message: await response.text()};
         }
 
         return new ErrorResponse(responseJson, response.status, tokenError);
@@ -1356,5 +1358,10 @@ export class ApiService implements ApiServiceAbstraction {
     private isJsonResponse(response: Response): boolean {
         const typeHeader = response.headers.get('content-type');
         return typeHeader != null && typeHeader.indexOf('application/json') > -1;
+    }
+
+    private isTextResponse(response: Response): boolean {
+        const typeHeader = response.headers.get('content-type');
+        return typeHeader != null && typeHeader.indexOf('text') > -1;
     }
 }


### PR DESCRIPTION
# Overview

Fix https://app.asana.com/0/1199659118818122/1200033242011053/f

Our proxy is blocking large file uploads with an text/html bodied error response. Handle those situations gracefully and never output [object Object] to CLI. Prefer serializing the error object for _some_ amount of information.

# File Changes
* **response.ts**: This file is used by CLIs to process a response for outputing to stdout. Do not allow output of `[object Object]`, it's not helpful. Prefer serialization in that case.
* **api.service**: Cloudflare is returning request too large information as status 413 with a text/html body. Handle that case in api.service error handling. This will return raw html, but it's better than nothing.

## TODO (post merge):
- [ ] update CLI jslib reference
- [ ] update directory-connector jslib reference 