### PR TITLE
Use iterator compatible Array instantiation

### DIFF
--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -37,7 +37,7 @@ export class Cipher {
         }
         if (view.collectionIds || req.collectionIds) {
             const set = new Set((view.collectionIds ?? []).concat(req.collectionIds ?? []));
-            view.collectionIds = [...set];
+            view.collectionIds = Array.from(set.values());
         }
         view.name = req.name;
         view.notes = req.notes;


### PR DESCRIPTION
# Overview

It appears that there are some issues with instantiating an Array by expanding a Set object through `[...set]`. This hopefully fixes this issue in other clients (`web` observed so far) requiting `downlevelIteration` option set in `tsconfig.json` in order to compile.

`downlevelIteration` comes with a warning that it will impact performance and increase verbosity for all javascript produces for any iteration. This doesn't seem worth it for this one line. Hopefully this instantiation works and we can get past this...


# Files changed:
*  **Cipher.ts**: instantiate the collectionId array in a different way