### PR TITLE
Use UserService to determine if user has premium access

### DIFF
--- a/src/angular/components/premium.component.ts
+++ b/src/angular/components/premium.component.ts
@@ -4,6 +4,7 @@ import { ApiService } from '../../abstractions/api.service';
 import { I18nService } from '../../abstractions/i18n.service';
 import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { TokenService } from '../../abstractions/token.service';
+import { UserService } from '../../abstractions/user.service';
 
 export class PremiumComponent implements OnInit {
     isPremium: boolean = false;
@@ -11,10 +12,10 @@ export class PremiumComponent implements OnInit {
     refreshPromise: Promise<any>;
 
     constructor(protected i18nService: I18nService, protected platformUtilsService: PlatformUtilsService,
-        protected tokenService: TokenService, protected apiService: ApiService) { }
+        protected apiService: ApiService, protected userService: UserService) { }
 
     async ngOnInit() {
-        this.isPremium = this.tokenService.getPremium();
+        this.isPremium = await this.userService.canAccessPremium();
     }
 
     async refresh() {
@@ -22,7 +23,7 @@ export class PremiumComponent implements OnInit {
             this.refreshPromise = this.apiService.refreshIdentityToken();
             await this.refreshPromise;
             this.platformUtilsService.showToast('success', null, this.i18nService.t('refreshComplete'));
-            this.isPremium = this.tokenService.getPremium();
+            this.isPremium = await this.userService.canAccessPremium();
         } catch { }
     }
 


### PR DESCRIPTION
# Overview

Premium component is not detecting if a user has premium due to organizations. This updates the premium page of non-web clients to display that the user is already a premium member.

> **Note:** This behaves differently to Web, which tell you you have access already due to an org, but still displays the purchase form.

# Files Changed
* **premium.component.ts**: Use userService's `canAccessPremium` because that method correctly checks all organizations as well as the user's token.

# Screenshots
<img width="379" alt="image" src="https://user-images.githubusercontent.com/18214891/112228876-fba8d800-8bff-11eb-805f-3bf55b779614.png">
<img width="757" alt="image" src="https://user-images.githubusercontent.com/18214891/112228909-05324000-8c00-11eb-8089-0f889f96a76a.png">

# TODO:
[ ] Desktop PR
[ ] Browser PR
