### PR TITLE
Restrict WebAuthn to Windows only for Electron

### DIFF
--- a/src/electron/services/electronPlatformUtils.service.ts
+++ b/src/electron/services/electronPlatformUtils.service.ts
@@ -130,8 +130,10 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
         return remote.app.getVersion();
     }
 
+    // Temporarily restricted to only Windows until https://github.com/electron/electron/pull/28349
+    // has been merged and an updated electron build is available.
     supportsWebAuthn(win: Window): boolean {
-        return true;
+        return process.platform === 'win32';
     }
 
     supportsDuo(): boolean {


### PR DESCRIPTION
## Overview
Electron currently does not support the UI elements required for WebAuthn to work correctly on macOS and Linux. This was an oversight on my part and I've restricted it to only run on Windows at this moment.

I've added an Asana task to remove this restriction once https://github.com/electron/electron/pull/28349 has been merged.