### PR TITLE
Export Organization events

### DIFF
--- a/src/abstractions/export.service.ts
+++ b/src/abstractions/export.service.ts
@@ -1,5 +1,8 @@
+import { EventView } from '../models/view/eventView';
+
 export abstract class ExportService {
     getExport: (format?: 'csv' | 'json' | 'encrypted_json') => Promise<string>;
     getOrganizationExport: (organizationId: string, format?: 'csv' | 'json' | 'encrypted_json') => Promise<string>;
+    getEventExport: (events: EventView[]) => Promise<string>;
     getFileName: (prefix?: string, extension?: string) => string;
 }

--- a/src/models/export/event.ts
+++ b/src/models/export/event.ts
@@ -1,0 +1,26 @@
+import { EventType } from '../../enums/eventType';
+import { EventView } from '../view/eventView';
+
+export class Event {
+    message: string;
+    appIcon: string;
+    appName: string;
+    userId: string;
+    userName: string;
+    userEmail: string;
+    date: string;
+    ip: string;
+    type: string;
+
+    constructor(event: EventView) {
+        this.message = event.humanReadableMessage;
+        this.appIcon = event.appIcon;
+        this.appName = event.appName;
+        this.userId = event.userId;
+        this.userName = event.userName;
+        this.userEmail = event.userEmail;
+        this.date = event.date;
+        this.ip = event.ip;
+        this.type = EventType[event.type];
+    }
+}

--- a/src/models/view/eventView.ts
+++ b/src/models/view/eventView.ts
@@ -1,0 +1,27 @@
+import { EventType } from '../../enums/eventType';
+
+export class EventView {
+    message: string;
+    humanReadableMessage: string;
+    appIcon: string;
+    appName: string;
+    userId: string;
+    userName: string;
+    userEmail: string;
+    date: string;
+    ip: string;
+    type: EventType;
+
+    constructor(data: Required<EventView>) {
+        this.message = data.message;
+        this.humanReadableMessage = data.humanReadableMessage;
+        this.appIcon = data.appIcon;
+        this.appName = data.appName;
+        this.userId = data.userId;
+        this.userName = data.userName;
+        this.userEmail = data.userEmail;
+        this.date = data.date;
+        this.ip = data.ip;
+        this.type = data.type;
+    }
+}

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -21,6 +21,8 @@ import { CollectionDetailsResponse } from '../models/response/collectionResponse
 
 import { CipherWithIds as CipherExport } from '../models/export/cipherWithIds';
 import { CollectionWithId as CollectionExport } from '../models/export/collectionWithId';
+import { Event } from '../models/export/event';
+import { EventView } from '../models/view/eventView';
 import { FolderWithId as FolderExport } from '../models/export/folderWithId';
 
 export class ExportService implements ExportServiceAbstraction {
@@ -42,6 +44,10 @@ export class ExportService implements ExportServiceAbstraction {
         } else {
             return this.getOrganizationDecryptedExport(organizationId, format);
         }
+    }
+
+    async getEventExport(events: EventView[]): Promise<string> {
+        return papa.unparse(events.map(e => new Event(e)));
     }
 
     getFileName(prefix: string = null, extension: string = 'csv'): string {

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -22,8 +22,8 @@ import { CollectionDetailsResponse } from '../models/response/collectionResponse
 import { CipherWithIds as CipherExport } from '../models/export/cipherWithIds';
 import { CollectionWithId as CollectionExport } from '../models/export/collectionWithId';
 import { Event } from '../models/export/event';
-import { EventView } from '../models/view/eventView';
 import { FolderWithId as FolderExport } from '../models/export/folderWithId';
+import { EventView } from '../models/view/eventView';
 
 export class ExportService implements ExportServiceAbstraction {
     constructor(private folderService: FolderService, private cipherService: CipherService,


### PR DESCRIPTION
# Overview

Closes https://app.asana.com/0/1199950673439194/1155011472108808/f

Adds the ability to export Organization events to a csv.

# Files Changed
* **export.service.ts**: Add csv creation for array of EventViews -- this turned out to be crazy simple since the component already does all the fetching/filtering for us.
* **export/event.ts**: The export model for Events. `humanReadableMessage` is preferred because the `EventView` message has html to link to searches and specific policies.
* **eventView.ts**: The full data available from event messages.