### PR TITLE
Improve .fsk importer

### DIFF
--- a/spec/common/importers/fsecureFskImporter.spec.ts
+++ b/spec/common/importers/fsecureFskImporter.spec.ts
@@ -1,0 +1,92 @@
+import { FieldType } from '../../../src/enums/fieldType';
+import { FSecureFskImporter as Importer } from '../../../src/importers/fsecureFskImporter';
+
+import { Utils } from '../../../src/misc/utils';
+
+if (Utils.isNode) {
+    // Polyfills
+    // tslint:disable-next-line
+    const jsdom: any = require('jsdom');
+    (global as any).DOMParser = new jsdom.JSDOM().window.DOMParser;
+}
+
+const TestDataWithStyleSetToWebsite: string =
+    JSON.stringify({
+        data: {
+            "8d58b5cf252dd06fbd98f5289e918ab1":
+            {
+                color: "#00baff",
+                reatedDate: 1609302913,
+                creditCvv: "",
+                creditExpiry: "",
+                creditNumber: "",
+                favorite: 0,
+                modifiedDate: 1609302913,
+                notes: "note",
+                password: "word",
+                passwordList: [],
+                passwordModifiedDate: 1609302913,
+                rev: 1,
+                service: "My first pass",
+                style: "website",
+                type: 1,
+                url: "https://bitwarden.com",
+                username: "pass"
+            }
+        }
+    });
+
+    const TestDataWithStyleSetToGlobe: string =
+    JSON.stringify({
+        data: {
+            "8d58b5cf252dd06fbd98f5289e918ab1":
+            {
+                color: "#00baff",
+                reatedDate: 1609302913,
+                creditCvv: "",
+                creditExpiry: "",
+                creditNumber: "",
+                favorite: 0,
+                modifiedDate: 1609302913,
+                notes: "note",
+                password: "word",
+                passwordList: [],
+                passwordModifiedDate: 1609302913,
+                rev: 1,
+                service: "My first pass",
+                style: "globe",
+                type: 1,
+                url: "https://bitwarden.com",
+                username: "pass"
+            }
+        }
+    });
+
+
+describe('FSecure FSK Importer', () => {
+    it('should parse data with style set to website', async () => {
+        const importer = new Importer();
+        const result = await importer.parse(TestDataWithStyleSetToWebsite);
+        expect(result != null).toBe(true);
+
+        const cipher = result.ciphers.shift();
+        expect(cipher.login.username).toEqual('pass');
+        expect(cipher.login.password).toEqual('word');
+        expect(cipher.login.uris.length).toEqual(1);
+        const uriView = cipher.login.uris.shift();
+        expect(uriView.uri).toEqual('https://bitwarden.com');
+    });
+
+    it('should parse data with style set to globe', async () => {
+        const importer = new Importer();
+        const result = await importer.parse(TestDataWithStyleSetToGlobe);
+        expect(result != null).toBe(true);
+
+        const cipher = result.ciphers.shift();
+        expect(cipher.login.username).toEqual('pass');
+        expect(cipher.login.password).toEqual('word');
+        expect(cipher.login.uris.length).toEqual(1);
+        const uriView = cipher.login.uris.shift();
+        expect(uriView.uri).toEqual('https://bitwarden.com');
+    });
+});

--- a/src/importers/fsecureFskImporter.ts
+++ b/src/importers/fsecureFskImporter.ts
@@ -26,7 +26,7 @@ export class FSecureFskImporter extends BaseImporter implements Importer {
             cipher.name = this.getValueOrDefault(value.service);
             cipher.notes = this.getValueOrDefault(value.notes);
 
-            if (value.style === 'website') {
+            if (value.style === 'website' || value.style === 'globe') {
                 cipher.login.username = this.getValueOrDefault(value.username);
                 cipher.login.password = this.getValueOrDefault(value.password);
                 cipher.login.uris = this.makeUriArray(value.url);


### PR DESCRIPTION
Fixes bitwarden/web#756

Checks the style-property of a fsk-file and now supports 'website' and 'globe'

Created some tests for the primary scenarios (fsecureFskImporter), could obviously be extended.