### PR TITLE
CLI specifies bitwarden api for send download

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -192,7 +192,7 @@ export abstract class ApiService {
     putSend: (id: string, request: SendRequest) => Promise<SendResponse>;
     putSendRemovePassword: (id: string) => Promise<SendResponse>;
     deleteSend: (id: string) => Promise<any>;
-    getSendFileDownloadData: (send: SendAccessView, request: SendAccessRequest) => Promise<SendFileDownloadDataResponse>;
+    getSendFileDownloadData: (send: SendAccessView, request: SendAccessRequest, apiUrl?: string) => Promise<SendFileDownloadDataResponse>;
     renewSendFileUploadUrl: (sendId: string, fileId: string) => Promise<SendFileUploadDataResponse>;
 
     getCipher: (id: string) => Promise<CipherResponse>;

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -423,8 +423,8 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
 
-    async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest): Promise<SendFileDownloadDataResponse> {
-        const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true);
+    async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest, apiUrl?: string): Promise<SendFileDownloadDataResponse> {
+        const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true, apiUrl);
         return new SendFileDownloadDataResponse(r);
     }
 


### PR DESCRIPTION
# Overview

Add an optional apiUrl to Send download requests. This is needed for CLI to download Send files from non-configured Bitwarden Servers. 

Web does not have this issue because it can assume api from its own url.

### TODO:
update jslib
 - [ ] web
 - [ ] browser
 - [ ] desktop
 - [ ] cli

I'll do these jslib updates at the same time as #347