### PR TITLE
Attachment azure upload blobs

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -1,6 +1,7 @@
 import { PolicyType } from '../enums/policyType';
 
 import { EnvironmentUrls } from '../models/domain/environmentUrls';
+import { AttachmentRequest } from '../models/request/attachmentRequest';
 
 import { BitPayInvoiceRequest } from '../models/request/bitPayInvoiceRequest';
 import { CipherBulkDeleteRequest } from '../models/request/cipherBulkDeleteRequest';
@@ -70,6 +71,8 @@ import { VerifyDeleteRecoverRequest } from '../models/request/verifyDeleteRecove
 import { VerifyEmailRequest } from '../models/request/verifyEmailRequest';
 
 import { ApiKeyResponse } from '../models/response/apiKeyResponse';
+import { AttachmentResponse } from '../models/response/attachmentResponse';
+import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { BillingResponse } from '../models/response/billingResponse';
 import { BreachAccountResponse } from '../models/response/breachAccountResponse';
 import { CipherResponse } from '../models/response/cipherResponse';
@@ -193,6 +196,7 @@ export abstract class ApiService {
 
     getCipher: (id: string) => Promise<CipherResponse>;
     getCipherAdmin: (id: string) => Promise<CipherResponse>;
+    getAttachmentData: (cipherId: string, attachmentId: string, emergencyAccessId?: string) => Promise<AttachmentResponse>;
     getCiphersOrganization: (organizationId: string) => Promise<ListResponse<CipherResponse>>;
     postCipher: (request: CipherRequest) => Promise<CipherResponse>;
     postCipherCreate: (request: CipherCreateRequest) => Promise<CipherResponse>;
@@ -221,10 +225,13 @@ export abstract class ApiService {
 
     postCipherAttachment: (id: string, data: FormData) => Promise<CipherResponse>;
     postCipherAttachmentAdmin: (id: string, data: FormData) => Promise<CipherResponse>;
+    postCipherAttachmentV2: (id: string, request: AttachmentRequest) => Promise<AttachmentUploadDataResponse>;
     deleteCipherAttachment: (id: string, attachmentId: string) => Promise<any>;
     deleteCipherAttachmentAdmin: (id: string, attachmentId: string) => Promise<any>;
     postShareCipherAttachment: (id: string, attachmentId: string, data: FormData,
         organizationId: string) => Promise<any>;
+    renewAttachmentUploadUrl: (id: string, attachmentId: string) => Promise<AttachmentUploadDataResponse>;
+    postAttachmentFile: (id: string, attachmentId: string, data: FormData) => Promise<any>;
 
     getCollectionDetails: (organizationId: string, id: string) => Promise<CollectionGroupDetailsResponse>;
     getUserCollections: () => Promise<ListResponse<CollectionResponse>>;

--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -223,9 +223,17 @@ export abstract class ApiService {
     putRestoreCipherAdmin: (id: string) => Promise<CipherResponse>;
     putRestoreManyCiphers: (request: CipherBulkRestoreRequest) => Promise<ListResponse<CipherResponse>>;
 
-    postCipherAttachment: (id: string, data: FormData) => Promise<CipherResponse>;
-    postCipherAttachmentAdmin: (id: string, data: FormData) => Promise<CipherResponse>;
-    postCipherAttachmentV2: (id: string, request: AttachmentRequest) => Promise<AttachmentUploadDataResponse>;
+    /**
+     * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
+     * This method still exists for backward compatibility with old server versions.
+     */
+    postCipherAttachmentLegacy: (id: string, data: FormData) => Promise<CipherResponse>;
+    /**
+     * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
+     * This method still exists for backward compatibility with old server versions.
+     */
+    postCipherAttachmentAdminLegacy: (id: string, data: FormData) => Promise<CipherResponse>;
+    postCipherAttachment: (id: string, request: AttachmentRequest) => Promise<AttachmentUploadDataResponse>;
     deleteCipherAttachment: (id: string, attachmentId: string) => Promise<any>;
     deleteCipherAttachmentAdmin: (id: string, attachmentId: string) => Promise<any>;
     postShareCipherAttachment: (id: string, attachmentId: string, data: FormData,

--- a/src/abstractions/fileUpload.service.ts
+++ b/src/abstractions/fileUpload.service.ts
@@ -1,7 +1,10 @@
 import { CipherString } from '../models/domain';
+import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 
 export abstract class FileUploadService {
     uploadSendFile: (uploadData: SendFileUploadDataResponse, fileName: CipherString,
+        encryptedFileData: ArrayBuffer) => Promise<any>;
+    uploadCipherAttachment: (admin: boolean, uploadData: AttachmentUploadDataResponse, fileName: string,
         encryptedFileData: ArrayBuffer) => Promise<any>;
 }

--- a/src/angular/components/attachments.component.ts
+++ b/src/angular/components/attachments.component.ts
@@ -136,7 +136,7 @@ export class AttachmentsComponent implements OnInit {
         }
 
         a.downloading = true;
-        let response = await fetch(new Request(url, { cache: 'no-store' }));
+        const response = await fetch(new Request(url, { cache: 'no-store' }));
         if (response.status !== 200) {
             this.platformUtilsService.showToast('error', null, this.i18nService.t('errorOccurred'));
             a.downloading = false;

--- a/src/angular/components/attachments.component.ts
+++ b/src/angular/components/attachments.component.ts
@@ -128,6 +128,10 @@ export class AttachmentsComponent implements OnInit {
         } catch (e) {
             if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404) {
                 url = attachment.url;
+            } else if (e instanceof ErrorResponse) {
+                throw new Error((e as ErrorResponse).getSingleMessage());
+            } else {
+                throw e;
             }
         }
 

--- a/src/models/request/attachmentRequest.ts
+++ b/src/models/request/attachmentRequest.ts
@@ -1,4 +1,6 @@
 export class AttachmentRequest {
     fileName: string;
     key: string;
+    fileSize: number;
+    adminRequest: boolean;
 }

--- a/src/models/response/attachmentUploadDataResponse.ts
+++ b/src/models/response/attachmentUploadDataResponse.ts
@@ -1,0 +1,20 @@
+import { FileUploadType } from '../../enums/fileUploadType';
+import { BaseResponse } from './baseResponse';
+import { CipherResponse } from './cipherResponse';
+
+export class AttachmentUploadDataResponse extends BaseResponse {
+    attachmentId: string;
+    fileUploadType: FileUploadType;
+    cipherResponse: CipherResponse;
+    cipherMiniResponse: CipherResponse;
+    url: string = null;
+    constructor(response: any) {
+        super(response);
+        this.attachmentId = this.getResponseProperty('AttachmentId');
+        this.fileUploadType = this.getResponseProperty('FileUploadType');
+        this.cipherResponse = this.getResponseProperty('CipherResponse');
+        this.cipherMiniResponse = this.getResponseProperty('CipherMiniResponse');
+        this.url = this.getResponseProperty('Url');
+    }
+
+}

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -7,6 +7,7 @@ import { TokenService } from '../abstractions/token.service';
 
 import { EnvironmentUrls } from '../models/domain/environmentUrls';
 
+import { AttachmentRequest } from '../models/request/attachmentRequest';
 import { BitPayInvoiceRequest } from '../models/request/bitPayInvoiceRequest';
 import { CipherBulkDeleteRequest } from '../models/request/cipherBulkDeleteRequest';
 import { CipherBulkMoveRequest } from '../models/request/cipherBulkMoveRequest';
@@ -51,7 +52,6 @@ import { PreloginRequest } from '../models/request/preloginRequest';
 import { RegisterRequest } from '../models/request/registerRequest';
 import { SeatRequest } from '../models/request/seatRequest';
 import { SelectionReadOnlyRequest } from '../models/request/selectionReadOnlyRequest';
-import { AttachmentRequest } from '../models/request/attachmentRequest';
 import { SendAccessRequest } from '../models/request/sendAccessRequest';
 import { SendRequest } from '../models/request/sendRequest';
 import { SetPasswordRequest } from '../models/request/setPasswordRequest';
@@ -77,6 +77,7 @@ import { VerifyEmailRequest } from '../models/request/verifyEmailRequest';
 import { Utils } from '../misc/utils';
 import { ApiKeyResponse } from '../models/response/apiKeyResponse';
 import { AttachmentResponse } from '../models/response/attachmentResponse';
+import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { BillingResponse } from '../models/response/billingResponse';
 import { BreachAccountResponse } from '../models/response/breachAccountResponse';
 import { CipherResponse } from '../models/response/cipherResponse';
@@ -130,17 +131,15 @@ import { TwoFactorWebAuthnResponse } from '../models/response/twoFactorWebAuthnR
 import { ChallengeResponse } from '../models/response/twoFactorWebAuthnResponse';
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
-import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 
 import { SendAccessView } from '../models/view/sendAccessView';
-import { cipher } from 'node-forge';
 
 export class ApiService implements ApiServiceAbstraction {
     urlsSet: boolean = false;
     apiBaseUrl: string;
     identityBaseUrl: string;
     eventsBaseUrl: string;
-    
+
     private device: DeviceType;
     private deviceType: string;
     private isWebClient = false;
@@ -612,17 +611,25 @@ export class ApiService implements ApiServiceAbstraction {
         return new AttachmentResponse(r);
     }
 
-    async postCipherAttachmentV2(id: string, request: AttachmentRequest): Promise<AttachmentUploadDataResponse> {
+    async postCipherAttachment(id: string, request: AttachmentRequest): Promise<AttachmentUploadDataResponse> {
         const r = await this.send('POST', '/ciphers/' + id + '/attachment/v2', request, true, true);
         return new AttachmentUploadDataResponse(r);
     }
 
-    async postCipherAttachment(id: string, data: FormData): Promise<CipherResponse> {
+    /**
+     * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
+     * This method still exists for backward compatibility with old server versions.
+     */
+    async postCipherAttachmentLegacy(id: string, data: FormData): Promise<CipherResponse> {
         const r = await this.send('POST', '/ciphers/' + id + '/attachment', data, true, true);
         return new CipherResponse(r);
     }
 
-    async postCipherAttachmentAdmin(id: string, data: FormData): Promise<CipherResponse> {
+    /**
+     * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
+     * This method still exists for backward compatibility with old server versions.
+     */
+    async postCipherAttachmentAdminLegacy(id: string, data: FormData): Promise<CipherResponse> {
         const r = await this.send('POST', '/ciphers/' + id + '/attachment-admin', data, true, true);
         return new CipherResponse(r);
     }

--- a/src/services/azureFileUpload.service.ts
+++ b/src/services/azureFileUpload.service.ts
@@ -32,6 +32,10 @@ export class AzureFileUploadService {
         });
 
         const blobResponse = await fetch(request);
+
+        if (blobResponse.status !== 201) {
+            throw new Error(`Failed to create Azure blob: ${blobResponse.status}`)
+        }
     }
     private async azureUploadBlocks(url: string, data: ArrayBuffer, renewalCallback: () => Promise<string>) {
         const baseUrl = Utils.getUrl(url);

--- a/src/services/azureFileUpload.service.ts
+++ b/src/services/azureFileUpload.service.ts
@@ -34,7 +34,7 @@ export class AzureFileUploadService {
         const blobResponse = await fetch(request);
 
         if (blobResponse.status !== 201) {
-            throw new Error(`Failed to create Azure blob: ${blobResponse.status}`)
+            throw new Error(`Failed to create Azure blob: ${blobResponse.status}`);
         }
     }
     private async azureUploadBlocks(url: string, data: ArrayBuffer, renewalCallback: () => Promise<string>) {

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -40,6 +40,7 @@ import { SortedCiphersCache } from '../models/domain/sortedCiphersCache';
 import { ApiService } from '../abstractions/api.service';
 import { CipherService as CipherServiceAbstraction } from '../abstractions/cipher.service';
 import { CryptoService } from '../abstractions/crypto.service';
+import { FileUploadService } from '../abstractions/fileUpload.service';
 import { I18nService } from '../abstractions/i18n.service';
 import { SearchService } from '../abstractions/search.service';
 import { SettingsService } from '../abstractions/settings.service';
@@ -51,8 +52,6 @@ import { ConstantsService } from './constants.service';
 import { sequentialize } from '../misc/sequentialize';
 import { Utils } from '../misc/utils';
 import { AttachmentRequest } from '../models/request/attachmentRequest';
-import { FileUploadType } from '../enums/fileUploadType';
-import { AzureStorageService } from '../abstractions/azureStorage.service';
 
 const Keys = {
     ciphersPrefix: 'ciphers_',
@@ -72,9 +71,8 @@ export class CipherService implements CipherServiceAbstraction {
 
     constructor(private cryptoService: CryptoService, private userService: UserService,
         private settingsService: SettingsService, private apiService: ApiService,
-        private storageService: StorageService, private i18nService: I18nService,
-        private azureStorageService: AzureStorageService,
-        private searchService: () => SearchService) {
+        private fileUploadService: FileUploadService, private storageService: StorageService,
+        private i18nService: I18nService, private searchService: () => SearchService) {
     }
 
     get decryptedCipherCache() {
@@ -628,32 +626,20 @@ export class CipherService implements CipherServiceAbstraction {
             fileSize: encData.byteLength,
             adminRequest: admin,
         };
-        const uploadDataResponse = await this.apiService.postCipherAttachmentV2(cipher.id, request);
-        const response = admin ? uploadDataResponse.cipherMiniResponse : uploadDataResponse.cipherResponse;
 
+        let response: CipherResponse;
         try {
-            switch (uploadDataResponse.fileUploadType) {
-                case FileUploadType.Direct:
-                    this.directUploadFileToServer(response.id, uploadDataResponse.attachmentId, encFileName, encData);
-                    break;
-                case FileUploadType.Azure:
-                    const renewalCallback = async () => {
-                        const renewalResponse = await this.apiService.renewAttachmentUploadUrl(response.id,
-                            uploadDataResponse.attachmentId);
-                        return renewalResponse.url;
-                    };
-                    this.azureStorageService.uploadFileToServer(uploadDataResponse.url, encData, renewalCallback);
-                    break;
-                default:
-                    throw new Error('Unknown file upload type.');
-            }
+            const uploadDataResponse = await this.apiService.postCipherAttachment(cipher.id, request);
+            response = admin ? uploadDataResponse.cipherMiniResponse : uploadDataResponse.cipherResponse;
+            this.fileUploadService.uploadCipherAttachment(admin, uploadDataResponse, filename, data);
         } catch (e) {
-            if (admin) {
-                this.apiService.deleteCipherAttachmentAdmin(cipher.id, uploadDataResponse.attachmentId);
+            if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404 || (e as ErrorResponse).statusCode == 405) {
+                response = await this.legacyServerAttachmentFileUpload(admin, cipher.id, encFileName, encData, dataEncKey[1]);
+            } else if (e instanceof ErrorResponse) {
+                throw new Error((e as ErrorResponse).getSingleMessage());
             } else {
-                this.apiService.deleteCipherAttachment(cipher.id, uploadDataResponse.attachmentId);
+                throw e;
             }
-            throw e;
         }
 
         const userId = await this.userService.getUserId();
@@ -662,6 +648,43 @@ export class CipherService implements CipherServiceAbstraction {
             await this.upsert(cData);
         }
         return new Cipher(cData);
+    }
+
+    /**
+     * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
+     * This method still exists for backward compatibility with old server versions.
+     */
+    async legacyServerAttachmentFileUpload(admin: boolean, cipherId: string, encFileName: CipherString,
+        encData: ArrayBuffer, key: CipherString) {
+        const fd = new FormData();
+        try {
+            const blob = new Blob([encData], { type: 'application/octet-stream' });
+            fd.append('key', key.encryptedString);
+            fd.append('data', blob, encFileName.encryptedString);
+        } catch (e) {
+            if (Utils.isNode && !Utils.isBrowser) {
+                fd.append('key', key.encryptedString);
+                fd.append('data', Buffer.from(encData) as any, {
+                    filepath: encFileName.encryptedString,
+                    contentType: 'application/octet-stream',
+                } as any);
+            } else {
+                throw e;
+            }
+        }
+
+        let response: CipherResponse;
+        try {
+            if (admin) {
+                response = await this.apiService.postCipherAttachmentAdminLegacy(cipherId, fd);
+            } else {
+                response = await this.apiService.postCipherAttachmentLegacy(cipherId, fd);
+            }
+        } catch (e) {
+            throw new Error((e as ErrorResponse).getSingleMessage());
+        }
+
+        return response;
     }
 
     async saveCollectionsWithServer(cipher: Cipher): Promise<any> {
@@ -1078,29 +1101,6 @@ export class CipherService implements CipherServiceAbstraction {
             return this.sortedCiphersCache.getLastUsed(url);
         } else {
             return this.sortedCiphersCache.getNext(url);
-        }
-    }
-
-    private async directUploadFileToServer(cipherId: string, attachmentId: string, encFileName: CipherString, encData: ArrayBuffer) {
-        const fd = new FormData();
-        try {
-            const blob = new Blob([encData], { type: 'application/octet-stream' });
-            fd.append('data', blob, encFileName.encryptedString);
-        } catch (e) {
-            if (Utils.isNode && !Utils.isBrowser) {
-                fd.append('data', Buffer.from(encData) as any, {
-                    filepath: encFileName.encryptedString,
-                    contentType: 'application/octet-stream',
-                } as any);
-            } else {
-                throw e;
-            }
-        }
-
-        try {
-            await this.apiService.postAttachmentFile(cipherId, attachmentId, fd)
-        } catch (e) {
-            throw new Error((e as ErrorResponse).getSingleMessage());
         }
     }
 }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -633,7 +633,7 @@ export class CipherService implements CipherServiceAbstraction {
             response = admin ? uploadDataResponse.cipherMiniResponse : uploadDataResponse.cipherResponse;
             this.fileUploadService.uploadCipherAttachment(admin, uploadDataResponse, filename, data);
         } catch (e) {
-            if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404 || (e as ErrorResponse).statusCode == 405) {
+            if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404 || (e as ErrorResponse).statusCode === 405) {
                 response = await this.legacyServerAttachmentFileUpload(admin, cipher.id, encFileName, encData, dataEncKey[1]);
             } else if (e instanceof ErrorResponse) {
                 throw new Error((e as ErrorResponse).getSingleMessage());

--- a/src/services/fileUpload.service.ts
+++ b/src/services/fileUpload.service.ts
@@ -5,6 +5,7 @@ import { LogService } from '../abstractions/log.service';
 import { FileUploadType } from '../enums/fileUploadType';
 
 import { CipherString } from '../models/domain';
+import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 
 import { AzureFileUploadService } from './azureFileUpload.service';
@@ -23,7 +24,8 @@ export class FileUploadService implements FileUploadServiceAbstraction {
         try {
             switch (uploadData.fileUploadType) {
                 case FileUploadType.Direct:
-                    await this.bitwardenFileUploadService.upload(uploadData.sendResponse, fileName, encryptedFileData);
+                    await this.bitwardenFileUploadService.upload(fileName.encryptedString, encryptedFileData,
+                        fd => this.apiService.postSendFile(uploadData.sendResponse.id, uploadData.sendResponse.file.id, fd));
                     break;
                 case FileUploadType.Azure:
                     const renewalCallback = async () => {
@@ -39,6 +41,35 @@ export class FileUploadService implements FileUploadServiceAbstraction {
             }
         } catch (e) {
             this.apiService.deleteSend(uploadData.sendResponse.id);
+            throw e;
+        }
+    }
+
+    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: string, encryptedFileData: ArrayBuffer) {
+        const response = admin ? uploadData.cipherMiniResponse : uploadData.cipherResponse;
+        try {
+            switch (uploadData.fileUploadType) {
+                case FileUploadType.Direct:
+                    await this.bitwardenFileUploadService.upload(encryptedFileName, encryptedFileData,
+                        fd => this.apiService.postAttachmentFile(response.id, uploadData.attachmentId, fd));
+                    break;
+                case FileUploadType.Azure:
+                    const renewalCallback = async () => {
+                        const renewalResponse = await this.apiService.renewAttachmentUploadUrl(response.id,
+                            uploadData.attachmentId);
+                        return renewalResponse.url;
+                    };
+                    this.azureFileUploadService.upload(uploadData.url, encryptedFileData, renewalCallback);
+                    break;
+                default:
+                    throw new Error('Unknown file upload type.');
+            }
+        } catch (e) {
+            if (admin) {
+                this.apiService.deleteCipherAttachmentAdmin(response.id, uploadData.attachmentId);
+            } else {
+                this.apiService.deleteCipherAttachment(response.id, uploadData.attachmentId);
+            }
             throw e;
         }
     }

--- a/src/services/send.service.ts
+++ b/src/services/send.service.ts
@@ -145,6 +145,8 @@ export class SendService implements SendServiceAbstraction {
                 } catch (e) {
                     if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404) {
                         response = await this.legacyServerSendFileUpload(sendData, request);
+                    } else if (e instanceof ErrorResponse) {
+                        throw new Error((e as ErrorResponse).getSingleMessage());
                     } else {
                         throw e;
                     }


### PR DESCRIPTION
# Overview

Enable direct-to-azure upload of cipher attachment items. Similar PR to #296.

# Files Changed
* **api.service**: Deprecate old attachment upload methods and include required methods for direct upload
* **fileUpload.service.ts**: Add attachment upload method
* **attachment.component.ts**: Grab url from new api endpoints. Fallback to old if not available. Upgrade limit to 500MB
* **AttachmentRequest**: Match new Server models
* **AttachmentUploadDataResponse**: Response model containing upload information for attachments. Two cipher types are for organization vs personal attachment uploads
* **azureFileUploadService**: Improve error handling
* **bitwardenFileUploadService**: Generalize upload of a file to bitwarden. Now accepts and api callback to actual upload the form data.
* **cipherService**: Upload attachments directly to storage endpoint. fallback to legacy file upload method
* **sendService**: Improve error handling.

# Testing

Testing burden on this is fairly large. We need to test attachment upload and download in
1. personal vault context
2. organization context
3. emergency access context

for attachments uploaded against all combinations of old/new web/server.
>Note: New web attachment uploads, which were uploaded on new server versions are incompatible with old server versions. This shouldn't come up in the wild unless someone downgrades their server.