### PR TITLE
Add collections to ciphers in export model.

### DIFF
--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -15,6 +15,7 @@ export class Cipher {
     static template(): Cipher {
         const req = new Cipher();
         req.organizationId = null;
+        req.collectionIds = null;
         req.folderId = null;
         req.type = CipherType.Login;
         req.name = 'Item name';
@@ -33,6 +34,10 @@ export class Cipher {
         view.folderId = req.folderId;
         if (view.organizationId == null) {
             view.organizationId = req.organizationId;
+        }
+        if (view.collectionIds || req.collectionIds) {
+            var set = new Set((view.collectionIds ?? []).concat(req.collectionIds ?? []));
+            view.collectionIds = [...set];
         }
         view.name = req.name;
         view.notes = req.notes;
@@ -95,6 +100,7 @@ export class Cipher {
     type: CipherType;
     folderId: string;
     organizationId: string;
+    collectionIds: string[];
     name: string;
     notes: string;
     favorite: boolean;

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -36,7 +36,7 @@ export class Cipher {
             view.organizationId = req.organizationId;
         }
         if (view.collectionIds || req.collectionIds) {
-            var set = new Set((view.collectionIds ?? []).concat(req.collectionIds ?? []));
+            const set = new Set((view.collectionIds ?? []).concat(req.collectionIds ?? []));
             view.collectionIds = [...set];
         }
         view.name = req.name;


### PR DESCRIPTION
# Overview 

This enables immediately setting collections from the CLI on create. Specifying a collection that does not exist will still create the item, but associate with no collection.

The other location this code is used is on import of Bitwarden json data. However, collectionId is explicitly nulled out here to be resolved later at the server level.

# TODO

- [x] Server PR to error on specifying a collection which doesn't exist
- [ ] update CLI jslib reference

# Testing

1. Create cipher with organization and collenctionid specified from CLI:
 ```
node bw.js get template item | jq '.organizationId="<<orgID>" | .name="NEW LOGIN ITEM" | .login.username="TestUser" | .login.password="Password123" | .login.uris=[{uri:"https://vault.bitwarden.com"}] | .collectionIds=["<<collectionId that exists>>"]' | node bw.js encode | node bw.js create item
```
  * expect success with cipher created and asociated with the specified collection -- depends on merging CLI changes
2. Create cipher with organization and collenctionid that that doesn't exist specified from CLI:
 ```
node bw.js get template item | jq '.organizationId="<<orgID>" | .name="NEW LOGIN ITEM" | .login.username="TestUser" | .login.password="Password123" | .login.uris=[{uri:"https://vault.bitwarden.com"}] | .collectionIds=["<<collectionId that doesn't exist>>"]' | node bw.js encode | node bw.js create item
```
  * expect failure -- depends on merging in server and CLI changes
  * If server is not updated, expect success with resulting cipher belonging to the organization but associated with no collections.
3. Import regression testing of Bitwarden files, since this code is shared with the bitwarden Importer