### PR TITLE
Allow external awaits of indexing

### DIFF
--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -4,7 +4,6 @@ import { SendView } from '../models/view/sendView';
 export abstract class SearchService {
     indexedEntityId?: string = null;
     clearIndex: () => void;
-    awaitAndClearIndex: () => Promise<void>;
     isSearchable: (query: string) => boolean;
     indexCiphers: (indexedEntityGuid?: string, ciphersToIndex?: CipherView[]) => Promise<void>;
     searchCiphers: (query: string,

--- a/src/abstractions/search.service.ts
+++ b/src/abstractions/search.service.ts
@@ -4,6 +4,7 @@ import { SendView } from '../models/view/sendView';
 export abstract class SearchService {
     indexedEntityId?: string = null;
     clearIndex: () => void;
+    awaitAndClearIndex: () => Promise<void>;
     isSearchable: (query: string) => boolean;
     indexCiphers: (indexedEntityGuid?: string, ciphersToIndex?: CipherView[]) => Promise<void>;
     searchCiphers: (query: string,

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -295,9 +295,10 @@ export class CipherService implements CipherServiceAbstraction {
     async getAllDecrypted(): Promise<CipherView[]> {
         if (this.decryptedCipherCache != null) {
             const userId = await this.userService.getUserId();
-            if ((this.searchService().indexedEntityId ?? userId) !== userId)
+            if (this.searchService().indexedEntityId ?? userId !== userId)
             {
-                await this.searchService().indexCiphers();
+                await this.searchService().awaitAndClearIndex();
+                this.searchService().indexCiphers();
             }
             return this.decryptedCipherCache;
         }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -295,10 +295,9 @@ export class CipherService implements CipherServiceAbstraction {
     async getAllDecrypted(): Promise<CipherView[]> {
         if (this.decryptedCipherCache != null) {
             const userId = await this.userService.getUserId();
-            if (this.searchService().indexedEntityId ?? userId !== userId)
+            if ((this.searchService().indexedEntityId ?? userId) !== userId)
             {
-                await this.searchService().awaitAndClearIndex();
-                this.searchService().indexCiphers();
+                await this.searchService().indexCiphers(userId, this.decryptedCipherCache);
             }
             return this.decryptedCipherCache;
         }

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -17,7 +17,6 @@ export class SearchService implements SearchServiceAbstraction {
     private indexing = false;
     private index: lunr.Index = null;
     private searchableMinLength = 2;
-    private indexingPromise: Promise<void> = null;
 
     constructor(private cipherService: CipherService, private logService: LogService,
         private i18nService: I18nService) {
@@ -29,13 +28,6 @@ export class SearchService implements SearchServiceAbstraction {
     clearIndex(): void {
         this.indexedEntityId = null;
         this.index = null;
-    }
-
-    async awaitAndClearIndex(): Promise<void> {
-        if (this.indexing && this.indexingPromise != null) {
-            await this.indexingPromise;
-        }
-        this.clearIndex();
     }
 
     isSearchable(query: string): boolean {
@@ -52,8 +44,35 @@ export class SearchService implements SearchServiceAbstraction {
         this.logService.time('search indexing');
         this.indexing = true;
         this.indexedEntityId = indexedEntityId;
-        this.indexingPromise = this.indexCiphersWork(ciphers);
-        await this.indexingPromise;
+        this.index = null;
+        const builder = new lunr.Builder();
+        builder.ref('id');
+        builder.field('shortid', { boost: 100, extractor: (c: CipherView) => c.id.substr(0, 8) });
+        builder.field('name', { boost: 10 });
+        builder.field('subtitle', {
+            boost: 5,
+            extractor: (c: CipherView) => {
+                if (c.subTitle != null && c.type === CipherType.Card) {
+                    return c.subTitle.replace(/\*/g, '');
+                }
+                return c.subTitle;
+            },
+        });
+        builder.field('notes');
+        builder.field('login.username', {
+            extractor: (c: CipherView) => c.type === CipherType.Login && c.login != null ? c.login.username : null,
+        });
+        builder.field('login.uris', { boost: 2, extractor: (c: CipherView) => this.uriExtractor(c) });
+        builder.field('fields', { extractor: (c: CipherView) => this.fieldExtractor(c, false) });
+        builder.field('fields_joined', { extractor: (c: CipherView) => this.fieldExtractor(c, true) });
+        builder.field('attachments', { extractor: (c: CipherView) => this.attachmentExtractor(c, false) });
+        builder.field('attachments_joined',
+            { extractor: (c: CipherView) => this.attachmentExtractor(c, true) });
+        builder.field('organizationid', { extractor: (c: CipherView) => c.organizationId });
+        ciphers = ciphers || await this.cipherService.getAllDecrypted();
+        ciphers.forEach(c => builder.add(c));
+        this.index = builder.build();
+
         this.indexing = false;
 
         this.logService.timeEnd('search indexing');
@@ -247,36 +266,5 @@ export class SearchService implements SearchServiceAbstraction {
             uris.push(uri);
         });
         return uris.length > 0 ? uris : null;
-    }
-
-    private async indexCiphersWork(ciphers?: CipherView[]) {
-        this.index = null;
-        const builder = new lunr.Builder();
-        builder.ref('id');
-        builder.field('shortid', { boost: 100, extractor: (c: CipherView) => c.id.substr(0, 8) });
-        builder.field('name', { boost: 10 });
-        builder.field('subtitle', {
-            boost: 5,
-            extractor: (c: CipherView) => {
-                if (c.subTitle != null && c.type === CipherType.Card) {
-                    return c.subTitle.replace(/\*/g, '');
-                }
-                return c.subTitle;
-            },
-        });
-        builder.field('notes');
-        builder.field('login.username', {
-            extractor: (c: CipherView) => c.type === CipherType.Login && c.login != null ? c.login.username : null,
-        });
-        builder.field('login.uris', { boost: 2, extractor: (c: CipherView) => this.uriExtractor(c) });
-        builder.field('fields', { extractor: (c: CipherView) => this.fieldExtractor(c, false) });
-        builder.field('fields_joined', { extractor: (c: CipherView) => this.fieldExtractor(c, true) });
-        builder.field('attachments', { extractor: (c: CipherView) => this.attachmentExtractor(c, false) });
-        builder.field('attachments_joined',
-            { extractor: (c: CipherView) => this.attachmentExtractor(c, true) });
-        builder.field('organizationid', { extractor: (c: CipherView) => c.organizationId });
-        ciphers = ciphers || await this.cipherService.getAllDecrypted();
-        ciphers.forEach(c => builder.add(c));
-        this.index = builder.build();
     }
 }


### PR DESCRIPTION
# Overview 

Fix for issue I missed while developing #356. We were getting stuck in an infinite load loop where we were basing logic on a dirty state of search service. This await enables us to wait until an index is complete, then update it rather than being kicked out of indexing early because it is in progress.

This allows `CipherService` to await indexing and restart with the full ciphers list.

# Files Changed
* **search.service**: move indexing hard work to a private method so we can store its promise and allow for outside awaits on it. Add await and clear method that will block until indexing is completed then clear out the index. Also reset indexedEntity value when clearing index.
* **cipher.service**: await and clear index prior to re-indexing if the indexed entity is not the full vault.