### PR TITLE
fix:  cmd + w doesn't close the window on macOS (bitwarden/desktop#714)

### DIFF
--- a/src/electron/baseMenu.ts
+++ b/src/electron/baseMenu.ts
@@ -9,8 +9,6 @@ import {
 import { I18nService } from '../abstractions/i18n.service';
 import { WindowMain } from './window.main';
 
-import { isMacAppStore } from './utils';
-
 export class BaseMenu {
     protected editMenuItemOptions: MenuItemConstructorOptions;
     protected viewSubMenuItemOptions: MenuItemConstructorOptions[];
@@ -143,7 +141,7 @@ export class BaseMenu {
                 },
                 {
                     label: this.i18nService.t('close'),
-                    role: isMacAppStore() ? 'quit' : 'close',
+                    role: 'close',
                 },
             ];
         }


### PR DESCRIPTION
cmd + w doesn't close the window on macOS - bitwarden/desktop#714

Based on @cscharf [explanation](https://github.com/bitwarden/desktop/issues/714#issuecomment-810554674) - it seems that issue was introduced in response to erroneous Apple Store approver request. 

The code change reverses previously made changes.