### PR TITLE
Fix cipher upload

### DIFF
--- a/spec/common/services/cipher.service.spec.ts
+++ b/spec/common/services/cipher.service.spec.ts
@@ -1,0 +1,61 @@
+import { Arg, Substitute, SubstituteOf } from '@fluffy-spoon/substitute';
+
+import { ApiService } from '../../../src/abstractions/api.service';
+import { CryptoService } from '../../../src/abstractions/crypto.service';
+import { FileUploadService } from '../../../src/abstractions/fileUpload.service';
+import { I18nService } from '../../../src/abstractions/i18n.service';
+import { SearchService } from '../../../src/abstractions/search.service';
+import { SettingsService } from '../../../src/abstractions/settings.service';
+import { StorageService } from '../../../src/abstractions/storage.service';
+import { UserService } from '../../../src/abstractions/user.service';
+import { Utils } from '../../../src/misc/utils';
+import { Cipher } from '../../../src/models/domain/cipher';
+import { CipherArrayBuffer } from '../../../src/models/domain/cipherArrayBuffer';
+import { CipherString } from '../../../src/models/domain/cipherString';
+import { SymmetricCryptoKey } from '../../../src/models/domain/symmetricCryptoKey';
+
+import { CipherService } from '../../../src/services/cipher.service';
+
+const ENCRYPTED_TEXT = 'This data has been encrypted';
+const ENCRYPTED_BYTES = new CipherArrayBuffer(Utils.fromUtf8ToArray(ENCRYPTED_TEXT).buffer);
+
+describe('Cipher Service', () => {
+    let cryptoService: SubstituteOf<CryptoService>;
+    let userService: SubstituteOf<UserService>;
+    let settingsService: SubstituteOf<SettingsService>;
+    let apiService: SubstituteOf<ApiService>;
+    let fileUploadService: SubstituteOf<FileUploadService>;
+    let storageService: SubstituteOf<StorageService>;
+    let i18nService: SubstituteOf<I18nService>;
+    let searchService: SubstituteOf<SearchService>;
+
+    let cipherService: CipherService;
+
+    beforeEach(() => {
+        cryptoService = Substitute.for<CryptoService>();
+        userService = Substitute.for<UserService>();
+        settingsService = Substitute.for<SettingsService>();
+        apiService = Substitute.for<ApiService>();
+        fileUploadService = Substitute.for<FileUploadService>();
+        storageService = Substitute.for<StorageService>();
+        i18nService = Substitute.for<I18nService>();
+        searchService = Substitute.for<SearchService>();
+
+        cryptoService.encryptToBytes(Arg.any(), Arg.any()).resolves(ENCRYPTED_BYTES);
+        cryptoService.encrypt(Arg.any(), Arg.any()).resolves(new CipherString(ENCRYPTED_TEXT));
+
+        cipherService = new CipherService(cryptoService, userService, settingsService, apiService, fileUploadService,
+            storageService, i18nService, () => searchService);
+    });
+
+    it('attachments upload encrypted file contents', async () => {
+        const key = new SymmetricCryptoKey(new Uint8Array(32).buffer);
+        const fileName = 'filename';
+        const fileData = new Uint8Array(10).buffer;
+        cryptoService.getOrgKey(Arg.any()).resolves(new SymmetricCryptoKey(new Uint8Array(32).buffer));
+
+        await cipherService.saveAttachmentRawWithServer(new Cipher(), fileName, fileData);
+
+        fileUploadService.received(1).uploadCipherAttachment(Arg.any(), Arg.any(), fileName, ENCRYPTED_BYTES);
+    });
+});

--- a/src/abstractions/crypto.service.ts
+++ b/src/abstractions/crypto.service.ts
@@ -1,3 +1,4 @@
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
 import { CipherString } from '../models/domain/cipherString';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
@@ -40,7 +41,7 @@ export abstract class CryptoService {
     makeEncKey: (key: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, CipherString]>;
     remakeEncKey: (key: SymmetricCryptoKey, encKey?: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, CipherString]>;
     encrypt: (plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey) => Promise<CipherString>;
-    encryptToBytes: (plainValue: ArrayBuffer, key?: SymmetricCryptoKey) => Promise<ArrayBuffer>;
+    encryptToBytes: (plainValue: ArrayBuffer, key?: SymmetricCryptoKey) => Promise<CipherArrayBuffer>;
     rsaEncrypt: (data: ArrayBuffer, publicKey?: ArrayBuffer) => Promise<CipherString>;
     rsaDecrypt: (encValue: string) => Promise<ArrayBuffer>;
     decryptToBytes: (cipherString: CipherString, key?: SymmetricCryptoKey) => Promise<ArrayBuffer>;

--- a/src/abstractions/fileUpload.service.ts
+++ b/src/abstractions/fileUpload.service.ts
@@ -1,10 +1,11 @@
 import { CipherString } from '../models/domain';
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
 import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 
 export abstract class FileUploadService {
     uploadSendFile: (uploadData: SendFileUploadDataResponse, fileName: CipherString,
-        encryptedFileData: ArrayBuffer) => Promise<any>;
+        encryptedFileData: CipherArrayBuffer) => Promise<any>;
     uploadCipherAttachment: (admin: boolean, uploadData: AttachmentUploadDataResponse, fileName: string,
-        encryptedFileData: ArrayBuffer) => Promise<any>;
+        encryptedFileData: CipherArrayBuffer) => Promise<any>;
 }

--- a/src/abstractions/send.service.ts
+++ b/src/abstractions/send.service.ts
@@ -1,5 +1,6 @@
 import { SendData } from '../models/data/sendData';
 
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
 import { Send } from '../models/domain/send';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
@@ -9,11 +10,11 @@ export abstract class SendService {
     decryptedSendCache: SendView[];
 
     clearCache: () => void;
-    encrypt: (model: SendView, file: File | ArrayBuffer, password: string, key?: SymmetricCryptoKey) => Promise<[Send, ArrayBuffer]>;
+    encrypt: (model: SendView, file: File | ArrayBuffer, password: string, key?: SymmetricCryptoKey) => Promise<[Send, CipherArrayBuffer]>;
     get: (id: string) => Promise<Send>;
     getAll: () => Promise<Send[]>;
     getAllDecrypted: () => Promise<SendView[]>;
-    saveWithServer: (sendData: [Send, ArrayBuffer]) => Promise<any>;
+    saveWithServer: (sendData: [Send, CipherArrayBuffer]) => Promise<any>;
     upsert: (send: SendData | SendData[]) => Promise<any>;
     replace: (sends: { [id: string]: SendData; }) => Promise<any>;
     clear: (userId: string) => Promise<any>;

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -24,6 +24,7 @@ import { SendFileView } from '../../../models/view/sendFileView';
 import { SendTextView } from '../../../models/view/sendTextView';
 import { SendView } from '../../../models/view/sendView';
 
+import { CipherArrayBuffer } from '../../../models/domain/cipherArrayBuffer';
 import { Send } from '../../../models/domain/send';
 
 // TimeOption is used for the dropdown implementation of custom times
@@ -385,7 +386,7 @@ export class AddEditComponent implements OnInit {
         return this.sendService.get(this.sendId);
     }
 
-    protected async encryptSend(file: File): Promise<[Send, ArrayBuffer]> {
+    protected async encryptSend(file: File): Promise<[Send, CipherArrayBuffer]> {
         const sendData = await this.sendService.encrypt(this.send, file, this.password, null);
 
         // Parse dates

--- a/src/models/domain/cipherArrayBuffer.ts
+++ b/src/models/domain/cipherArrayBuffer.ts
@@ -1,0 +1,3 @@
+export class CipherArrayBuffer {
+    constructor(public buffer: ArrayBuffer) { }
+}

--- a/src/services/bitwardenFileUpload.service.ts
+++ b/src/services/bitwardenFileUpload.service.ts
@@ -1,19 +1,21 @@
 import { ApiService } from '../abstractions/api.service';
 
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
+
 import { Utils } from '../misc/utils';
 
 export class BitwardenFileUploadService
 {
     constructor(private apiService: ApiService) { }
 
-    async upload(encryptedFileName: string, encryptedFileData: ArrayBuffer, apiCall: (fd: FormData) => Promise<any>) {
+    async upload(encryptedFileName: string, encryptedFileData: CipherArrayBuffer, apiCall: (fd: FormData) => Promise<any>) {
         const fd = new FormData();
         try {
-            const blob = new Blob([encryptedFileData], { type: 'application/octet-stream' });
+            const blob = new Blob([encryptedFileData.buffer], { type: 'application/octet-stream' });
             fd.append('data', blob, encryptedFileName);
         } catch (e) {
             if (Utils.isNode && !Utils.isBrowser) {
-                fd.append('data', Buffer.from(encryptedFileData) as any, {
+                fd.append('data', Buffer.from(encryptedFileData.buffer) as any, {
                     filepath: encryptedFileName,
                     contentType: 'application/octet-stream',
                 } as any);

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -631,7 +631,7 @@ export class CipherService implements CipherServiceAbstraction {
         try {
             const uploadDataResponse = await this.apiService.postCipherAttachment(cipher.id, request);
             response = admin ? uploadDataResponse.cipherMiniResponse : uploadDataResponse.cipherResponse;
-            await this.fileUploadService.uploadCipherAttachment(admin, uploadDataResponse, filename, data);
+            await this.fileUploadService.uploadCipherAttachment(admin, uploadDataResponse, filename, encData);
         } catch (e) {
             if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404 || (e as ErrorResponse).statusCode === 405) {
                 response = await this.legacyServerAttachmentFileUpload(admin, cipher.id, encFileName, encData, dataEncKey[1]);

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -7,6 +7,7 @@ import { CipherData } from '../models/data/cipherData';
 import { Attachment } from '../models/domain/attachment';
 import { Card } from '../models/domain/card';
 import { Cipher } from '../models/domain/cipher';
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
 import { CipherString } from '../models/domain/cipherString';
 import Domain from '../models/domain/domainBase';
 import { Field } from '../models/domain/field';
@@ -17,6 +18,7 @@ import { Password } from '../models/domain/password';
 import { SecureNote } from '../models/domain/secureNote';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
+import { AttachmentRequest } from '../models/request/attachmentRequest';
 import { CipherBulkDeleteRequest } from '../models/request/cipherBulkDeleteRequest';
 import { CipherBulkMoveRequest } from '../models/request/cipherBulkMoveRequest';
 import { CipherBulkRestoreRequest } from '../models/request/cipherBulkRestoreRequest';
@@ -51,7 +53,6 @@ import { ConstantsService } from './constants.service';
 
 import { sequentialize } from '../misc/sequentialize';
 import { Utils } from '../misc/utils';
-import { AttachmentRequest } from '../models/request/attachmentRequest';
 
 const Keys = {
     ciphersPrefix: 'ciphers_',
@@ -623,7 +624,7 @@ export class CipherService implements CipherServiceAbstraction {
         const request: AttachmentRequest = {
             key: dataEncKey[1].encryptedString,
             fileName: encFileName.encryptedString,
-            fileSize: encData.byteLength,
+            fileSize: encData.buffer.byteLength,
             adminRequest: admin,
         };
 
@@ -655,16 +656,16 @@ export class CipherService implements CipherServiceAbstraction {
      * This method still exists for backward compatibility with old server versions.
      */
     async legacyServerAttachmentFileUpload(admin: boolean, cipherId: string, encFileName: CipherString,
-        encData: ArrayBuffer, key: CipherString) {
+        encData: CipherArrayBuffer, key: CipherString) {
         const fd = new FormData();
         try {
-            const blob = new Blob([encData], { type: 'application/octet-stream' });
+            const blob = new Blob([encData.buffer], { type: 'application/octet-stream' });
             fd.append('key', key.encryptedString);
             fd.append('data', blob, encFileName.encryptedString);
         } catch (e) {
             if (Utils.isNode && !Utils.isBrowser) {
                 fd.append('key', key.encryptedString);
-                fd.append('data', Buffer.from(encData) as any, {
+                fd.append('data', Buffer.from(encData.buffer) as any, {
                     filepath: encFileName.encryptedString,
                     contentType: 'application/octet-stream',
                 } as any);
@@ -970,13 +971,13 @@ export class CipherService implements CipherServiceAbstraction {
 
         const fd = new FormData();
         try {
-            const blob = new Blob([encData], { type: 'application/octet-stream' });
+            const blob = new Blob([encData.buffer], { type: 'application/octet-stream' });
             fd.append('key', dataEncKey[1].encryptedString);
             fd.append('data', blob, encFileName.encryptedString);
         } catch (e) {
             if (Utils.isNode && !Utils.isBrowser) {
                 fd.append('key', dataEncKey[1].encryptedString);
-                fd.append('data', Buffer.from(encData) as any, {
+                fd.append('data', Buffer.from(encData.buffer) as any, {
                     filepath: encFileName.encryptedString,
                     contentType: 'application/octet-stream',
                 } as any);

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -3,6 +3,7 @@ import * as bigInt from 'big-integer';
 import { EncryptionType } from '../enums/encryptionType';
 import { KdfType } from '../enums/kdfType';
 
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
 import { CipherString } from '../models/domain/cipherString';
 import { EncryptedObject } from '../models/domain/encryptedObject';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
@@ -406,7 +407,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         return new CipherString(encObj.key.encType, data, iv, mac);
     }
 
-    async encryptToBytes(plainValue: ArrayBuffer, key?: SymmetricCryptoKey): Promise<ArrayBuffer> {
+    async encryptToBytes(plainValue: ArrayBuffer, key?: SymmetricCryptoKey): Promise<CipherArrayBuffer> {
         const encValue = await this.aesEncrypt(plainValue, key);
         let macLen = 0;
         if (encValue.mac != null) {
@@ -421,7 +422,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         }
 
         encBytes.set(new Uint8Array(encValue.data), 1 + encValue.iv.byteLength + macLen);
-        return encBytes.buffer;
+        return new CipherArrayBuffer(encBytes.buffer);
     }
 
     async rsaEncrypt(data: ArrayBuffer, publicKey?: ArrayBuffer): Promise<CipherString> {

--- a/src/services/fileUpload.service.ts
+++ b/src/services/fileUpload.service.ts
@@ -4,7 +4,9 @@ import { LogService } from '../abstractions/log.service';
 
 import { FileUploadType } from '../enums/fileUploadType';
 
-import { CipherString } from '../models/domain';
+import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
+import { CipherString } from '../models/domain/cipherString';
+
 import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 
@@ -20,7 +22,7 @@ export class FileUploadService implements FileUploadServiceAbstraction {
         this.bitwardenFileUploadService = new BitwardenFileUploadService(apiService);
     }
 
-    async uploadSendFile(uploadData: SendFileUploadDataResponse, fileName: CipherString, encryptedFileData: ArrayBuffer) {
+    async uploadSendFile(uploadData: SendFileUploadDataResponse, fileName: CipherString, encryptedFileData: CipherArrayBuffer) {
         try {
             switch (uploadData.fileUploadType) {
                 case FileUploadType.Direct:
@@ -45,7 +47,7 @@ export class FileUploadService implements FileUploadServiceAbstraction {
         }
     }
 
-    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: string, encryptedFileData: ArrayBuffer) {
+    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: string, encryptedFileData: CipherArrayBuffer) {
         const response = admin ? uploadData.cipherMiniResponse : uploadData.cipherResponse;
         try {
             switch (uploadData.fileUploadType) {


### PR DESCRIPTION
# Overview

This bug was discovered by our QA team prior to public availability. No public unencrypted data was uploaded.

This PR fixes the bug (cipher.service line 634) as well as:
* add cipher service test to ensure file upload data is encrypted
* Create a CipherArrayBuffer tiny type which signifies an encrypted array buffer. CryptoService is the only generator of these buffers and all upload methods require them, converting to a buffer only on upload.

# Files Changed
* **cipher.service.spec.ts**: Quick test of uploading cipher array buffer file data
* **crypto.service.ts**: Return CipherArrayBuffer from encryptToBytes to signify an encrypted array
* **fileUpload.service/send.service/add-edit.component/azureFileUpload.service/bitwardenFileUpload.service/cipher.service**: Use CipherArrayBuffer
* **CipherArrayBuffer.ts**: define CipherArrayBuffer tiny type. The type doesn't do anything other than hold an ArrayBuffer. The benefit comes from Typescript and requiring CipherArrayBuffer type for upload methods.

# TODO
### Client updates
- [ ] web
- [ ] browser
- [ ] desktop
- [ ] cli
### Mobile Tiny Type
- [ ] Similar protection in Mobile