### PR TITLE
Add node including version to requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Common code referenced across Bitwarden JavaScript projects.
 
 ## Requirements
-
+* [Node.js](https://nodejs.org) v14.17 or greater
 * Git
 * node-gyp
 


### PR DESCRIPTION
With @Hinton bumping node to 14 recently, I've adjusted the README to show the need for Node 14.17 (LTS)