### PR TITLE
Fix post attachment file path

### DIFF
--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -654,7 +654,7 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     postAttachmentFile(id: string, attachmentId: string, data: FormData): Promise<any> {
-        return this.send('POST', '/ciphers/' + id + '/attachment/' + attachmentId + '/renew', data, true, false);
+        return this.send('POST', '/ciphers/' + id + '/attachment/' + attachmentId, data, true, false);
     }
 
     // Collections APIs


### PR DESCRIPTION
# Overview

The path for uploading an attachment file to a Bitwarden server was wrong. It shouldn't include `renew` in the path.

>Note: I have a PR on server (bitwarden/server#1229) to remove the `renew` string from the renew url path in order to match Send's controller paths

# Files Changed
* **api.service.ts**: correct the path.