### PR TITLE
Include encrypt in formPromise

### DIFF
--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -300,7 +300,7 @@ export class AddEditComponent implements OnInit {
         }
 
         this.formPromise = this.encryptSend(file)
-            .then(async (encSend) => {
+            .then(async encSend => {
                 try {
                     const uploadPromise = this.sendService.saveWithServer(encSend);
                     let inactive = false;

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -299,27 +299,30 @@ export class AddEditComponent implements OnInit {
             this.password = null;
         }
 
-        const encSend = await this.encryptSend(file);
-        try {
-            this.formPromise = this.sendService.saveWithServer(encSend);
-            let inactive = false;
-            setTimeout(() => inactive = true, 4500);
-            await this.formPromise;
-            if (this.send.id == null) {
-                this.send.id = encSend[0].id;
-            }
-            if (this.send.accessId == null) {
-                this.send.accessId = encSend[0].accessId;
-            }
-            this.onSavedSend.emit(this.send);
-            await this.showSuccessMessage(inactive);
-            if (this.copyLink) {
-                this.copyLinkToClipboard(this.link);
-            }
-            return true;
-        } catch { }
+        this.formPromise = this.encryptSend(file)
+            .then(async (encSend) => {
+                try {
+                    this.formPromise = this.sendService.saveWithServer(encSend);
+                    let inactive = false;
+                    setTimeout(() => inactive = true, 4500);
+                    await this.formPromise;
+                    if (this.send.id == null) {
+                        this.send.id = encSend[0].id;
+                    }
+                    if (this.send.accessId == null) {
+                        this.send.accessId = encSend[0].accessId;
+                    }
+                    this.onSavedSend.emit(this.send);
+                    await this.showSuccessMessage(inactive);
+                    if (this.copyLink) {
+                        this.copyLinkToClipboard(this.link);
+                    }
+                    return true;
+                } catch { }
+                return false;
+            });
 
-        return false;
+        return await this.formPromise;
     }
 
     async showSuccessMessage(inactive: boolean) {

--- a/src/angular/components/send/add-edit.component.ts
+++ b/src/angular/components/send/add-edit.component.ts
@@ -302,10 +302,10 @@ export class AddEditComponent implements OnInit {
         this.formPromise = this.encryptSend(file)
             .then(async (encSend) => {
                 try {
-                    this.formPromise = this.sendService.saveWithServer(encSend);
+                    const uploadPromise = this.sendService.saveWithServer(encSend);
                     let inactive = false;
                     setTimeout(() => inactive = true, 4500);
-                    await this.formPromise;
+                    await uploadPromise;
                     if (this.send.id == null) {
                         this.send.id = encSend[0].id;
                     }


### PR DESCRIPTION
## Objective
We currently do not include the encryption process in the formPromise. Which means there is a slight delay between submitting the form, and form promise starting. Which would potentially allow users to start multiple requests. To avoid this I added the encryption step to formPromise.
