### PR TITLE
Default values for cipher.reprompt

### DIFF
--- a/src/angular/components/add-edit.component.ts
+++ b/src/angular/components/add-edit.component.ts
@@ -228,6 +228,7 @@ export class AddEditComponent implements OnInit {
                 this.cipher.identity = new IdentityView();
                 this.cipher.secureNote = new SecureNoteView();
                 this.cipher.secureNote.type = SecureNoteType.Generic;
+                this.cipher.reprompt = CipherRepromptType.None;
             }
         }
 

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -15,6 +15,7 @@ import { FolderView } from '../models/view/folderView';
 import { LoginView } from '../models/view/loginView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
+import { CipherRepromptType } from '../enums/cipherRepromptType';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
@@ -292,6 +293,7 @@ export abstract class BaseImporter {
         cipher.fields = [];
         cipher.login = new LoginView();
         cipher.type = CipherType.Login;
+        cipher.reprompt = CipherRepromptType.None;
         return cipher;
     }
 

--- a/src/importers/baseImporter.ts
+++ b/src/importers/baseImporter.ts
@@ -293,7 +293,6 @@ export abstract class BaseImporter {
         cipher.fields = [];
         cipher.login = new LoginView();
         cipher.type = CipherType.Login;
-        cipher.reprompt = CipherRepromptType.None;
         return cipher;
     }
 

--- a/src/importers/bitwardenCsvImporter.ts
+++ b/src/importers/bitwardenCsvImporter.ts
@@ -10,6 +10,7 @@ import { FolderView } from '../models/view/folderView';
 import { LoginView } from '../models/view/loginView';
 import { SecureNoteView } from '../models/view/secureNoteView';
 
+import { CipherRepromptType } from '../enums/cipherRepromptType';
 import { CipherType } from '../enums/cipherType';
 import { FieldType } from '../enums/fieldType';
 import { SecureNoteType } from '../enums/secureNoteType';
@@ -55,6 +56,13 @@ export class BitwardenCsvImporter extends BaseImporter implements Importer {
             cipher.type = CipherType.Login;
             cipher.notes = this.getValueOrDefault(value.notes);
             cipher.name = this.getValueOrDefault(value.name, '--');
+            try {
+                cipher.reprompt = parseInt(this.getValueOrDefault(value.reprompt, CipherRepromptType.None.toString()), 10);
+            } catch (e) {
+                // tslint:disable-next-line
+                console.error('Unable to parse reprompt value', e);
+                cipher.reprompt = CipherRepromptType.None;
+            }
 
             if (!this.isNullOrWhitespace(value.fields)) {
                 const fields = this.splitNewLine(value.fields);

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -27,6 +27,7 @@ export class Cipher {
         req.secureNote = null;
         req.card = null;
         req.identity = null;
+        req.reprompt = CipherRepromptType.None;
         return req;
     }
 
@@ -43,7 +44,7 @@ export class Cipher {
         view.name = req.name;
         view.notes = req.notes;
         view.favorite = req.favorite;
-        view.reprompt = CipherRepromptType.None;
+        view.reprompt = req.reprompt;
 
         if (req.fields != null) {
             view.fields = req.fields.map(f => Field.toView(f));
@@ -76,6 +77,7 @@ export class Cipher {
         domain.name = req.name != null ? new EncString(req.name) : null;
         domain.notes = req.notes != null ? new EncString(req.notes) : null;
         domain.favorite = req.favorite;
+        domain.reprompt = req.reprompt;
 
         if (req.fields != null) {
             domain.fields = req.fields.map(f => Field.toDomain(f));
@@ -111,12 +113,14 @@ export class Cipher {
     secureNote: SecureNote;
     card: Card;
     identity: Identity;
+    reprompt: CipherRepromptType;
 
     // Use build method instead of ctor so that we can control order of JSON stringify for pretty print
     build(o: CipherView | CipherDomain) {
         this.organizationId = o.organizationId;
         this.folderId = o.folderId;
         this.type = o.type;
+        this.reprompt = o.reprompt;
 
         if (o instanceof CipherView) {
             this.name = o.name;

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -44,7 +44,7 @@ export class Cipher {
         view.name = req.name;
         view.notes = req.notes;
         view.favorite = req.favorite;
-        view.reprompt = req.reprompt;
+        view.reprompt = req.reprompt ?? CipherRepromptType.None;
 
         if (req.fields != null) {
             view.fields = req.fields.map(f => Field.toView(f));
@@ -77,7 +77,7 @@ export class Cipher {
         domain.name = req.name != null ? new EncString(req.name) : null;
         domain.notes = req.notes != null ? new EncString(req.notes) : null;
         domain.favorite = req.favorite;
-        domain.reprompt = req.reprompt;
+        domain.reprompt = req.reprompt ?? CipherRepromptType.None;
 
         if (req.fields != null) {
             domain.fields = req.fields.map(f => Field.toDomain(f));

--- a/src/models/export/cipher.ts
+++ b/src/models/export/cipher.ts
@@ -1,3 +1,4 @@
+import { CipherRepromptType } from '../../enums/cipherRepromptType';
 import { CipherType } from '../../enums/cipherType';
 
 import { CipherView } from '../view/cipherView';
@@ -42,6 +43,7 @@ export class Cipher {
         view.name = req.name;
         view.notes = req.notes;
         view.favorite = req.favorite;
+        view.reprompt = CipherRepromptType.None;
 
         if (req.fields != null) {
             view.fields = req.fields.map(f => Field.toView(f));

--- a/src/models/view/cipherView.ts
+++ b/src/models/view/cipherView.ts
@@ -34,7 +34,7 @@ export class CipherView implements View {
     collectionIds: string[] = null;
     revisionDate: Date = null;
     deletedDate: Date = null;
-    reprompt: CipherRepromptType = null;
+    reprompt: CipherRepromptType = CipherRepromptType.None;
 
     constructor(c?: Cipher) {
         if (!c) {

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -308,6 +308,7 @@ export class ExportService implements ExportServiceAbstraction {
         cipher.name = c.name;
         cipher.notes = c.notes;
         cipher.fields = null;
+        cipher.reprompt = c.reprompt;
         // Login props
         cipher.login_uri = null;
         cipher.login_username = null;


### PR DESCRIPTION
## Objective

I'm getting a few errors because the new `cipher.reprompt` property does not have a default value set in some places. e.g.
* if you create a new cipher and save it without changing the value of the reprompt checkbox, it tries to save a null value
* all imports fail because imported ciphers are not initialized with a default reprompt value

On the import/export question, should we export this value so that users can import & export without any change in behaviour? Currently I've just initialized it to `CipherRepromptType.None` on all imports, but users may not be expecting that if they're importing a vault backup. Happy to do this if required as I'm poking around in the import/export code at the moment.

@Hinton I know you're still working on this feature, let me know if this is helpful or if we've crossed paths.

EDIT: looks like unit tests need to be updated, or I've done something wrong... will wait for feedback before spending any more time on it anyway