### PR TITLE
Convert Sets to Arrays before saving locally

### DIFF
--- a/src/electron/services/electronStorage.service.ts
+++ b/src/electron/services/electronStorage.service.ts
@@ -39,6 +39,9 @@ export class ElectronStorageService implements StorageService {
     }
 
     save(key: string, obj: any): Promise<any> {
+        if (obj instanceof Set) {
+            obj = Array.from(obj);
+        }
         this.store.set(key, obj);
         return Promise.resolve();
     }


### PR DESCRIPTION
## Objective
Fix https://github.com/bitwarden/desktop/issues/894.

The problem is that we were saving a Set object to localStorage [here](https://github.com/bitwarden/jslib/blob/master/src/angular/components/groupings.component.ts#L162). However, `electron-storage` requires that stored values are serializable. `Set` objects are not:

``` node
> JSON.stringify(new Set([1, 2, 3]))
'{}'
```

When the empty object (`{}`) was loaded from storage, it passed the `null` check but caused the `Set` constructor to throw an error (because it is not an iterable).

## Code changes
`electronStorage.service` - check if the value is `instanceof Set` and if so, convert it to an array before saving.

Desktop `jslib` will need to be bumped after this is merged, and maybe a hotfix put out.