### PR TITLE
Fix mistake and clarify api method name

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -193,7 +193,7 @@ export abstract class ApiService {
     putSendRemovePassword: (id: string) => Promise<SendResponse>;
     deleteSend: (id: string) => Promise<any>;
     getSendFileDownloadData: (send: SendAccessView, request: SendAccessRequest) => Promise<SendFileDownloadDataResponse>;
-    renewFileUploadUrl: (sendId: string, fileId: string) => Promise<SendFileUploadDataResponse>;
+    renewSendFileUploadUrl: (sendId: string, fileId: string) => Promise<SendFileUploadDataResponse>;
 
     getCipher: (id: string) => Promise<CipherResponse>;
     getCipherAdmin: (id: string) => Promise<CipherResponse>;

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -443,8 +443,8 @@ export class ApiService implements ApiServiceAbstraction {
         return new SendFileUploadDataResponse(r);
     }
 
-    async renewFileUploadUrl(sendId: string, fileId: string): Promise<SendFileUploadDataResponse> {
-        const r = await this.send('GET', '/sends/' + sendId + '/file/' + fileId + '/renew', null, true, true);
+    async renewSendFileUploadUrl(sendId: string, fileId: string): Promise<SendFileUploadDataResponse> {
+        const r = await this.send('GET', '/sends/' + sendId + '/file/' + fileId, null, true, true);
         return new SendFileUploadDataResponse(r);
     }
 
@@ -650,7 +650,7 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     async renewAttachmentUploadUrl(id: string, attachmentId: string): Promise<AttachmentUploadDataResponse> {
-        const r = await this.send('GET', '/ciphers/' + id + '/attachment/' + attachmentId, null, true, true);
+        const r = await this.send('GET', '/ciphers/' + id + '/attachment/' + attachmentId + '/renew', null, true, true);
         return new AttachmentUploadDataResponse(r);
     }
 

--- a/src/services/fileUpload.service.ts
+++ b/src/services/fileUpload.service.ts
@@ -31,7 +31,7 @@ export class FileUploadService implements FileUploadServiceAbstraction {
                     break;
                 case FileUploadType.Azure:
                     const renewalCallback = async () => {
-                        const renewalResponse = await this.apiService.renewFileUploadUrl(uploadData.sendResponse.id,
+                        const renewalResponse = await this.apiService.renewSendFileUploadUrl(uploadData.sendResponse.id,
                             uploadData.sendResponse.file.id);
                         return renewalResponse.url;
                     };


### PR DESCRIPTION
# Overview

In #335, I foolishly tacked `/renew` onto the Send endpoint, when it is needed on `ciphers attachment` endpoint. This corrects that mistake and clarifies the SendFile method name.#278 

### TODO:
update jslib references for:
 - [ ] web
 - [ ] desktop
 - [ ] browser
 - [ ] cli

I'll do these jslib updates at the same time as #348 