### PR TITLE
Fix auth error if last block put takes too long

### DIFF
--- a/src/services/azureFileUpload.service.ts
+++ b/src/services/azureFileUpload.service.ts
@@ -84,6 +84,7 @@ export class AzureFileUploadService {
                 blockIndex++;
             }
 
+            url = await this.renewUrlIfNecessary(url, renewalCallback);
             const blockListUrl = Utils.getUrl(url);
             const blockListXml = this.blockListXml(blocksStaged);
             blockListUrl.searchParams.append('comp', 'blocklist');


### PR DESCRIPTION
# Overview

During an azure block upload, if the last block PUT request takes too long, the upload URL will time out prior to the block list request being sent up. This results in an authorization error.

The fix is the renew the upload url just prior to block list PUT as well.

### TODO:
 - [ ] push to `rc`
 - [ ] web
 - [ ] browser
 - [ ] cli
 - [ ] desktop