### PR TITLE
Bulk re-invite of org users

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -67,6 +67,7 @@ import { UpdateTwoFactorEmailRequest } from '../models/request/updateTwoFactorEm
 import { UpdateTwoFactorWebAuthnDeleteRequest } from '../models/request/updateTwoFactorWebAuthnDeleteRequest';
 import { UpdateTwoFactorWebAuthnRequest } from '../models/request/updateTwoFactorWebAuthnRequest';
 import { UpdateTwoFactorYubioOtpRequest } from '../models/request/updateTwoFactorYubioOtpRequest';
+import { UserBulkReinviteRequest } from '../models/request/userBulkReinviteRequest';
 import { VerifyBankRequest } from '../models/request/verifyBankRequest';
 import { VerifyDeleteRecoverRequest } from '../models/request/verifyDeleteRecoverRequest';
 import { VerifyEmailRequest } from '../models/request/verifyEmailRequest';
@@ -272,6 +273,7 @@ export abstract class ApiService {
     getOrganizationUsers: (organizationId: string) => Promise<ListResponse<OrganizationUserUserDetailsResponse>>;
     postOrganizationUserInvite: (organizationId: string, request: OrganizationUserInviteRequest) => Promise<any>;
     postOrganizationUserReinvite: (organizationId: string, id: string) => Promise<any>;
+    postManyOrganizationUserReinvite: (organizationId: string, request: UserBulkReinviteRequest) => Promise<any>;
     postOrganizationUserAccept: (organizationId: string, id: string,
         request: OrganizationUserAcceptRequest) => Promise<any>;
     postOrganizationUserConfirm: (organizationId: string, id: string,

--- a/src/models/request/userBulkReinviteRequest.ts
+++ b/src/models/request/userBulkReinviteRequest.ts
@@ -1,0 +1,7 @@
+export class UserBulkReinviteRequest {
+    ids: string[];
+
+    constructor(ids: string[]) {
+        this.ids = ids == null ? [] : ids;
+    }
+}

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -71,6 +71,7 @@ import { UpdateTwoFactorEmailRequest } from '../models/request/updateTwoFactorEm
 import { UpdateTwoFactorWebAuthnDeleteRequest } from '../models/request/updateTwoFactorWebAuthnDeleteRequest';
 import { UpdateTwoFactorWebAuthnRequest } from '../models/request/updateTwoFactorWebAuthnRequest';
 import { UpdateTwoFactorYubioOtpRequest } from '../models/request/updateTwoFactorYubioOtpRequest';
+import { UserBulkReinviteRequest } from '../models/request/userBulkReinviteRequest';
 import { VerifyBankRequest } from '../models/request/verifyBankRequest';
 import { VerifyDeleteRecoverRequest } from '../models/request/verifyDeleteRecoverRequest';
 import { VerifyEmailRequest } from '../models/request/verifyEmailRequest';
@@ -799,6 +800,10 @@ export class ApiService implements ApiServiceAbstraction {
 
     postOrganizationUserReinvite(organizationId: string, id: string): Promise<any> {
         return this.send('POST', '/organizations/' + organizationId + '/users/' + id + '/reinvite', null, true, false);
+    }
+
+    postManyOrganizationUserReinvite(organizationId: string, request: UserBulkReinviteRequest): Promise<any> {
+        return this.send('POST', '/organizations/' + organizationId + '/users/reinvite', request, true, false);
     }
 
     postOrganizationUserAccept(organizationId: string, id: string,


### PR DESCRIPTION
## Objective
Currently org administrators needs to manually re-invite each user which requires multiple steps in the UI per user. To streamline this I've added a new bulk api which allows for re-inviting multiple users at a time.

### Code Changes
- **src/services/api.service.ts**: Added new method for reinviting many organization users.
- **src/models/request/userBulkReinviteRequest.ts**: New request model for bulk invites.

https://app.asana.com/0/1198901840263430/1200202229721743