### PR TITLE
Change download to happen in the renderer

### DIFF
--- a/src/electron/services/electronMainMessaging.service.ts
+++ b/src/electron/services/electronMainMessaging.service.ts
@@ -19,17 +19,6 @@ export class ElectronMainMessagingService implements MessagingService {
             return dialog.showMessageBox(options);
         });
 
-        ipcMain.handle('saveFile', (event, options) => {
-            dialog.showSaveDialog(windowMain.win, {
-                defaultPath: options.fileName,
-                showsTagField: false,
-            }).then(ret => {
-                if (ret.filePath != null) {
-                    fs.writeFile(ret.filePath, options.buffer, { mode: 0o600 });
-                }
-            });
-        });
-
         ipcMain.handle('openContextMenu', (event, options: {menu: RendererMenuItem[]}) => {
             return new Promise(resolve => {
                 const menu = new Menu();

--- a/src/electron/services/electronPlatformUtils.service.ts
+++ b/src/electron/services/electronPlatformUtils.service.ts
@@ -97,10 +97,13 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
     }
 
     saveFile(win: Window, blobData: any, blobOptions: any, fileName: string): void {
-        ipcRenderer.invoke('saveFile', {
-            fileName: fileName,
-            buffer: Buffer.from(blobData),
-        });
+        const blob = new Blob([blobData], blobOptions);
+        const a = win.document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = fileName;
+        win.document.body.appendChild(a);
+        a.click();
+        win.document.body.removeChild(a);
     }
 
     getApplicationVersion(): Promise<string> {


### PR DESCRIPTION
## Objective
In #332 I removed the remote module and moved the save file logic to happen in the main process instead. This had the unfortunate side effect of slowing down file saving quite significantly for large files. Changing the logic to use the same download method we use in the browser extensions resolves this since we no longer need to send content between processes.

### Code Changes
- **src/electron/services/electronMainMessaging.service.ts**: Remove `saveFile` ipc handler.
- **src/electron/services/electronPlatformUtils.service.ts**: Change download to happen in the renderer.

### Testing Considerations
Verify downloading attachments works similar as before on all platforms.