### PR TITLE
Pin versions of actions in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Set up cloc
         run: |
@@ -28,9 +28,9 @@ jobs:
 
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14.x'
+          node-version: '14'
 
       - name: Print environment
         run: |
@@ -38,7 +38,7 @@ jobs:
           npm --version
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Install Node dependencies
         run: npm install
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test coverage artifact
         if: runner.os != 'Linux'
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: test-coverage
           path: coverage/


### PR DESCRIPTION
This pins all action versions in the workflows to commit hashes. This protects us from any malicious changes to the actions in case people force push tags.