### PR TITLE
Pass ciphers to index and indexed ciphers to search service

### DIFF
--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -4,7 +4,7 @@ import { SendView } from '../models/view/sendView';
 export abstract class SearchService {
     clearIndex: () => void;
     isSearchable: (query: string) => boolean;
-    indexCiphers: () => Promise<void>;
+    indexCiphers: (ciphersToIndex?: CipherView[]) => Promise<void>;
     searchCiphers: (query: string,
         filter?: ((cipher: CipherView) => boolean) | (((cipher: CipherView) => boolean)[]),
         ciphers?: CipherView[]) => Promise<CipherView[]>;

--- a/src/angular/components/ciphers.component.ts
+++ b/src/angular/components/ciphers.component.ts
@@ -77,20 +77,20 @@ export class CiphersComponent {
         await this.search(null);
     }
 
-    async search(timeout: number = null) {
+    async search(timeout: number = null, indexedCiphers?: CipherView[]) {
         this.searchPending = false;
         if (this.searchTimeout != null) {
             clearTimeout(this.searchTimeout);
         }
         const deletedFilter: (cipher: CipherView) => boolean = c => c.isDeleted === this.deleted;
         if (timeout == null) {
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, [this.filter, deletedFilter], null);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, [this.filter, deletedFilter], indexedCiphers);
             await this.resetPaging();
             return;
         }
         this.searchPending = true;
         this.searchTimeout = setTimeout(async () => {
-            this.ciphers = await this.searchService.searchCiphers(this.searchText, [this.filter, deletedFilter], null);
+            this.ciphers = await this.searchService.searchCiphers(this.searchText, [this.filter, deletedFilter], indexedCiphers);
             await this.resetPaging();
             this.searchPending = false;
         }, timeout);

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -28,7 +28,7 @@ export class SearchService implements SearchServiceAbstraction {
         return !notSearchable;
     }
 
-    async indexCiphers(): Promise<void> {
+    async indexCiphers(ciphers?: CipherView[]): Promise<void> {
         if (this.indexing) {
             return;
         }
@@ -60,7 +60,7 @@ export class SearchService implements SearchServiceAbstraction {
         builder.field('attachments_joined',
             { extractor: (c: CipherView) => this.attachmentExtractor(c, true) });
         builder.field('organizationid', { extractor: (c: CipherView) => c.organizationId });
-        const ciphers = await this.cipherService.getAllDecrypted();
+        ciphers = ciphers || await this.cipherService.getAllDecrypted();
         ciphers.forEach(c => builder.add(c));
         this.index = builder.build();
         this.indexing = false;


### PR DESCRIPTION
# Overview

jslib changes for: https://app.asana.com/0/1169444489336079/1183168049159854/f

This expands organization searches to allow for advanced search functionality the same as in personal vault.

# Files Changed
* **search.service.ts**: indexCiphers method optionally takes a list of ciphers to index. Organization view will pass all organization ciphers to this method on load in order to index only the organization's ciphers
* **ciphers.component.ts**: optionally pass ciphers to search. Organization view will pass the organizations ciphers to this search method
* **search.service.ts**: optionally take ciphers to search. Defaults to all ciphers from cipherService like normal.
