### PR TITLE
 Add setting to disable biometric auto prompt on desktop

### DIFF
--- a/src/electron/biometric.darwin.main.ts
+++ b/src/electron/biometric.darwin.main.ts
@@ -13,6 +13,7 @@ export default class BiometricDarwinMain implements BiometricMain {
     async init() {
         this.storageService.save(ElectronConstants.enableBiometric, await this.supportsBiometric());
         this.storageService.save(ConstantsService.biometricText, 'unlockWithTouchId');
+        this.storageService.save(ElectronConstants.noAutoPromptBiometricsText, 'noAutoPromptTouchId');
 
         ipcMain.on('biometric', async (event: any, message: any) => {
             event.returnValue = await this.requestCreate();

--- a/src/electron/biometric.windows.main.ts
+++ b/src/electron/biometric.windows.main.ts
@@ -27,6 +27,7 @@ export default class BiometricWindowsMain implements BiometricMain {
         }
         this.storageService.save(ElectronConstants.enableBiometric, supportsBiometric);
         this.storageService.save(ConstantsService.biometricText, 'unlockWithWindowsHello');
+        this.storageService.save(ElectronConstants.noAutoPromptBiometricsText, 'noAutoPromptWindowsHello');
 
         ipcMain.on('biometric', async (event: any, message: any) => {
             event.returnValue = await this.requestCreate();

--- a/src/electron/electronConstants.ts
+++ b/src/electron/electronConstants.ts
@@ -10,4 +10,6 @@ export class ElectronConstants {
     static readonly enableBrowserIntegrationFingerprint: string = 'enableBrowserIntegrationFingerprint';
     static readonly alwaysShowDock: string = 'alwaysShowDock';
     static readonly openAtLogin: string = 'openAtLogin';
+    static readonly noAutoPromptBiometrics: string = 'noAutoPromptBiometrics';
+    static readonly noAutoPromptBiometricsText: string = 'noAutoPromptBiometricsText';
 }

--- a/src/electron/services/electronMainMessaging.service.ts
+++ b/src/electron/services/electronMainMessaging.service.ts
@@ -37,6 +37,10 @@ export class ElectronMainMessagingService implements MessagingService {
             });
         });
 
+        ipcMain.handle('windowVisible', () => {
+            return windowMain.win?.isVisible();
+        });
+
         nativeTheme.on('updated', () => {
             windowMain.win.webContents.send('systemThemeUpdated', nativeTheme.shouldUseDarkColors ? 'dark' : 'light');
         });


### PR DESCRIPTION
## Objective
When starting the desktop application on launch or when running using `npm run electron`, the biometrics prompts can be quite annoying. This PR adds the boilerplate required to add a setting to the desktop application for disabling the auto prompt behaviour.

### Code Changes
- **src/electron/biometric.{darwin|windows}.main.ts**: Set `noAutoPrompt` text on windows or mac.
- **src/electron/electronConstants.ts**: Add some constants required to setup no auto prompt.
- **src/electron/services/electronMainMessaging.service.ts**: Add ipc callback for checking if the window is visible.