### PR TITLE
 Fix null search service checking

### DIFF
--- a/src/cli/baseProgram.ts
+++ b/src/cli/baseProgram.ts
@@ -1,4 +1,4 @@
-import * as chk from 'chalk';
+import * as chalk from 'chalk';
 
 import { Response } from './models/response';
 import { ListResponse } from './models/response/listResponse';
@@ -6,8 +6,6 @@ import { MessageResponse } from './models/response/messageResponse';
 import { StringResponse } from './models/response/stringResponse';
 
 import { UserService } from '../abstractions/user.service';
-
-const chalk = chk.default;
 
 export abstract class BaseProgram {
     constructor(

--- a/src/cli/baseProgram.ts
+++ b/src/cli/baseProgram.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import * as chk from 'chalk';
 
 import { Response } from './models/response';
 import { ListResponse } from './models/response/listResponse';
@@ -6,6 +6,8 @@ import { MessageResponse } from './models/response/messageResponse';
 import { StringResponse } from './models/response/stringResponse';
 
 import { UserService } from '../abstractions/user.service';
+
+const chalk = chk.default;
 
 export abstract class BaseProgram {
     constructor(

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -296,7 +296,7 @@ export class CipherService implements CipherServiceAbstraction {
     async getAllDecrypted(): Promise<CipherView[]> {
         if (this.decryptedCipherCache != null) {
             const userId = await this.userService.getUserId();
-            if (this.searchService() != null && (this.searchService().indexedEntityId ?? userId) !== userId)
+            if (this.searchService != null && (this.searchService().indexedEntityId ?? userId) !== userId)
             {
                 await this.searchService().indexCiphers(userId, this.decryptedCipherCache);
             }

--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -296,7 +296,7 @@ export class CipherService implements CipherServiceAbstraction {
     async getAllDecrypted(): Promise<CipherView[]> {
         if (this.decryptedCipherCache != null) {
             const userId = await this.userService.getUserId();
-            if ((this.searchService().indexedEntityId ?? userId) !== userId)
+            if (this.searchService() != null && (this.searchService().indexedEntityId ?? userId) !== userId)
             {
                 await this.searchService().indexCiphers(userId, this.decryptedCipherCache);
             }


### PR DESCRIPTION
# Overview

#356 incorrectly assumes that the `searchService` generator in `cipherService` will always be available. CLI does not currently use SearchService so this is null. A null check is added where `searchService` is accessed.

# Files Changed
* **cipher.service**: Check null search service 
* **baseProgram.ts**: chalk has been updated and now exports two objects, set the default export as `chalk` for use in responses.