### PR TITLE
Add functionality to search the notes field for partial matches.

### DIFF
--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -135,6 +135,7 @@ export class SearchService implements SearchServiceAbstraction {
                     q.term(t, { fields: ['name'], wildcard: soWild });
                     q.term(t, { fields: ['subtitle'], wildcard: soWild });
                     q.term(t, { fields: ['login.uris'], wildcard: soWild });
+                    q.term(t, { fields: ['notes'], wildcard: soWild });
                     q.term(t, {});
                 });
             });


### PR DESCRIPTION
This PR is to correct the issue [877](https://github.com/bitwarden/desktop/issues/877) reported on desktop but also confirmed on browser and web.

This will make notes partial match for all TYPES: Login, Card, Identity, and Secure Note. I've uploaded the video to show functionality after adding notes to the wild-card search list.

https://user-images.githubusercontent.com/16548994/118257658-747e2f00-b4e1-11eb-9025-d7b478d9d580.mov



If this looks good, I can update jslib once merged as well.