### PR TITLE
Validate key before using it

### DIFF
--- a/src/abstractions/crypto.service.ts
+++ b/src/abstractions/crypto.service.ts
@@ -48,4 +48,5 @@ export abstract class CryptoService {
     decryptToUtf8: (encString: EncString, key?: SymmetricCryptoKey) => Promise<string>;
     decryptFromBytes: (encBuf: ArrayBuffer, key: SymmetricCryptoKey) => Promise<ArrayBuffer>;
     randomNumber: (min: number, max: number) => Promise<number>;
+    validateKey: (key: SymmetricCryptoKey) => Promise<boolean>;
 }

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -92,10 +92,9 @@ export class CryptoService implements CryptoServiceAbstraction {
         }
 
         const key = await this.secureStorageService.get<string>(Keys.key);
-
         if (key != null) {
             if (!await this.shouldStoreKey()) {
-                console.error("Throwing away stored key since settings have changed")
+                this.logService.warning('Throwing away stored key since settings have changed');
                 this.secureStorageService.remove(Keys.key);
                 return null;
             }
@@ -103,7 +102,7 @@ export class CryptoService implements CryptoServiceAbstraction {
             const symmetricKey = new SymmetricCryptoKey(Utils.fromB64ToArray(key).buffer);
 
             if (!await this.validateKey(symmetricKey)) {
-                console.error('Wrong key, throwing away stored key');
+                this.logService.warning('Wrong key, throwing away stored key');
                 this.secureStorageService.remove(Keys.key);
                 return null;
             }
@@ -598,10 +597,10 @@ export class CryptoService implements CryptoServiceAbstraction {
             if (encPrivateKey == null) {
                 return false;
             }
-    
+
             const encKey = await this.getEncKey(key);
             const privateKey = await this.decryptToBytes(new EncString(encPrivateKey), encKey);
-            await this.cryptoFunctionService.rsaExtractPublicKey(privateKey)
+            await this.cryptoFunctionService.rsaExtractPublicKey(privateKey);
         } catch (e) {
             return false;
         }


### PR DESCRIPTION
## Objective
When running multiple desktop applications (portable and installed) using different accounts it was possible for the application to get confused and use the wrong key to unlock and decrypt items. To avoid this we validate the key prior to returning it and should it be invalid we delete it from the storage.

### Code Changes
- **src/abstractions/crypto.service.ts**: Added new method `validateKey` used to check if the key is valid for the stored encKey.
- **src/services/crypto.service.ts**: Implemented `validateKey` and refactored `shouldStoreKey` to be more readable.
