### PR TITLE
Rename CipherString and CipherArrayBuffer to Enc

### DIFF
--- a/spec/common/services/cipher.service.spec.ts
+++ b/spec/common/services/cipher.service.spec.ts
@@ -10,14 +10,14 @@ import { StorageService } from '../../../src/abstractions/storage.service';
 import { UserService } from '../../../src/abstractions/user.service';
 import { Utils } from '../../../src/misc/utils';
 import { Cipher } from '../../../src/models/domain/cipher';
-import { CipherArrayBuffer } from '../../../src/models/domain/cipherArrayBuffer';
-import { CipherString } from '../../../src/models/domain/cipherString';
+import { EncArrayBuffer } from '../../../src/models/domain/encArrayBuffer';
+import { EncString } from '../../../src/models/domain/encString';
 import { SymmetricCryptoKey } from '../../../src/models/domain/symmetricCryptoKey';
 
 import { CipherService } from '../../../src/services/cipher.service';
 
 const ENCRYPTED_TEXT = 'This data has been encrypted';
-const ENCRYPTED_BYTES = new CipherArrayBuffer(Utils.fromUtf8ToArray(ENCRYPTED_TEXT).buffer);
+const ENCRYPTED_BYTES = new EncArrayBuffer(Utils.fromUtf8ToArray(ENCRYPTED_TEXT).buffer);
 
 describe('Cipher Service', () => {
     let cryptoService: SubstituteOf<CryptoService>;
@@ -42,7 +42,7 @@ describe('Cipher Service', () => {
         searchService = Substitute.for<SearchService>();
 
         cryptoService.encryptToBytes(Arg.any(), Arg.any()).resolves(ENCRYPTED_BYTES);
-        cryptoService.encrypt(Arg.any(), Arg.any()).resolves(new CipherString(ENCRYPTED_TEXT));
+        cryptoService.encrypt(Arg.any(), Arg.any()).resolves(new EncString(ENCRYPTED_TEXT));
 
         cipherService = new CipherService(cryptoService, userService, settingsService, apiService, fileUploadService,
             storageService, i18nService, () => searchService);

--- a/spec/common/services/export.service.spec.ts
+++ b/spec/common/services/export.service.spec.ts
@@ -7,7 +7,7 @@ import { FolderService } from '../../../src/abstractions/folder.service';
 import { ExportService } from '../../../src/services/export.service';
 
 import { Cipher } from '../../../src/models/domain/cipher';
-import { CipherString } from '../../../src/models/domain/cipherString';
+import { EncString } from '../../../src/models/domain/encString';
 import { Login } from '../../../src/models/domain/login';
 import { CipherWithIds as CipherExport } from '../../../src/models/export/cipherWithIds';
 
@@ -46,11 +46,11 @@ function generateCipherView(deleted: boolean) {
 function generateCipherDomain(deleted: boolean) {
     return BuildTestObject({
         id: GetUniqueString('id'),
-        notes: new CipherString(GetUniqueString('notes')),
+        notes: new EncString(GetUniqueString('notes')),
         type: CipherType.Login,
         login: BuildTestObject<Login>({
-            username: new CipherString(GetUniqueString('username')),
-            password: new CipherString(GetUniqueString('password')),
+            username: new EncString(GetUniqueString('username')),
+            password: new EncString(GetUniqueString('password')),
         }, Login),
         collectionIds: null,
         deletedDate: deleted ? new Date() : null,

--- a/src/abstractions/crypto.service.ts
+++ b/src/abstractions/crypto.service.ts
@@ -1,5 +1,5 @@
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
-import { CipherString } from '../models/domain/cipherString';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
+import { EncString } from '../models/domain/encString';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
 import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
@@ -32,20 +32,20 @@ export abstract class CryptoService {
     toggleKey: () => Promise<any>;
     makeKey: (password: string, salt: string, kdf: KdfType, kdfIterations: number) => Promise<SymmetricCryptoKey>;
     makeKeyFromPin: (pin: string, salt: string, kdf: KdfType, kdfIterations: number,
-        protectedKeyCs?: CipherString) => Promise<SymmetricCryptoKey>;
-    makeShareKey: () => Promise<[CipherString, SymmetricCryptoKey]>;
-    makeKeyPair: (key?: SymmetricCryptoKey) => Promise<[string, CipherString]>;
+        protectedKeyCs?: EncString) => Promise<SymmetricCryptoKey>;
+    makeShareKey: () => Promise<[EncString, SymmetricCryptoKey]>;
+    makeKeyPair: (key?: SymmetricCryptoKey) => Promise<[string, EncString]>;
     makePinKey: (pin: string, salt: string, kdf: KdfType, kdfIterations: number) => Promise<SymmetricCryptoKey>;
     makeSendKey: (keyMaterial: ArrayBuffer) => Promise<SymmetricCryptoKey>;
     hashPassword: (password: string, key: SymmetricCryptoKey) => Promise<string>;
-    makeEncKey: (key: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, CipherString]>;
-    remakeEncKey: (key: SymmetricCryptoKey, encKey?: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, CipherString]>;
-    encrypt: (plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey) => Promise<CipherString>;
-    encryptToBytes: (plainValue: ArrayBuffer, key?: SymmetricCryptoKey) => Promise<CipherArrayBuffer>;
-    rsaEncrypt: (data: ArrayBuffer, publicKey?: ArrayBuffer) => Promise<CipherString>;
+    makeEncKey: (key: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, EncString]>;
+    remakeEncKey: (key: SymmetricCryptoKey, encKey?: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, EncString]>;
+    encrypt: (plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey) => Promise<EncString>;
+    encryptToBytes: (plainValue: ArrayBuffer, key?: SymmetricCryptoKey) => Promise<EncArrayBuffer>;
+    rsaEncrypt: (data: ArrayBuffer, publicKey?: ArrayBuffer) => Promise<EncString>;
     rsaDecrypt: (encValue: string) => Promise<ArrayBuffer>;
-    decryptToBytes: (cipherString: CipherString, key?: SymmetricCryptoKey) => Promise<ArrayBuffer>;
-    decryptToUtf8: (cipherString: CipherString, key?: SymmetricCryptoKey) => Promise<string>;
+    decryptToBytes: (encString: EncString, key?: SymmetricCryptoKey) => Promise<ArrayBuffer>;
+    decryptToUtf8: (encString: EncString, key?: SymmetricCryptoKey) => Promise<string>;
     decryptFromBytes: (encBuf: ArrayBuffer, key: SymmetricCryptoKey) => Promise<ArrayBuffer>;
     randomNumber: (min: number, max: number) => Promise<number>;
 }

--- a/src/abstractions/fileUpload.service.ts
+++ b/src/abstractions/fileUpload.service.ts
@@ -1,11 +1,11 @@
-import { CipherString } from '../models/domain';
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
+import { EncString } from '../models/domain/encString';
 import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
 
 export abstract class FileUploadService {
-    uploadSendFile: (uploadData: SendFileUploadDataResponse, fileName: CipherString,
-        encryptedFileData: CipherArrayBuffer) => Promise<any>;
+    uploadSendFile: (uploadData: SendFileUploadDataResponse, fileName: EncString,
+        encryptedFileData: EncArrayBuffer) => Promise<any>;
     uploadCipherAttachment: (admin: boolean, uploadData: AttachmentUploadDataResponse, fileName: string,
-        encryptedFileData: CipherArrayBuffer) => Promise<any>;
+        encryptedFileData: EncArrayBuffer) => Promise<any>;
 }

--- a/src/abstractions/send.service.ts
+++ b/src/abstractions/send.service.ts
@@ -1,6 +1,6 @@
 import { SendData } from '../models/data/sendData';
 
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
 import { Send } from '../models/domain/send';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
@@ -10,11 +10,11 @@ export abstract class SendService {
     decryptedSendCache: SendView[];
 
     clearCache: () => void;
-    encrypt: (model: SendView, file: File | ArrayBuffer, password: string, key?: SymmetricCryptoKey) => Promise<[Send, CipherArrayBuffer]>;
+    encrypt: (model: SendView, file: File | ArrayBuffer, password: string, key?: SymmetricCryptoKey) => Promise<[Send, EncArrayBuffer]>;
     get: (id: string) => Promise<Send>;
     getAll: () => Promise<Send[]>;
     getAllDecrypted: () => Promise<SendView[]>;
-    saveWithServer: (sendData: [Send, CipherArrayBuffer]) => Promise<any>;
+    saveWithServer: (sendData: [Send, EncArrayBuffer]) => Promise<any>;
     upsert: (send: SendData | SendData[]) => Promise<any>;
     replace: (sends: { [id: string]: SendData; }) => Promise<any>;
     clear: (userId: string) => Promise<any>;

--- a/src/abstractions/vaultTimeout.service.ts
+++ b/src/abstractions/vaultTimeout.service.ts
@@ -1,8 +1,8 @@
-import { CipherString } from '../models/domain/cipherString';
+import { EncString } from '../models/domain/encString';
 
 export abstract class VaultTimeoutService {
     biometricLocked: boolean;
-    pinProtectedKey: CipherString;
+    pinProtectedKey: EncString;
     isLocked: () => Promise<boolean>;
     checkVaultTimeout: () => Promise<void>;
     lock: (allowSoftLock?: boolean) => Promise<void>;

--- a/src/angular/components/change-password.component.ts
+++ b/src/angular/components/change-password.component.ts
@@ -8,7 +8,7 @@ import { PlatformUtilsService } from '../../abstractions/platformUtils.service';
 import { PolicyService } from '../../abstractions/policy.service';
 import { UserService } from '../../abstractions/user.service';
 
-import { CipherString } from '../../models/domain/cipherString';
+import { EncString } from '../../models/domain/encString';
 import { MasterPasswordPolicyOptions } from '../../models/domain/masterPasswordPolicyOptions';
 import { SymmetricCryptoKey } from '../../models/domain/symmetricCryptoKey';
 
@@ -77,7 +77,7 @@ export class ChangePasswordComponent implements OnInit {
             this.kdf, this.kdfIterations);
         const masterPasswordHash = await this.cryptoService.hashPassword(this.masterPassword, key);
 
-        let encKey: [SymmetricCryptoKey, CipherString] = null;
+        let encKey: [SymmetricCryptoKey, EncString] = null;
         const existingEncKey = await this.cryptoService.getEncKey();
         if (existingEncKey == null) {
             encKey = await this.cryptoService.makeEncKey(key);
@@ -95,7 +95,7 @@ export class ChangePasswordComponent implements OnInit {
     }
 
     async performSubmitActions(masterPasswordHash: string, key: SymmetricCryptoKey,
-        encKey: [SymmetricCryptoKey, CipherString]) {
+        encKey: [SymmetricCryptoKey, EncString]) {
         // Override in sub-class
     }
 

--- a/src/angular/components/lock.component.ts
+++ b/src/angular/components/lock.component.ts
@@ -14,7 +14,7 @@ import { VaultTimeoutService } from '../../abstractions/vaultTimeout.service';
 
 import { ConstantsService } from '../../services/constants.service';
 
-import { CipherString } from '../../models/domain/cipherString';
+import { EncString } from '../../models/domain/encString';
 import { SymmetricCryptoKey } from '../../models/domain/symmetricCryptoKey';
 
 import { PasswordVerificationRequest } from '../../models/request/passwordVerificationRequest';
@@ -83,7 +83,7 @@ export class LockComponent implements OnInit {
                         this.vaultTimeoutService.pinProtectedKey);
                     const encKey = await this.cryptoService.getEncKey(key);
                     const protectedPin = await this.storageService.get<string>(ConstantsService.protectedPin);
-                    const decPin = await this.cryptoService.decryptToUtf8(new CipherString(protectedPin), encKey);
+                    const decPin = await this.cryptoService.decryptToUtf8(new EncString(protectedPin), encKey);
                     failed = decPin !== this.pin;
                     if (!failed) {
                         await this.setKeyAndContinue(key);
@@ -132,7 +132,7 @@ export class LockComponent implements OnInit {
                 if (this.pinSet[0]) {
                     const protectedPin = await this.storageService.get<string>(ConstantsService.protectedPin);
                     const encKey = await this.cryptoService.getEncKey(key);
-                    const decPin = await this.cryptoService.decryptToUtf8(new CipherString(protectedPin), encKey);
+                    const decPin = await this.cryptoService.decryptToUtf8(new EncString(protectedPin), encKey);
                     const pinKey = await this.cryptoService.makePinKey(decPin, this.email, kdf, kdfIterations);
                     this.vaultTimeoutService.pinProtectedKey = await this.cryptoService.encrypt(key.key, pinKey);
                 }

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -23,7 +23,7 @@ import { SendFileView } from '../../../models/view/sendFileView';
 import { SendTextView } from '../../../models/view/sendTextView';
 import { SendView } from '../../../models/view/sendView';
 
-import { CipherArrayBuffer } from '../../../models/domain/cipherArrayBuffer';
+import { EncArrayBuffer } from '../../../models/domain/encArrayBuffer';
 import { Send } from '../../../models/domain/send';
 
 // TimeOption is used for the dropdown implementation of custom times
@@ -384,7 +384,7 @@ export class AddEditComponent implements OnInit {
         return this.sendService.get(this.sendId);
     }
 
-    protected async encryptSend(file: File): Promise<[Send, CipherArrayBuffer]> {
+    protected async encryptSend(file: File): Promise<[Send, EncArrayBuffer]> {
         const sendData = await this.sendService.encrypt(this.send, file, this.password, null);
 
         // Parse dates

--- a/src/angular/components/set-password.component.ts
+++ b/src/angular/components/set-password.component.ts
@@ -13,7 +13,7 @@ import { PolicyService } from '../../abstractions/policy.service';
 import { SyncService } from '../../abstractions/sync.service';
 import { UserService } from '../../abstractions/user.service';
 
-import { CipherString } from '../../models/domain/cipherString';
+import { EncString } from '../../models/domain/encString';
 import { SymmetricCryptoKey } from '../../models/domain/symmetricCryptoKey';
 
 import { KeysRequest } from '../../models/request/keysRequest';
@@ -65,7 +65,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     }
 
     async performSubmitActions(masterPasswordHash: string, key: SymmetricCryptoKey,
-        encKey: [SymmetricCryptoKey, CipherString]) {
+        encKey: [SymmetricCryptoKey, EncString]) {
         const request = new SetPasswordRequest();
         request.masterPasswordHash = masterPasswordHash;
         request.key = encKey[1].encryptedString;

--- a/src/models/domain/attachment.ts
+++ b/src/models/domain/attachment.ts
@@ -2,8 +2,8 @@ import { AttachmentData } from '../data/attachmentData';
 
 import { AttachmentView } from '../view/attachmentView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 import { CryptoService } from '../../abstractions/crypto.service';
@@ -15,8 +15,8 @@ export class Attachment extends Domain {
     url: string;
     size: string;
     sizeName: string;
-    key: CipherString;
-    fileName: CipherString;
+    key: EncString;
+    fileName: EncString;
 
     constructor(obj?: AttachmentData, alreadyEncrypted: boolean = false) {
         super();

--- a/src/models/domain/card.ts
+++ b/src/models/domain/card.ts
@@ -1,18 +1,18 @@
 import { CardData } from '../data/cardData';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 
 import { CardView } from '../view/cardView';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 export class Card extends Domain {
-    cardholderName: CipherString;
-    brand: CipherString;
-    number: CipherString;
-    expMonth: CipherString;
-    expYear: CipherString;
-    code: CipherString;
+    cardholderName: EncString;
+    brand: EncString;
+    number: EncString;
+    expMonth: EncString;
+    expYear: EncString;
+    code: EncString;
 
     constructor(obj?: CardData, alreadyEncrypted: boolean = false) {
         super();

--- a/src/models/domain/cipher.ts
+++ b/src/models/domain/cipher.ts
@@ -7,8 +7,8 @@ import { CipherView } from '../view/cipherView';
 
 import { Attachment } from './attachment';
 import { Card } from './card';
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { Field } from './field';
 import { Identity } from './identity';
 import { Login } from './login';
@@ -20,8 +20,8 @@ export class Cipher extends Domain {
     id: string;
     organizationId: string;
     folderId: string;
-    name: CipherString;
-    notes: CipherString;
+    name: EncString;
+    notes: EncString;
     type: CipherType;
     favorite: boolean;
     organizationUseTotp: boolean;

--- a/src/models/domain/collection.ts
+++ b/src/models/domain/collection.ts
@@ -2,13 +2,13 @@ import { CollectionData } from '../data/collectionData';
 
 import { CollectionView } from '../view/collectionView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 
 export class Collection extends Domain {
     id: string;
     organizationId: string;
-    name: CipherString;
+    name: EncString;
     externalId: string;
     readOnly: boolean;
     hidePasswords: boolean;

--- a/src/models/domain/domainBase.ts
+++ b/src/models/domain/domainBase.ts
@@ -1,4 +1,4 @@
-import { CipherString } from './cipherString';
+import { EncString } from './encString';
 
 import { View } from '../view/view';
 
@@ -16,21 +16,21 @@ export default class Domain {
             if (alreadyEncrypted === true || notEncList.indexOf(prop) > -1) {
                 (domain as any)[prop] = objProp ? objProp : null;
             } else {
-                (domain as any)[prop] = objProp ? new CipherString(objProp) : null;
+                (domain as any)[prop] = objProp ? new EncString(objProp) : null;
             }
         }
     }
-    protected buildDataModel<D extends Domain>(domain: D, dataObj: any, map: any, notCipherStringList: any[] = []) {
+    protected buildDataModel<D extends Domain>(domain: D, dataObj: any, map: any, notEncStringList: any[] = []) {
         for (const prop in map) {
             if (!map.hasOwnProperty(prop)) {
                 continue;
             }
 
             const objProp = (domain as any)[(map[prop] || prop)];
-            if (notCipherStringList.indexOf(prop) > -1) {
+            if (notEncStringList.indexOf(prop) > -1) {
                 (dataObj as any)[prop] = objProp != null ? objProp : null;
             } else {
-                (dataObj as any)[prop] = objProp != null ? (objProp as CipherString).encryptedString : null;
+                (dataObj as any)[prop] = objProp != null ? (objProp as EncString).encryptedString : null;
             }
         }
     }

--- a/src/models/domain/encArrayBuffer.ts
+++ b/src/models/domain/encArrayBuffer.ts
@@ -1,3 +1,3 @@
-export class CipherArrayBuffer {
+export class EncArrayBuffer {
     constructor(public buffer: ArrayBuffer) { }
 }

--- a/src/models/domain/encString.ts
+++ b/src/models/domain/encString.ts
@@ -6,7 +6,7 @@ import { Utils } from '../../misc/utils';
 
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
-export class CipherString {
+export class EncString {
     encryptedString?: string;
     encryptionType?: EncryptionType;
     decryptedValue?: string;

--- a/src/models/domain/field.ts
+++ b/src/models/domain/field.ts
@@ -2,15 +2,15 @@ import { FieldType } from '../../enums/fieldType';
 
 import { FieldData } from '../data/fieldData';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 
 import { FieldView } from '../view/fieldView';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 export class Field extends Domain {
-    name: CipherString;
-    value: CipherString;
+    name: EncString;
+    value: EncString;
     type: FieldType;
 
     constructor(obj?: FieldData, alreadyEncrypted: boolean = false) {

--- a/src/models/domain/folder.ts
+++ b/src/models/domain/folder.ts
@@ -2,12 +2,12 @@ import { FolderData } from '../data/folderData';
 
 import { FolderView } from '../view/folderView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 
 export class Folder extends Domain {
     id: string;
-    name: CipherString;
+    name: EncString;
     revisionDate: Date;
 
     constructor(obj?: FolderData, alreadyEncrypted: boolean = false) {

--- a/src/models/domain/identity.ts
+++ b/src/models/domain/identity.ts
@@ -1,30 +1,30 @@
 import { IdentityData } from '../data/identityData';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 import { IdentityView } from '../view/identityView';
 
 export class Identity extends Domain {
-    title: CipherString;
-    firstName: CipherString;
-    middleName: CipherString;
-    lastName: CipherString;
-    address1: CipherString;
-    address2: CipherString;
-    address3: CipherString;
-    city: CipherString;
-    state: CipherString;
-    postalCode: CipherString;
-    country: CipherString;
-    company: CipherString;
-    email: CipherString;
-    phone: CipherString;
-    ssn: CipherString;
-    username: CipherString;
-    passportNumber: CipherString;
-    licenseNumber: CipherString;
+    title: EncString;
+    firstName: EncString;
+    middleName: EncString;
+    lastName: EncString;
+    address1: EncString;
+    address2: EncString;
+    address3: EncString;
+    city: EncString;
+    state: EncString;
+    postalCode: EncString;
+    country: EncString;
+    company: EncString;
+    email: EncString;
+    phone: EncString;
+    ssn: EncString;
+    username: EncString;
+    passportNumber: EncString;
+    licenseNumber: EncString;
 
     constructor(obj?: IdentityData, alreadyEncrypted: boolean = false) {
         super();

--- a/src/models/domain/index.ts
+++ b/src/models/domain/index.ts
@@ -2,7 +2,7 @@ export { Attachment } from './attachment';
 export { AuthResult } from './authResult';
 export { Card } from './card';
 export { Cipher } from './cipher';
-export { CipherString } from './cipherString';
+export { EncString } from './encString';
 export { Collection } from './collection';
 export { EncryptedObject } from './encryptedObject';
 export { EnvironmentUrls } from './environmentUrls';

--- a/src/models/domain/login.ts
+++ b/src/models/domain/login.ts
@@ -4,16 +4,16 @@ import { LoginData } from '../data/loginData';
 
 import { LoginView } from '../view/loginView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 export class Login extends Domain {
     uris: LoginUri[];
-    username: CipherString;
-    password: CipherString;
+    username: EncString;
+    password: EncString;
     passwordRevisionDate?: Date;
-    totp: CipherString;
+    totp: EncString;
 
     constructor(obj?: LoginData, alreadyEncrypted: boolean = false) {
         super();

--- a/src/models/domain/loginUri.ts
+++ b/src/models/domain/loginUri.ts
@@ -4,12 +4,12 @@ import { LoginUriData } from '../data/loginUriData';
 
 import { LoginUriView } from '../view/loginUriView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 export class LoginUri extends Domain {
-    uri: CipherString;
+    uri: EncString;
     match: UriMatchType;
 
     constructor(obj?: LoginUriData, alreadyEncrypted: boolean = false) {

--- a/src/models/domain/password.ts
+++ b/src/models/domain/password.ts
@@ -1,13 +1,13 @@
 import { PasswordHistoryData } from '../data/passwordHistoryData';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 
 import { PasswordHistoryView } from '../view/passwordHistoryView';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 export class Password extends Domain {
-    password: CipherString;
+    password: EncString;
     lastUsedDate: Date;
 
     constructor(obj?: PasswordHistoryData, alreadyEncrypted: boolean = false) {

--- a/src/models/domain/send.ts
+++ b/src/models/domain/send.ts
@@ -8,8 +8,8 @@ import { SendData } from '../data/sendData';
 
 import { SendView } from '../view/sendView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SendFile } from './sendFile';
 import { SendText } from './sendText';
 
@@ -18,11 +18,11 @@ export class Send extends Domain {
     accessId: string;
     userId: string;
     type: SendType;
-    name: CipherString;
-    notes: CipherString;
+    name: EncString;
+    notes: EncString;
     file: SendFile;
     text: SendText;
-    key: CipherString;
+    key: EncString;
     maxAccessCount?: number;
     accessCount: number;
     revisionDate: Date;

--- a/src/models/domain/sendAccess.ts
+++ b/src/models/domain/sendAccess.ts
@@ -4,8 +4,8 @@ import { SendAccessResponse } from '../response/sendAccessResponse';
 
 import { SendAccessView } from '../view/sendAccessView';
 
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SendFile } from './sendFile';
 import { SendText } from './sendText';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
@@ -13,7 +13,7 @@ import { SymmetricCryptoKey } from './symmetricCryptoKey';
 export class SendAccess extends Domain {
     id: string;
     type: SendType;
-    name: CipherString;
+    name: EncString;
     file: SendFile;
     text: SendText;
     expirationDate: Date;

--- a/src/models/domain/sendFile.ts
+++ b/src/models/domain/sendFile.ts
@@ -1,5 +1,5 @@
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 import { SendFileData } from '../data/sendFileData';
@@ -10,7 +10,7 @@ export class SendFile extends Domain {
     id: string;
     size: string;
     sizeName: string;
-    fileName: CipherString;
+    fileName: EncString;
 
     constructor(obj?: SendFileData, alreadyEncrypted: boolean = false) {
         super();

--- a/src/models/domain/sendText.ts
+++ b/src/models/domain/sendText.ts
@@ -1,5 +1,5 @@
-import { CipherString } from './cipherString';
 import Domain from './domainBase';
+import { EncString } from './encString';
 import { SymmetricCryptoKey } from './symmetricCryptoKey';
 
 import { SendTextData } from '../data/sendTextData';
@@ -7,7 +7,7 @@ import { SendTextData } from '../data/sendTextData';
 import { SendTextView } from '../view/sendTextView';
 
 export class SendText extends Domain {
-    text: CipherString;
+    text: EncString;
     hidden: boolean;
 
     constructor(obj?: SendTextData, alreadyEncrypted: boolean = false) {

--- a/src/models/export/card.ts
+++ b/src/models/export/card.ts
@@ -1,7 +1,7 @@
 import { CardView } from '../view/cardView';
 
 import { Card as CardDomain } from '../domain/card';
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 
 export class Card {
     static template(): Card {
@@ -26,12 +26,12 @@ export class Card {
     }
 
     static toDomain(req: Card, domain = new CardDomain()) {
-        domain.cardholderName = req.cardholderName != null ? new CipherString(req.cardholderName) : null;
-        domain.brand = req.brand != null ? new CipherString(req.brand) : null;
-        domain.number = req.number != null ? new CipherString(req.number) : null;
-        domain.expMonth = req.expMonth != null ? new CipherString(req.expMonth) : null;
-        domain.expYear = req.expYear != null ? new CipherString(req.expYear) : null;
-        domain.code = req.code != null ? new CipherString(req.code) : null;
+        domain.cardholderName = req.cardholderName != null ? new EncString(req.cardholderName) : null;
+        domain.brand = req.brand != null ? new EncString(req.brand) : null;
+        domain.number = req.number != null ? new EncString(req.number) : null;
+        domain.expMonth = req.expMonth != null ? new EncString(req.expMonth) : null;
+        domain.expYear = req.expYear != null ? new EncString(req.expYear) : null;
+        domain.code = req.code != null ? new EncString(req.code) : null;
         return domain;
     }
 

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -3,7 +3,7 @@ import { CipherType } from '../../enums/cipherType';
 import { CipherView } from '../view/cipherView';
 
 import { Cipher as CipherDomain } from '../domain/cipher';
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 
 import { Card } from './card';
 import { Field } from './field';
@@ -71,8 +71,8 @@ export class Cipher {
         if (domain.organizationId == null) {
             domain.organizationId = req.organizationId;
         }
-        domain.name = req.name != null ? new CipherString(req.name) : null;
-        domain.notes = req.notes != null ? new CipherString(req.notes) : null;
+        domain.name = req.name != null ? new EncString(req.name) : null;
+        domain.notes = req.notes != null ? new EncString(req.notes) : null;
         domain.favorite = req.favorite;
 
         if (req.fields != null) {

--- a/src/models/export/collection.ts
+++ b/src/models/export/collection.ts
@@ -1,7 +1,7 @@
 import { CollectionView } from '../view/collectionView';
 
-import { CipherString } from '../domain/cipherString';
 import { Collection as CollectionDomain } from '../domain/collection';
+import { EncString } from '../domain/encString';
 
 export class Collection {
     static template(): Collection {
@@ -22,7 +22,7 @@ export class Collection {
     }
 
     static toDomain(req: Collection, domain = new CollectionDomain()) {
-        domain.name = req.name != null ? new CipherString(req.name) : null;
+        domain.name = req.name != null ? new EncString(req.name) : null;
         domain.externalId = req.externalId;
         if (domain.organizationId == null) {
             domain.organizationId = req.organizationId;

--- a/src/models/export/field.ts
+++ b/src/models/export/field.ts
@@ -2,7 +2,7 @@ import { FieldType } from '../../enums/fieldType';
 
 import { FieldView } from '../view/fieldView';
 
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 import { Field as FieldDomain } from '../domain/field';
 
 export class Field {
@@ -23,8 +23,8 @@ export class Field {
 
     static toDomain(req: Field, domain = new FieldDomain()) {
         domain.type = req.type;
-        domain.value = req.value != null ? new CipherString(req.value) : null;
-        domain.name = req.name != null ? new CipherString(req.name) : null;
+        domain.value = req.value != null ? new EncString(req.value) : null;
+        domain.name = req.name != null ? new EncString(req.name) : null;
         return domain;
     }
 

--- a/src/models/export/folder.ts
+++ b/src/models/export/folder.ts
@@ -1,6 +1,6 @@
 import { FolderView } from '../view/folderView';
 
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 import { Folder as FolderDomain } from '../domain/folder';
 
 export class Folder {
@@ -16,7 +16,7 @@ export class Folder {
     }
 
     static toDomain(req: Folder, domain = new FolderDomain()) {
-        domain.name = req.name != null ? new CipherString(req.name) : null;
+        domain.name = req.name != null ? new EncString(req.name) : null;
         return domain;
     }
 

--- a/src/models/export/identity.ts
+++ b/src/models/export/identity.ts
@@ -1,6 +1,6 @@
 import { IdentityView } from '../view/identityView';
 
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 import { Identity as IdentityDomain } from '../domain/identity';
 
 export class Identity {
@@ -50,24 +50,24 @@ export class Identity {
     }
 
     static toDomain(req: Identity, domain = new IdentityDomain()) {
-        domain.title = req.title != null ? new CipherString(req.title) : null;
-        domain.firstName = req.firstName != null ? new CipherString(req.firstName) : null;
-        domain.middleName = req.middleName != null ? new CipherString(req.middleName) : null;
-        domain.lastName = req.lastName != null ? new CipherString(req.lastName) : null;
-        domain.address1 = req.address1 != null ? new CipherString(req.address1) : null;
-        domain.address2 = req.address2 != null ? new CipherString(req.address2) : null;
-        domain.address3 = req.address3 != null ? new CipherString(req.address3) : null;
-        domain.city = req.city != null ? new CipherString(req.city) : null;
-        domain.state = req.state != null ? new CipherString(req.state) : null;
-        domain.postalCode = req.postalCode != null ? new CipherString(req.postalCode) : null;
-        domain.country = req.country != null ? new CipherString(req.country) : null;
-        domain.company = req.company != null ? new CipherString(req.company) : null;
-        domain.email = req.email != null ? new CipherString(req.email) : null;
-        domain.phone = req.phone != null ? new CipherString(req.phone) : null;
-        domain.ssn = req.ssn != null ? new CipherString(req.ssn) : null;
-        domain.username = req.username != null ? new CipherString(req.username) : null;
-        domain.passportNumber = req.passportNumber != null ? new CipherString(req.passportNumber) : null;
-        domain.licenseNumber = req.licenseNumber != null ? new CipherString(req.licenseNumber) : null;
+        domain.title = req.title != null ? new EncString(req.title) : null;
+        domain.firstName = req.firstName != null ? new EncString(req.firstName) : null;
+        domain.middleName = req.middleName != null ? new EncString(req.middleName) : null;
+        domain.lastName = req.lastName != null ? new EncString(req.lastName) : null;
+        domain.address1 = req.address1 != null ? new EncString(req.address1) : null;
+        domain.address2 = req.address2 != null ? new EncString(req.address2) : null;
+        domain.address3 = req.address3 != null ? new EncString(req.address3) : null;
+        domain.city = req.city != null ? new EncString(req.city) : null;
+        domain.state = req.state != null ? new EncString(req.state) : null;
+        domain.postalCode = req.postalCode != null ? new EncString(req.postalCode) : null;
+        domain.country = req.country != null ? new EncString(req.country) : null;
+        domain.company = req.company != null ? new EncString(req.company) : null;
+        domain.email = req.email != null ? new EncString(req.email) : null;
+        domain.phone = req.phone != null ? new EncString(req.phone) : null;
+        domain.ssn = req.ssn != null ? new EncString(req.ssn) : null;
+        domain.username = req.username != null ? new EncString(req.username) : null;
+        domain.passportNumber = req.passportNumber != null ? new EncString(req.passportNumber) : null;
+        domain.licenseNumber = req.licenseNumber != null ? new EncString(req.licenseNumber) : null;
         return domain;
     }
 

--- a/src/models/export/login.ts
+++ b/src/models/export/login.ts
@@ -2,7 +2,7 @@ import { LoginUri } from './loginUri';
 
 import { LoginView } from '../view/loginView';
 
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 import { Login as LoginDomain } from '../domain/login';
 
 export class Login {
@@ -29,9 +29,9 @@ export class Login {
         if (req.uris != null) {
             domain.uris = req.uris.map(u => LoginUri.toDomain(u));
         }
-        domain.username = req.username != null ? new CipherString(req.username) : null;
-        domain.password = req.password != null ? new CipherString(req.password) : null;
-        domain.totp = req.totp != null ? new CipherString(req.totp) : null;
+        domain.username = req.username != null ? new EncString(req.username) : null;
+        domain.password = req.password != null ? new EncString(req.password) : null;
+        domain.totp = req.totp != null ? new EncString(req.totp) : null;
         return domain;
     }
 

--- a/src/models/export/loginUri.ts
+++ b/src/models/export/loginUri.ts
@@ -2,7 +2,7 @@ import { UriMatchType } from '../../enums/uriMatchType';
 
 import { LoginUriView } from '../view/loginUriView';
 
-import { CipherString } from '../domain/cipherString';
+import { EncString } from '../domain/encString';
 import { LoginUri as LoginUriDomain } from '../domain/loginUri';
 
 export class LoginUri {
@@ -20,7 +20,7 @@ export class LoginUri {
     }
 
     static toDomain(req: LoginUri, domain = new LoginUriDomain()) {
-        domain.uri = req.uri != null ? new CipherString(req.uri) : null;
+        domain.uri = req.uri != null ? new EncString(req.uri) : null;
         domain.match = req.match;
         return domain;
     }

--- a/src/services/azureFileUpload.service.ts
+++ b/src/services/azureFileUpload.service.ts
@@ -2,7 +2,7 @@ import { LogService } from '../abstractions/log.service';
 
 import { Utils } from '../misc/utils';
 
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
 
 const MAX_SINGLE_BLOB_UPLOAD_SIZE = 256 * 1024 * 1024; // 256 MiB
 const MAX_BLOCKS_PER_BLOB = 50000;
@@ -10,14 +10,14 @@ const MAX_BLOCKS_PER_BLOB = 50000;
 export class AzureFileUploadService {
     constructor(private logService: LogService) { }
 
-    async upload(url: string, data: CipherArrayBuffer, renewalCallback: () => Promise<string>) {
+    async upload(url: string, data: EncArrayBuffer, renewalCallback: () => Promise<string>) {
         if (data.buffer.byteLength <= MAX_SINGLE_BLOB_UPLOAD_SIZE) {
             return await this.azureUploadBlob(url, data);
         } else {
             return await this.azureUploadBlocks(url, data, renewalCallback);
         }
     }
-    private async azureUploadBlob(url: string, data: CipherArrayBuffer) {
+    private async azureUploadBlob(url: string, data: EncArrayBuffer) {
         const urlObject = Utils.getUrl(url);
         const headers = new Headers({
             'x-ms-date': new Date().toUTCString(),
@@ -39,7 +39,7 @@ export class AzureFileUploadService {
             throw new Error(`Failed to create Azure blob: ${blobResponse.status}`);
         }
     }
-    private async azureUploadBlocks(url: string, data: CipherArrayBuffer, renewalCallback: () => Promise<string>) {
+    private async azureUploadBlocks(url: string, data: EncArrayBuffer, renewalCallback: () => Promise<string>) {
         const baseUrl = Utils.getUrl(url);
         const blockSize = this.getMaxBlockSize(baseUrl.searchParams.get('sv'));
         let blockIndex = 0;

--- a/src/services/bitwardenFileUpload.service.ts
+++ b/src/services/bitwardenFileUpload.service.ts
@@ -1,6 +1,6 @@
 import { ApiService } from '../abstractions/api.service';
 
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
 
 import { Utils } from '../misc/utils';
 
@@ -8,7 +8,7 @@ export class BitwardenFileUploadService
 {
     constructor(private apiService: ApiService) { }
 
-    async upload(encryptedFileName: string, encryptedFileData: CipherArrayBuffer, apiCall: (fd: FormData) => Promise<any>) {
+    async upload(encryptedFileName: string, encryptedFileData: EncArrayBuffer, apiCall: (fd: FormData) => Promise<any>) {
         const fd = new FormData();
         try {
             const blob = new Blob([encryptedFileData.buffer], { type: 'application/octet-stream' });

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -7,9 +7,9 @@ import { CipherData } from '../models/data/cipherData';
 import { Attachment } from '../models/domain/attachment';
 import { Card } from '../models/domain/card';
 import { Cipher } from '../models/domain/cipher';
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
-import { CipherString } from '../models/domain/cipherString';
 import Domain from '../models/domain/domainBase';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
+import { EncString } from '../models/domain/encString';
 import { Field } from '../models/domain/field';
 import { Identity } from '../models/domain/identity';
 import { Login } from '../models/domain/login';
@@ -656,8 +656,8 @@ export class CipherService implements CipherServiceAbstraction {
      * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
      * This method still exists for backward compatibility with old server versions.
      */
-    async legacyServerAttachmentFileUpload(admin: boolean, cipherId: string, encFileName: CipherString,
-        encData: CipherArrayBuffer, key: CipherString) {
+    async legacyServerAttachmentFileUpload(admin: boolean, cipherId: string, encFileName: EncString,
+        encData: EncArrayBuffer, key: EncString) {
         const fd = new FormData();
         try {
             const blob = new Blob([encData.buffer], { type: 'application/octet-stream' });
@@ -1012,7 +1012,7 @@ export class CipherService implements CipherServiceAbstraction {
                         return self.cryptoService.encrypt(modelProp, key);
                     }
                     return null;
-                }).then((val: CipherString) => {
+                }).then((val: EncString) => {
                     (theObj as any)[theProp] = val;
                 });
                 promises.push(p);

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -3,9 +3,9 @@ import * as bigInt from 'big-integer';
 import { EncryptionType } from '../enums/encryptionType';
 import { KdfType } from '../enums/kdfType';
 
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
-import { CipherString } from '../models/domain/cipherString';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
 import { EncryptedObject } from '../models/domain/encryptedObject';
+import { EncString } from '../models/domain/encString';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
 
@@ -134,7 +134,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         }
 
         let decEncKey: ArrayBuffer;
-        const encKeyCipher = new CipherString(encKey);
+        const encKeyCipher = new EncString(encKey);
         if (encKeyCipher.encryptionType === EncryptionType.AesCbc256_B64) {
             decEncKey = await this.decryptToBytes(encKeyCipher, key);
         } else if (encKeyCipher.encryptionType === EncryptionType.AesCbc256_HmacSha256_B64) {
@@ -175,7 +175,7 @@ export class CryptoService implements CryptoServiceAbstraction {
             return null;
         }
 
-        this.privateKey = await this.decryptToBytes(new CipherString(encPrivateKey), null);
+        this.privateKey = await this.decryptToBytes(new EncString(encPrivateKey), null);
         return this.privateKey;
     }
 
@@ -325,28 +325,28 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
 
     async makeKeyFromPin(pin: string, salt: string, kdf: KdfType, kdfIterations: number,
-        protectedKeyCs: CipherString = null):
+        protectedKeyCs: EncString = null):
         Promise<SymmetricCryptoKey> {
         if (protectedKeyCs == null) {
             const pinProtectedKey = await this.storageService.get<string>(ConstantsService.pinProtectedKey);
             if (pinProtectedKey == null) {
                 throw new Error('No PIN protected key found.');
             }
-            protectedKeyCs = new CipherString(pinProtectedKey);
+            protectedKeyCs = new EncString(pinProtectedKey);
         }
         const pinKey = await this.makePinKey(pin, salt, kdf, kdfIterations);
         const decKey = await this.decryptToBytes(protectedKeyCs, pinKey);
         return new SymmetricCryptoKey(decKey);
     }
 
-    async makeShareKey(): Promise<[CipherString, SymmetricCryptoKey]> {
+    async makeShareKey(): Promise<[EncString, SymmetricCryptoKey]> {
         const shareKey = await this.cryptoFunctionService.randomBytes(64);
         const publicKey = await this.getPublicKey();
         const encShareKey = await this.rsaEncrypt(shareKey, publicKey);
         return [encShareKey, new SymmetricCryptoKey(shareKey)];
     }
 
-    async makeKeyPair(key?: SymmetricCryptoKey): Promise<[string, CipherString]> {
+    async makeKeyPair(key?: SymmetricCryptoKey): Promise<[string, EncString]> {
         const keyPair = await this.cryptoFunctionService.rsaGenerateKeyPair(2048);
         const publicB64 = Utils.fromBufferToB64(keyPair[0]);
         const privateEnc = await this.encrypt(keyPair[1], key);
@@ -375,20 +375,20 @@ export class CryptoService implements CryptoServiceAbstraction {
         return Utils.fromBufferToB64(hash);
     }
 
-    async makeEncKey(key: SymmetricCryptoKey): Promise<[SymmetricCryptoKey, CipherString]> {
+    async makeEncKey(key: SymmetricCryptoKey): Promise<[SymmetricCryptoKey, EncString]> {
         const theKey = await this.getKeyForEncryption(key);
         const encKey = await this.cryptoFunctionService.randomBytes(64);
         return this.buildEncKey(theKey, encKey);
     }
 
-    async remakeEncKey(key: SymmetricCryptoKey, encKey?: SymmetricCryptoKey): Promise<[SymmetricCryptoKey, CipherString]> {
+    async remakeEncKey(key: SymmetricCryptoKey, encKey?: SymmetricCryptoKey): Promise<[SymmetricCryptoKey, EncString]> {
         if (encKey == null) {
             encKey = await this.getEncKey();
         }
         return this.buildEncKey(key, encKey.key);
     }
 
-    async encrypt(plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey): Promise<CipherString> {
+    async encrypt(plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey): Promise<EncString> {
         if (plainValue == null) {
             return Promise.resolve(null);
         }
@@ -404,10 +404,10 @@ export class CryptoService implements CryptoServiceAbstraction {
         const iv = Utils.fromBufferToB64(encObj.iv);
         const data = Utils.fromBufferToB64(encObj.data);
         const mac = encObj.mac != null ? Utils.fromBufferToB64(encObj.mac) : null;
-        return new CipherString(encObj.key.encType, data, iv, mac);
+        return new EncString(encObj.key.encType, data, iv, mac);
     }
 
-    async encryptToBytes(plainValue: ArrayBuffer, key?: SymmetricCryptoKey): Promise<CipherArrayBuffer> {
+    async encryptToBytes(plainValue: ArrayBuffer, key?: SymmetricCryptoKey): Promise<EncArrayBuffer> {
         const encValue = await this.aesEncrypt(plainValue, key);
         let macLen = 0;
         if (encValue.mac != null) {
@@ -422,10 +422,10 @@ export class CryptoService implements CryptoServiceAbstraction {
         }
 
         encBytes.set(new Uint8Array(encValue.data), 1 + encValue.iv.byteLength + macLen);
-        return new CipherArrayBuffer(encBytes.buffer);
+        return new EncArrayBuffer(encBytes.buffer);
     }
 
-    async rsaEncrypt(data: ArrayBuffer, publicKey?: ArrayBuffer): Promise<CipherString> {
+    async rsaEncrypt(data: ArrayBuffer, publicKey?: ArrayBuffer): Promise<EncString> {
         if (publicKey == null) {
             publicKey = await this.getPublicKey();
         }
@@ -434,7 +434,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         }
 
         const encBytes = await this.cryptoFunctionService.rsaEncrypt(data, publicKey, 'sha1');
-        return new CipherString(EncryptionType.Rsa2048_OaepSha1_B64, Utils.fromBufferToB64(encBytes));
+        return new EncString(EncryptionType.Rsa2048_OaepSha1_B64, Utils.fromBufferToB64(encBytes));
     }
 
     async rsaDecrypt(encValue: string): Promise<ArrayBuffer> {
@@ -489,11 +489,11 @@ export class CryptoService implements CryptoServiceAbstraction {
         return this.cryptoFunctionService.rsaDecrypt(data, privateKey, alg);
     }
 
-    async decryptToBytes(cipherString: CipherString, key?: SymmetricCryptoKey): Promise<ArrayBuffer> {
-        const iv = Utils.fromB64ToArray(cipherString.iv).buffer;
-        const data = Utils.fromB64ToArray(cipherString.data).buffer;
-        const mac = cipherString.mac ? Utils.fromB64ToArray(cipherString.mac).buffer : null;
-        const decipher = await this.aesDecryptToBytes(cipherString.encryptionType, data, iv, mac, key);
+    async decryptToBytes(encString: EncString, key?: SymmetricCryptoKey): Promise<ArrayBuffer> {
+        const iv = Utils.fromB64ToArray(encString.iv).buffer;
+        const data = Utils.fromB64ToArray(encString.data).buffer;
+        const mac = encString.mac ? Utils.fromB64ToArray(encString.mac).buffer : null;
+        const decipher = await this.aesDecryptToBytes(encString.encryptionType, data, iv, mac, key);
         if (decipher == null) {
             return null;
         }
@@ -501,9 +501,9 @@ export class CryptoService implements CryptoServiceAbstraction {
         return decipher;
     }
 
-    async decryptToUtf8(cipherString: CipherString, key?: SymmetricCryptoKey): Promise<string> {
-        return await this.aesDecryptToUtf8(cipherString.encryptionType, cipherString.data,
-            cipherString.iv, cipherString.mac, key);
+    async decryptToUtf8(encString: EncString, key?: SymmetricCryptoKey): Promise<string> {
+        return await this.aesDecryptToUtf8(encString.encryptionType, encString.data,
+            encString.iv, encString.mac, key);
     }
 
     async decryptFromBytes(encBuf: ArrayBuffer, key: SymmetricCryptoKey): Promise<ArrayBuffer> {
@@ -715,8 +715,8 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
 
     private async buildEncKey(key: SymmetricCryptoKey, encKey: ArrayBuffer)
-        : Promise<[SymmetricCryptoKey, CipherString]> {
-        let encKeyEnc: CipherString = null;
+        : Promise<[SymmetricCryptoKey, EncString]> {
+        let encKeyEnc: EncString = null;
         if (key.key.byteLength === 32) {
             const newKey = await this.stretchKey(key);
             encKeyEnc = await this.encrypt(encKey, newKey);

--- a/src/services/fileUpload.service.ts
+++ b/src/services/fileUpload.service.ts
@@ -4,8 +4,8 @@ import { LogService } from '../abstractions/log.service';
 
 import { FileUploadType } from '../enums/fileUploadType';
 
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
-import { CipherString } from '../models/domain/cipherString';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
+import { EncString } from '../models/domain/encString';
 
 import { AttachmentUploadDataResponse } from '../models/response/attachmentUploadDataResponse';
 import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDataResponse';
@@ -22,7 +22,7 @@ export class FileUploadService implements FileUploadServiceAbstraction {
         this.bitwardenFileUploadService = new BitwardenFileUploadService(apiService);
     }
 
-    async uploadSendFile(uploadData: SendFileUploadDataResponse, fileName: CipherString, encryptedFileData: CipherArrayBuffer) {
+    async uploadSendFile(uploadData: SendFileUploadDataResponse, fileName: EncString, encryptedFileData: EncArrayBuffer) {
         try {
             switch (uploadData.fileUploadType) {
                 case FileUploadType.Direct:
@@ -47,7 +47,7 @@ export class FileUploadService implements FileUploadServiceAbstraction {
         }
     }
 
-    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: string, encryptedFileData: CipherArrayBuffer) {
+    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: string, encryptedFileData: EncArrayBuffer) {
         const response = admin ? uploadData.cipherMiniResponse : uploadData.cipherResponse;
         try {
             switch (uploadData.fileUploadType) {

--- a/src/services/passwordGeneration.service.ts
+++ b/src/services/passwordGeneration.service.ts
@@ -1,6 +1,6 @@
 import * as zxcvbn from 'zxcvbn';
 
-import { CipherString } from '../models/domain/cipherString';
+import { EncString } from '../models/domain/encString';
 import { GeneratedPasswordHistory } from '../models/domain/generatedPasswordHistory';
 import { PasswordGeneratorPolicyOptions } from '../models/domain/passwordGeneratorPolicyOptions';
 import { Policy } from '../models/domain/policy';
@@ -485,7 +485,7 @@ export class PasswordGenerationService implements PasswordGenerationServiceAbstr
         }
 
         const promises = history.map(async item => {
-            const decrypted = await this.cryptoService.decryptToUtf8(new CipherString(item.password));
+            const decrypted = await this.cryptoService.decryptToUtf8(new EncString(item.password));
             return new GeneratedPasswordHistory(decrypted, item.date);
         });
 

--- a/src/services/send.service.ts
+++ b/src/services/send.service.ts
@@ -5,8 +5,8 @@ import { SendRequest } from '../models/request/sendRequest';
 import { ErrorResponse } from '../models/response/errorResponse';
 import { SendResponse } from '../models/response/sendResponse';
 
-import { CipherArrayBuffer } from '../models/domain/cipherArrayBuffer';
-import { CipherString } from '../models/domain/cipherString';
+import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
+import { EncString } from '../models/domain/encString';
 import { Send } from '../models/domain/send';
 import { SendFile } from '../models/domain/sendFile';
 import { SendText } from '../models/domain/sendText';
@@ -45,8 +45,8 @@ export class SendService implements SendServiceAbstraction {
     }
 
     async encrypt(model: SendView, file: File | ArrayBuffer, password: string,
-        key?: SymmetricCryptoKey): Promise<[Send, CipherArrayBuffer]> {
-        let fileData: CipherArrayBuffer = null;
+        key?: SymmetricCryptoKey): Promise<[Send, EncArrayBuffer]> {
+        let fileData: EncArrayBuffer = null;
         const send = new Send();
         send.id = model.id;
         send.type = model.type;
@@ -132,7 +132,7 @@ export class SendService implements SendServiceAbstraction {
         return this.decryptedSendCache;
     }
 
-    async saveWithServer(sendData: [Send, CipherArrayBuffer]): Promise<any> {
+    async saveWithServer(sendData: [Send, EncArrayBuffer]): Promise<any> {
         const request = new SendRequest(sendData[0], sendData[1]?.buffer.byteLength);
         let response: SendResponse;
         if (sendData[0].id == null) {
@@ -169,7 +169,7 @@ export class SendService implements SendServiceAbstraction {
      * @deprecated Mar 25 2021: This method has been deprecated in favor of direct uploads.
      * This method still exists for backward compatibility with old server versions.
      */
-    async legacyServerSendFileUpload(sendData: [Send, CipherArrayBuffer], request: SendRequest): Promise<SendResponse>
+    async legacyServerSendFileUpload(sendData: [Send, EncArrayBuffer], request: SendRequest): Promise<SendResponse>
     {
         const fd = new FormData();
         try {
@@ -257,7 +257,7 @@ export class SendService implements SendServiceAbstraction {
         await this.upsert(data);
     }
 
-    private parseFile(send: Send, file: File, key: SymmetricCryptoKey): Promise<CipherArrayBuffer> {
+    private parseFile(send: Send, file: File, key: SymmetricCryptoKey): Promise<EncArrayBuffer> {
         return new Promise((resolve, reject) => {
             const reader = new FileReader();
             reader.readAsArrayBuffer(file);
@@ -277,7 +277,7 @@ export class SendService implements SendServiceAbstraction {
     }
 
     private async encryptFileData(fileName: string, data: ArrayBuffer,
-        key: SymmetricCryptoKey): Promise<[CipherString, CipherArrayBuffer]> {
+        key: SymmetricCryptoKey): Promise<[EncString, EncArrayBuffer]> {
         const encFileName = await this.cryptoService.encrypt(fileName, key);
         const encFileData = await this.cryptoService.encryptToBytes(data, key);
         return [encFileName, encFileData];

--- a/src/services/vaultTimeout.service.ts
+++ b/src/services/vaultTimeout.service.ts
@@ -12,10 +12,10 @@ import { TokenService } from '../abstractions/token.service';
 import { UserService } from '../abstractions/user.service';
 import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from '../abstractions/vaultTimeout.service';
 
-import { CipherString } from '../models/domain/cipherString';
+import { EncString } from '../models/domain/encString';
 
 export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
-    pinProtectedKey: CipherString = null;
+    pinProtectedKey: EncString = null;
     biometricLocked: boolean = true;
 
     private inited = false;


### PR DESCRIPTION
# Overview

Discussions over this PR: https://github.com/bitwarden/mobile/pull/1366 prompted starting to remove the overloading of `Cipher` between the db table and the cryptographic concept. This PR renames `CipherString` and the newly created `CipherArrayBuffer` to `EncString` and `EncArrayBuffer`.

Each client will need updating, but there should be no impact to any functionality.

### TODO

- [ ] web
- [ ] browser
- [ ] CLI
- [ ] Desktop
- [ ] Directory-connector