### PR TITLE
Use syncService + userService instead of tokenService to manage emailVerified

### DIFF
--- a/src/abstractions/user.service.ts
+++ b/src/abstractions/user.service.ts
@@ -5,12 +5,14 @@ import { KdfType } from '../enums/kdfType';
 
 export abstract class UserService {
     setInformation: (userId: string, email: string, kdf: KdfType, kdfIterations: number) => Promise<any>;
+    setEmailVerified: (emailVerified: boolean) => Promise<any>;
     setSecurityStamp: (stamp: string) => Promise<any>;
     getUserId: () => Promise<string>;
     getEmail: () => Promise<string>;
     getSecurityStamp: () => Promise<string>;
     getKdf: () => Promise<KdfType>;
     getKdfIterations: () => Promise<number>;
+    getEmailVerified: () => Promise<boolean>;
     clear: () => Promise<any>;
     isAuthenticated: () => Promise<boolean>;
     canAccessPremium: () => Promise<boolean>;

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -17,7 +17,6 @@ import { MessagingService } from '../../../abstractions/messaging.service';
 import { PlatformUtilsService } from '../../../abstractions/platformUtils.service';
 import { PolicyService } from '../../../abstractions/policy.service';
 import { SendService } from '../../../abstractions/send.service';
-import { TokenService } from '../../../abstractions/token.service';
 import { UserService } from '../../../abstractions/user.service';
 
 import { SendFileView } from '../../../models/view/sendFileView';
@@ -82,8 +81,7 @@ export class AddEditComponent implements OnInit {
     constructor(protected i18nService: I18nService, protected platformUtilsService: PlatformUtilsService,
         protected environmentService: EnvironmentService, protected datePipe: DatePipe,
         protected sendService: SendService, protected userService: UserService,
-        protected messagingService: MessagingService, protected policyService: PolicyService,
-        protected tokenService: TokenService) {
+        protected messagingService: MessagingService, protected policyService: PolicyService) {
         this.typeOptions = [
             { name: i18nService.t('sendTypeFile'), value: SendType.File },
             { name: i18nService.t('sendTypeText'), value: SendType.Text },
@@ -173,7 +171,7 @@ export class AddEditComponent implements OnInit {
         });
 
         this.canAccessPremium = await this.userService.canAccessPremium();
-        this.emailVerified = this.tokenService.getEmailVerified();
+        this.emailVerified = await this.userService.getEmailVerified();
         if (!this.canAccessPremium || !this.emailVerified) {
             this.type = SendType.Text;
         }

--- a/src/services/sync.service.ts
+++ b/src/services/sync.service.ts
@@ -288,6 +288,7 @@ export class SyncService implements SyncServiceAbstraction {
         await this.cryptoService.setEncPrivateKey(response.privateKey);
         await this.cryptoService.setOrgKeys(response.organizations);
         await this.userService.setSecurityStamp(response.securityStamp);
+        await this.userService.setEmailVerified(response.emailVerified);
 
         const organizations: { [id: string]: OrganizationData; } = {};
         response.organizations.forEach(o => {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -14,6 +14,7 @@ const Keys = {
     kdf: 'kdf',
     kdfIterations: 'kdfIterations',
     organizationsPrefix: 'organizations_',
+    emailVerified: 'emailVerified',
 };
 
 export class UserService implements UserServiceAbstraction {
@@ -22,6 +23,7 @@ export class UserService implements UserServiceAbstraction {
     private stamp: string;
     private kdf: KdfType;
     private kdfIterations: number;
+    private emailVerified: boolean;
 
     constructor(private tokenService: TokenService, private storageService: StorageService) { }
 
@@ -42,6 +44,11 @@ export class UserService implements UserServiceAbstraction {
     setSecurityStamp(stamp: string): Promise<any> {
         this.stamp = stamp;
         return this.storageService.save(Keys.stamp, stamp);
+    }
+
+    setEmailVerified(emailVerified: boolean) {
+        this.emailVerified = emailVerified;
+        return this.storageService.save(Keys.emailVerified, emailVerified);
     }
 
     async getUserId(): Promise<string> {
@@ -77,6 +84,13 @@ export class UserService implements UserServiceAbstraction {
             this.kdfIterations = await this.storageService.get<number>(Keys.kdfIterations);
         }
         return this.kdfIterations;
+    }
+
+    async getEmailVerified(): Promise<boolean> {
+        if (this.emailVerified == null) {
+            this.emailVerified = await this.storageService.get<boolean>(Keys.emailVerified);
+        }
+        return this.emailVerified;
     }
 
     async clear(): Promise<any> {


### PR DESCRIPTION
## Objective

Fixes a defect in https://github.com/bitwarden/web/pull/915: when a user verifies their email, they must log out and log back in again for the client to recognise the changes. This was confirmed to affect the desktop client, but in theory should affect others as well.

This is because I was using `tokenService` to check whether the user had verified their email, but the token is not updated when syncing the vault. However, we can get the same information via `syncService.syncProfile`, which is updated when syncing.

## Code changes

* use `userService.getEmailVerified` as the standard interface for checking whether a user's email is verified
* update this stored `emailVerified` value when syncing the vault

It's a bit of a chore to go back and change this, but I think the behaviour will be more in line with user expectations, and it'll structure it nicely for any other features we want to require email verification for.

Once this is merged, I'll submit PRs to update all the Angular clients. I'll also update mobile so that we have consistent implementation across the board.