### PR TITLE
[Reset Password] Enrollment API, event type, and models update

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -37,6 +37,7 @@ import { OrganizationUpgradeRequest } from '../models/request/organizationUpgrad
 import { OrganizationUserAcceptRequest } from '../models/request/organizationUserAcceptRequest';
 import { OrganizationUserConfirmRequest } from '../models/request/organizationUserConfirmRequest';
 import { OrganizationUserInviteRequest } from '../models/request/organizationUserInviteRequest';
+import { OrganizationUserResetPasswordEnrollmentRequest } from '../models/request/organizationUserResetPasswordEnrollmentRequest';
 import { OrganizationUserUpdateGroupsRequest } from '../models/request/organizationUserUpdateGroupsRequest';
 import { OrganizationUserUpdateRequest } from '../models/request/organizationUserUpdateRequest';
 import { PasswordHintRequest } from '../models/request/passwordHintRequest';
@@ -278,6 +279,8 @@ export abstract class ApiService {
     putOrganizationUser: (organizationId: string, id: string, request: OrganizationUserUpdateRequest) => Promise<any>;
     putOrganizationUserGroups: (organizationId: string, id: string,
         request: OrganizationUserUpdateGroupsRequest) => Promise<any>;
+    putOrganizationUserResetPasswordEnrollment: (organizationId: string, userId: string,
+        request: OrganizationUserResetPasswordEnrollmentRequest) => Promise<any>;
     deleteOrganizationUser: (organizationId: string, id: string) => Promise<any>;
 
     getSync: () => Promise<SyncResponse>;

--- a/src/enums/eventType.ts
+++ b/src/enums/eventType.ts
@@ -40,6 +40,8 @@ export enum EventType {
     OrganizationUser_Removed = 1503,
     OrganizationUser_UpdatedGroups = 1504,
     OrganizationUser_UnlinkedSso = 1505,
+    OrganizationUser_ResetPassword_Enroll = 1506,
+    OrganizationUser_ResetPassword_Withdraw = 1507,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,

--- a/src/models/data/organizationData.ts
+++ b/src/models/data/organizationData.ts
@@ -27,6 +27,8 @@ export class OrganizationData {
     ssoBound: boolean;
     identifier: string;
     permissions: PermissionsApi;
+    resetPasswordKey: string;
+    userId: string;
 
     constructor(response: ProfileOrganizationResponse) {
         this.id = response.id;
@@ -51,5 +53,7 @@ export class OrganizationData {
         this.ssoBound = response.ssoBound;
         this.identifier = response.identifier;
         this.permissions = response.permissions;
+        this.resetPasswordKey = response.resetPasswordKey;
+        this.userId = response.userId;
     }
 }

--- a/src/models/domain/organization.ts
+++ b/src/models/domain/organization.ts
@@ -28,6 +28,8 @@ export class Organization {
     ssoBound: boolean;
     identifier: string;
     permissions: PermissionsApi;
+    resetPasswordKey: string;
+    userId: string;
 
     constructor(obj?: OrganizationData) {
         if (obj == null) {
@@ -56,6 +58,8 @@ export class Organization {
         this.ssoBound = obj.ssoBound;
         this.identifier = obj.identifier;
         this.permissions = obj.permissions;
+        this.resetPasswordKey = obj.resetPasswordKey;
+        this.userId = obj.userId;
     }
 
     get canAccess() {
@@ -116,5 +120,9 @@ export class Organization {
 
     get canManageUsers() {
         return this.isAdmin || this.permissions.manageUsers;
+    }
+
+    get isResetPasswordEnrolled() {
+        return this.resetPasswordKey != null;
     }
 }

--- a/src/models/request/organizationUserResetPasswordEnrollmentRequest.ts
+++ b/src/models/request/organizationUserResetPasswordEnrollmentRequest.ts
@@ -1,0 +1,3 @@
+export class OrganizationUserResetPasswordEnrollmentRequest {
+    resetPasswordKey: string;
+}

--- a/src/models/response/profileOrganizationResponse.ts
+++ b/src/models/response/profileOrganizationResponse.ts
@@ -28,6 +28,8 @@ export class ProfileOrganizationResponse extends BaseResponse {
     ssoBound: boolean;
     identifier: string;
     permissions: PermissionsApi;
+    resetPasswordKey: string;
+    userId: string;
 
     constructor(response: any) {
         super(response);
@@ -54,5 +56,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
         this.ssoBound = this.getResponseProperty('SsoBound');
         this.identifier = this.getResponseProperty('Identifier');
         this.permissions = new PermissionsApi(this.getResponseProperty('permissions'));
+        this.resetPasswordKey = this.getResponseProperty('ResetPasswordKey');
+        this.userId = this.getResponseProperty('UserId');
     }
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -41,6 +41,7 @@ import { OrganizationUpgradeRequest } from '../models/request/organizationUpgrad
 import { OrganizationUserAcceptRequest } from '../models/request/organizationUserAcceptRequest';
 import { OrganizationUserConfirmRequest } from '../models/request/organizationUserConfirmRequest';
 import { OrganizationUserInviteRequest } from '../models/request/organizationUserInviteRequest';
+import { OrganizationUserResetPasswordEnrollmentRequest } from '../models/request/organizationUserResetPasswordEnrollmentRequest';
 import { OrganizationUserUpdateGroupsRequest } from '../models/request/organizationUserUpdateGroupsRequest';
 import { OrganizationUserUpdateRequest } from '../models/request/organizationUserUpdateRequest';
 import { PasswordHintRequest } from '../models/request/passwordHintRequest';
@@ -820,6 +821,12 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('PUT', '/organizations/' + organizationId + '/users/' + id + '/groups', request, true, false);
     }
 
+    putOrganizationUserResetPasswordEnrollment(organizationId: string, userId: string,
+        request: OrganizationUserResetPasswordEnrollmentRequest): Promise<any> {
+        return this.send('PUT', '/organizations/' + organizationId + '/users/' + userId + '/reset-password-enrollment',
+            request, true, false);
+    }
+
     deleteOrganizationUser(organizationId: string, id: string): Promise<any> {
         return this.send('DELETE', '/organizations/' + organizationId + '/users/' + id, null, true, false);
     }
@@ -1347,7 +1354,7 @@ export class ApiService implements ApiServiceAbstraction {
         if (this.isJsonResponse(response)) {
             responseJson = await response.json();
         } else if (this.isTextResponse(response)) {
-            responseJson = {Message: await response.text()};
+            responseJson = { Message: await response.text() };
         }
 
         return new ErrorResponse(responseJson, response.status, tokenError);


### PR DESCRIPTION
## Objective
> Create the `ResetPasswordEnrollment` API that will set an Organization User's `ResetPasswordKey`.  

## Code Changes
- **api.service/abstraction**: Created `putOrganizationUserResetPasswordEnrollment` API
- **eventType**: Added `OrganizationUser_ResetPassword_Enroll` and `OrganizationUser_ResetPassword_Withdraw` enums
- **organizationData**: Added `ResetPasswordKey` and `UserId`
- **organization**: Added `ResetPasswordKey` and `UserId`. Added helper method `isResetPasswordEnrolled`
-  **organizationUserResetPasswordEnrollmentRequest**: Created new request that has the `ResetPasswordKey`
- **profileOrganizationResponse**: Added `ResetPasswordKey` and `UserId`
