### PR TITLE
Check file size client side

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -270,6 +270,11 @@ export class AddEditComponent implements OnInit {
             }
 
             file = files[0];
+            if (files[0].size > 524288000) { // 500 MB
+                this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                    this.i18nService.t('maxFileSize'));
+                return;
+            }
         }
 
         if (!this.editMode) {


### PR DESCRIPTION
# Overview

I removed max size check in #296, but we decided to maintain a 500MB max upload for now (pending legitimate examples for greater need).

This puts the server side check back and ups it to the current 500 MB

# Files Changed
* **add-edit.component.ts**: client side check on save.