### PR TITLE
Remove electron remote

### DIFF
--- a/src/abstractions/platformUtils.service.ts
+++ b/src/abstractions/platformUtils.service.ts
@@ -20,7 +20,7 @@ export abstract class PlatformUtilsService {
     lockTimeout: () => number;
     launchUri: (uri: string, options?: any) => void;
     saveFile: (win: Window, blobData: any, blobOptions: any, fileName: string) => void;
-    getApplicationVersion: () => string;
+    getApplicationVersion: () => Promise<string>;
     supportsWebAuthn: (win: Window) => boolean;
     supportsDuo: () => boolean;
     showToast: (type: 'error' | 'success' | 'warning' | 'info', title: string, text: string | string[],
@@ -34,7 +34,7 @@ export abstract class PlatformUtilsService {
     readFromClipboard: (options?: any) => Promise<string>;
     supportsBiometric: () => Promise<boolean>;
     authenticateBiometric: () => Promise<boolean>;
-    getDefaultSystemTheme: () => 'light' | 'dark';
+    getDefaultSystemTheme: () => Promise<'light' | 'dark'>;
     onDefaultSystemThemeChange: (callback: ((theme: 'light' | 'dark') => unknown)) => unknown;
     supportsSecureStorage: () => boolean;
 }

--- a/src/cli/commands/update.command.ts
+++ b/src/cli/commands/update.command.ts
@@ -16,7 +16,7 @@ export class UpdateCommand {
     }
 
     async run(): Promise<Response> {
-        const currentVersion = this.platformUtilsService.getApplicationVersion();
+        const currentVersion = await this.platformUtilsService.getApplicationVersion();
 
         const response = await fetch.default('https://api.github.com/repos/bitwarden/' +
             this.repoName + '/releases/latest');

--- a/src/cli/services/cliPlatformUtils.service.ts
+++ b/src/cli/services/cliPlatformUtils.service.ts
@@ -96,8 +96,8 @@ export class CliPlatformUtilsService implements PlatformUtilsService {
         throw new Error('Not implemented.');
     }
 
-    getApplicationVersion(): string {
-        return this.packageJson.version;
+    getApplicationVersion(): Promise<string> {
+        return Promise.resolve(this.packageJson.version);
     }
 
     supportsWebAuthn(win: Window) {
@@ -147,7 +147,7 @@ export class CliPlatformUtilsService implements PlatformUtilsService {
     }
 
     getDefaultSystemTheme() {
-        return 'light' as 'light' | 'dark';
+        return Promise.resolve('light' as 'light' | 'dark');
     }
 
     onDefaultSystemThemeChange() {

--- a/src/electron/services/electronMainMessaging.service.ts
+++ b/src/electron/services/electronMainMessaging.service.ts
@@ -1,6 +1,7 @@
-import { app, dialog, ipcMain, nativeTheme } from 'electron';
-import {promises as fs} from 'fs';
+import { app, dialog, ipcMain, Menu, MenuItem, nativeTheme } from 'electron';
+import { promises as fs } from 'fs';
 import { MessagingService } from '../../abstractions/messaging.service';
+import { RendererMenu, RendererMenuItem } from '../utils';
 
 import { WindowMain } from '../window.main';
 
@@ -26,6 +27,24 @@ export class ElectronMainMessagingService implements MessagingService {
                 if (ret.filePath != null) {
                     fs.writeFile(ret.filePath, options.buffer, { mode: 0o600 });
                 }
+            });
+        });
+
+        ipcMain.handle('menu-popup', (event, options: {menu: RendererMenuItem[]}) => {
+            return new Promise((resolve) => {
+                const menu = new Menu();
+                options.menu.forEach((m, index) => {
+                    menu.append(new MenuItem({
+                        label: m.label,
+                        type: m.type,
+                        click: () => {
+                            resolve(index);
+                        }
+                    }));
+                });
+                menu.popup({ window: windowMain.win, callback: () => {
+                    resolve(-1);
+                }});
             });
         });
 

--- a/src/electron/services/electronMainMessaging.service.ts
+++ b/src/electron/services/electronMainMessaging.service.ts
@@ -1,7 +1,7 @@
 import { app, dialog, ipcMain, Menu, MenuItem, nativeTheme } from 'electron';
 import { promises as fs } from 'fs';
 import { MessagingService } from '../../abstractions/messaging.service';
-import { RendererMenu, RendererMenuItem } from '../utils';
+import { RendererMenuItem } from '../utils';
 
 import { WindowMain } from '../window.main';
 
@@ -31,7 +31,7 @@ export class ElectronMainMessagingService implements MessagingService {
         });
 
         ipcMain.handle('menu-popup', (event, options: {menu: RendererMenuItem[]}) => {
-            return new Promise((resolve) => {
+            return new Promise(resolve => {
                 const menu = new Menu();
                 options.menu.forEach((m, index) => {
                     menu.append(new MenuItem({
@@ -39,7 +39,7 @@ export class ElectronMainMessagingService implements MessagingService {
                         type: m.type,
                         click: () => {
                             resolve(index);
-                        }
+                        },
                     }));
                 });
                 menu.popup({ window: windowMain.win, callback: () => {

--- a/src/electron/services/electronMainMessaging.service.ts
+++ b/src/electron/services/electronMainMessaging.service.ts
@@ -30,7 +30,7 @@ export class ElectronMainMessagingService implements MessagingService {
             });
         });
 
-        ipcMain.handle('menu-popup', (event, options: {menu: RendererMenuItem[]}) => {
+        ipcMain.handle('openContextMenu', (event, options: {menu: RendererMenuItem[]}) => {
             return new Promise(resolve => {
                 const menu = new Menu();
                 options.menu.forEach((m, index) => {

--- a/src/electron/services/electronRendererStorage.service.ts
+++ b/src/electron/services/electronRendererStorage.service.ts
@@ -3,12 +3,10 @@ import { ipcRenderer } from 'electron';
 import { StorageService } from '../../abstractions/storage.service';
 
 export class ElectronRendererStorageService implements StorageService {
-    constructor() {}
-
     get<T>(key: string): Promise<T> {
         return ipcRenderer.invoke('storageService', {
             action: 'get',
-            key: key
+            key: key,
         });
     }
 

--- a/src/electron/services/electronRendererStorage.service.ts
+++ b/src/electron/services/electronRendererStorage.service.ts
@@ -1,0 +1,29 @@
+import { ipcRenderer } from 'electron';
+
+import { StorageService } from '../../abstractions/storage.service';
+
+export class ElectronRendererStorageService implements StorageService {
+    constructor() {}
+
+    get<T>(key: string): Promise<T> {
+        return ipcRenderer.invoke('storageService', {
+            action: 'get',
+            key: key
+        });
+    }
+
+    save(key: string, obj: any): Promise<any> {
+        return ipcRenderer.invoke('storageService', {
+            action: 'save',
+            key: key,
+            obj: obj,
+        });
+    }
+
+    remove(key: string): Promise<any> {
+        return ipcRenderer.invoke('storageService', {
+            action: 'remove',
+            key: key,
+        });
+    }
+}

--- a/src/electron/services/electronStorage.service.ts
+++ b/src/electron/services/electronStorage.service.ts
@@ -1,3 +1,4 @@
+import { ipcMain, ipcRenderer } from 'electron';
 import * as fs from 'fs';
 
 import { StorageService } from '../../abstractions/storage.service';
@@ -19,6 +20,17 @@ export class ElectronStorageService implements StorageService {
             name: 'data',
         };
         this.store = new Store(storeConfig);
+
+        ipcMain.handle('storageService', (event, options) => {
+            switch (options.action) {
+                case 'get':
+                    return this.get(options.key);
+                case 'save':
+                    return this.save(options.key, options.obj);
+                case 'remove':
+                    return this.remove(options.key);
+            }
+        });
     }
 
     get<T>(key: string): Promise<T> {

--- a/src/electron/utils.ts
+++ b/src/electron/utils.ts
@@ -1,3 +1,18 @@
+import { ipcRenderer } from "electron";
+
+export type RendererMenuItem = {label?: string, type?: ('normal' | 'separator' | 'submenu' | 'checkbox' | 'radio'), click?: () => any};
+
+export function invokeMenu(menu: RendererMenuItem[]) {
+    const menuWithoutClick = menu.map((m) => {
+        return { label: m.label, type: m.type }
+    });
+    ipcRenderer.invoke('menu-popup', { menu: menuWithoutClick }).then((i: number) => {
+        if (i !== -1) {
+            menu[i].click();
+        }
+    });
+}
+
 export function isDev() {
     // ref: https://github.com/sindresorhus/electron-is-dev
     if ('ELECTRON_IS_DEV' in process.env) {

--- a/src/electron/utils.ts
+++ b/src/electron/utils.ts
@@ -6,7 +6,7 @@ export function invokeMenu(menu: RendererMenuItem[]) {
     const menuWithoutClick = menu.map(m => {
         return { label: m.label, type: m.type };
     });
-    ipcRenderer.invoke('menu-popup', { menu: menuWithoutClick }).then((i: number) => {
+    ipcRenderer.invoke('openContextMenu', { menu: menuWithoutClick }).then((i: number) => {
         if (i !== -1) {
             menu[i].click();
         }

--- a/src/electron/utils.ts
+++ b/src/electron/utils.ts
@@ -1,10 +1,10 @@
-import { ipcRenderer } from "electron";
+import { ipcRenderer } from 'electron';
 
 export type RendererMenuItem = {label?: string, type?: ('normal' | 'separator' | 'submenu' | 'checkbox' | 'radio'), click?: () => any};
 
 export function invokeMenu(menu: RendererMenuItem[]) {
-    const menuWithoutClick = menu.map((m) => {
-        return { label: m.label, type: m.type }
+    const menuWithoutClick = menu.map(m => {
+        return { label: m.label, type: m.type };
     });
     ipcRenderer.invoke('menu-popup', { menu: menuWithoutClick }).then((i: number) => {
         if (i !== -1) {

--- a/src/misc/analytics.ts
+++ b/src/misc/analytics.ts
@@ -41,7 +41,7 @@ export class Analytics {
             }
         }
 
-        this.platformUtilsService.getApplicationVersion().then((v) => this.appVersion = v);
+        this.platformUtilsService.getApplicationVersion().then(v => this.appVersion = v);
         this.defaultDisabled = this.platformUtilsService.getDevice() === DeviceType.FirefoxExtension ||
             this.platformUtilsService.isMacAppStore();
         this.gaTrackingId = this.platformUtilsService.analyticsId();

--- a/src/misc/analytics.ts
+++ b/src/misc/analytics.ts
@@ -41,7 +41,7 @@ export class Analytics {
             }
         }
 
-        this.appVersion = this.platformUtilsService.getApplicationVersion();
+        this.platformUtilsService.getApplicationVersion().then((v) => this.appVersion = v);
         this.defaultDisabled = this.platformUtilsService.getDevice() === DeviceType.FirefoxExtension ||
             this.platformUtilsService.isMacAppStore();
         this.gaTrackingId = this.platformUtilsService.analyticsId();


### PR DESCRIPTION
## Objective
Since Electron has [deprecated the remote module](https://www.electronjs.org/docs/api/remote) we need to migrate away from it. The recommended alternative is to use `ipc` to explicitly communicate between the main and renderer. This was mostly straightforward to convert and I placed the handlers in `electronMainMessaging.service.ts` we might opt to create a separate service for this but since it handles messaging it seemed a suitable home for now.

### Code Changes
* **src/abstractions/platformUtils.service.ts**: Promisified some async values.
* **src/electron/services/electronMainMessaging.service.ts**: Added handlers for renderer ipc calls.
* **src/electron/services/electronPlatformUtils.service.ts**: Converted remote to ipcRenderer.invoke.
* **src/electron/services/electronRendererStorage.service.ts**: Storage now lives in the main process and this is a wrapper for retrieving values using IPC.
* **src/electron/services/electronStorage.service.ts**: Added ipchandlers for storage.
* **src/electron/utils.ts**: Helper function for invoking a context menu (right-click).