### PR TITLE
Deep parse models

### DIFF
--- a/src/models/response/attachmentUploadDataResponse.ts
+++ b/src/models/response/attachmentUploadDataResponse.ts
@@ -12,8 +12,10 @@ export class AttachmentUploadDataResponse extends BaseResponse {
         super(response);
         this.attachmentId = this.getResponseProperty('AttachmentId');
         this.fileUploadType = this.getResponseProperty('FileUploadType');
-        this.cipherResponse = this.getResponseProperty('CipherResponse');
-        this.cipherMiniResponse = this.getResponseProperty('CipherMiniResponse');
+        const cipherResponse = this.getResponseProperty('CipherResponse');
+        const cipherMiniResponse = this.getResponseProperty('CipherMiniResponse');
+        this.cipherResponse = cipherResponse == null ? null : new CipherResponse(cipherResponse);
+        this.cipherMiniResponse = cipherMiniResponse == null ? null : new CipherResponse(cipherMiniResponse);
         this.url = this.getResponseProperty('Url');
     }
 

--- a/src/models/response/sendFileUploadDataResponse.ts
+++ b/src/models/response/sendFileUploadDataResponse.ts
@@ -11,7 +11,8 @@ export class SendFileUploadDataResponse extends BaseResponse {
     constructor(response: any) {
         super(response);
         this.fileUploadType = this.getResponseProperty('FileUploadType');
-        this.sendResponse = this.getResponseProperty('SendResponse');
+        const sendResponse = this.getResponseProperty('SendResponse');
+        this.sendResponse = sendResponse == null ? null : new SendResponse(sendResponse);
         this.url = this.getResponseProperty('Url');
     }
 }


### PR DESCRIPTION
# Overview

Fixes https://app.asana.com/0/1153292148278655/1200144714522727/f.

The issue is I do not deep-parse this model and so the `sendResponse` property is an object with all caps as provided by the c# server.

# Files Changed

* **attachmentUploadDataResponse**: Parse CipherResponse models returned
* **SendUploadDataResponse**: Parse SendResponse models returned

# TODO
- [ ] update web
- [ ] update browser
- [ ] update cli
- [ ] update desktop