### PR TITLE
Specify Organization indexed on search service

### DIFF
--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -2,9 +2,10 @@ import { CipherView } from '../models/view/cipherView';
 import { SendView } from '../models/view/sendView';
 
 export abstract class SearchService {
+    indexedEntityId?: string = null;
     clearIndex: () => void;
     isSearchable: (query: string) => boolean;
-    indexCiphers: (ciphersToIndex?: CipherView[]) => Promise<void>;
+    indexCiphers: (indexedEntityGuid?: string, ciphersToIndex?: CipherView[]) => Promise<void>;
     searchCiphers: (query: string,
         filter?: ((cipher: CipherView) => boolean) | (((cipher: CipherView) => boolean)[]),
         ciphers?: CipherView[]) => Promise<CipherView[]>;

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -295,7 +295,7 @@ export class CipherService implements CipherServiceAbstraction {
     async getAllDecrypted(): Promise<CipherView[]> {
         if (this.decryptedCipherCache != null) {
             const userId = await this.userService.getUserId();
-            if ((this.searchService().indexedEntityId ?? userId) != userId)
+            if ((this.searchService().indexedEntityId ?? userId) !== userId)
             {
                 await this.searchService().indexCiphers();
             }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -294,6 +294,11 @@ export class CipherService implements CipherServiceAbstraction {
     @sequentialize(() => 'getAllDecrypted')
     async getAllDecrypted(): Promise<CipherView[]> {
         if (this.decryptedCipherCache != null) {
+            const userId = await this.userService.getUserId();
+            if ((this.searchService().indexedEntityId ?? userId) != userId)
+            {
+                await this.searchService().indexCiphers();
+            }
             return this.decryptedCipherCache;
         }
 

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -13,6 +13,7 @@ import { UriMatchType } from '../enums/uriMatchType';
 import { SendView } from '../models/view/sendView';
 
 export class SearchService implements SearchServiceAbstraction {
+    indexedEntityId?: string = null;
     private indexing = false;
     private index: lunr.Index = null;
     private searchableMinLength = 2;
@@ -34,7 +35,7 @@ export class SearchService implements SearchServiceAbstraction {
         return !notSearchable;
     }
 
-    async indexCiphers(ciphers?: CipherView[]): Promise<void> {
+    async indexCiphers(indexedEntityId?: string, ciphers?: CipherView[]): Promise<void> {
         if (this.indexing) {
             return;
         }
@@ -69,6 +70,7 @@ export class SearchService implements SearchServiceAbstraction {
         ciphers = ciphers || await this.cipherService.getAllDecrypted();
         ciphers.forEach(c => builder.add(c));
         this.index = builder.build();
+        this.indexedEntityId = indexedEntityId;
         this.indexing = false;
 
         this.logService.timeEnd('search indexing');


### PR DESCRIPTION
# Overview

Fixes https://app.asana.com/0/1169444489336079/1183168049159854/f. A defect in organization vault advanced searching.

Searching a user vault after searching an organization vault leaves a subset index on SearchService which consists only on org vault items. To fix this, I've added a property to SearchService that indicates the entity for which an index was built.

A null indexedEntityId specifies it is the users entire vault. Otherwise, organizations specify their id to signify the index is a subset.

User's vault will re-index if the indexed entity does not match the users id or null. At the moment, user's vault does not set userId because indexing occurs in the setter for decryptedCipherCache, which cannot be asynchronous.

# Files Changed
* **search.service.ts**: Update indexing to accept indexedEntity and set public parameter.
* **cipher.service.ts**: When grabbing decrypted ciphers (which occurs on all searches with no specified cipher list), validate the entity against which the index was built. If it was built for a non-user vault, re-build the index for the full vault.

# Testing
In addition to testing the error scenario, this fix may impact index creation time. While steps have been taken to minimize indexing, a large vault should be searched several times to ensure performance is up to par.

### TODO
update jslib in web and set organization id in the organization vault indexing method.
 - [ ] web
Web is the only impacted client since no other clients have separated organization vaults.

- [ ] cherry pick to `rc` branch