### PR TITLE
Update color-password.pipe.js to handle Unicode/Emoji correctly accross platforms.

### DIFF
--- a/src/angular/pipes/color-password.pipe.ts
+++ b/src/angular/pipes/color-password.pipe.ts
@@ -3,15 +3,20 @@ import {
     PipeTransform,
 } from '@angular/core';
 
-/**
- * A pipe that sanitizes HTML and highlights numbers and special characters (in different colors each).
- */
+/*
+ An updated pipe that sanitizes HTML, highlights numbers and special characters (in different colors each)
+ and handles Unicode / Emoji characters correctly.
+*/
 @Pipe({ name: 'colorPassword' })
 export class ColorPasswordPipe implements PipeTransform {
     transform(password: string) {
+        // Regex Unicode property escapes for checking if emoji in passwords.
+        const regexpEmojiPresentation = /\p{Emoji_Presentation}/gu;
+        // Convert to an array to handle cases that stings have special characters, ie: emoji.
+        const passwordArray = Array.from(password);
         let colorizedPassword = '';
-        for (let i = 0; i < password.length; i++) {
-            let character = password[i];
+        for (let i = 0; i < passwordArray.length; i++) {
+            let character = passwordArray[i];
             let isSpecial = false;
             // Sanitize HTML first.
             switch (character) {
@@ -35,7 +40,9 @@ export class ColorPasswordPipe implements PipeTransform {
                     break;
             }
             let type = 'letter';
-            if (isSpecial || character.match(/[^\w ]/)) {
+            if (character.match(regexpEmojiPresentation)) {
+                type = 'emoji';
+            } else if (isSpecial || character.match(/[^\w ]/)) {
                 type = 'special';
             } else if (character.match(/\d/)) {
                 type = 'number';


### PR DESCRIPTION
Original PR on `Desktop`: 

- [#844](https://github.com/bitwarden/desktop/pull/844#event-4628417442)

Issues this PR is related to: 

- [#768](https://github.com/bitwarden/desktop/issues/768)
- [#1682](https://github.com/bitwarden/browser/issues/1682)

The issue is associated with an angular pipe ColorPasswordPipe used for sanitizing HTML and colorizing the password. Unicode characters do not play well with this Pipe because of issues with Unicode, ie: "💩".length === 2, and how it parsed through a basic string. I've updated the Pipe to use [Array.from](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) because it is a simple approach that will keep Unicode characters properly grouped. I've also set the type for emoji in case there are any desires to implement specific styling.

I've noticed that this issue does not exist on Web because Web does not implement the ColorPasswordPipe (maybe it should be implemented?). I confirmed locally that this fix works both on browser and Desktop.