### PR TITLE
Fix lockGuard logic

### DIFF
--- a/src/angular/services/lock-guard.service.ts
+++ b/src/angular/services/lock-guard.service.ts
@@ -13,17 +13,17 @@ export class LockGuardService implements CanActivate {
         private router: Router) { }
 
     async canActivate() {
-        const locked = await this.vaultTimeoutService.isLocked();
-        if (!locked) {
-            const isAuthed = await this.userService.isAuthenticated();
-            if (!isAuthed) {
-                this.router.navigate(['login']);
+        const isAuthed = await this.userService.isAuthenticated();
+        if (isAuthed) {
+            const locked = await this.vaultTimeoutService.isLocked();
+            if (locked) {
+                return true;
             } else {
                 this.router.navigate(['vault']);
             }
             return false;
         }
 
-        return true;
+        this.router.navigate(['']);
     }
 }

--- a/src/angular/services/lock-guard.service.ts
+++ b/src/angular/services/lock-guard.service.ts
@@ -20,10 +20,11 @@ export class LockGuardService implements CanActivate {
                 return true;
             } else {
                 this.router.navigate(['vault']);
+                return false;
             }
-            return false;
         }
 
         this.router.navigate(['']);
+        return false;
     }
 }


### PR DESCRIPTION
## Objective

Fix https://github.com/bitwarden/web/issues/978:

> After closing bitwarden tab, and reopening, you are not logged in as your account, but rather logged in as $1

## Code changes

This was introduced by the `lockGuardService`, which is meant to only allow navigation to the lock screen if the vault is locked. Thanks to @Hinton for picking this up.

The problem is that we were allowing navigation if `vaultTimeoutService.isLocked() == true`. However, that returns true if the user is logged out as well as if the vault is locked, so it was allowing a logged out user to access the lock page.

I've changed the order of the logic so that it should work as intended. This closely follows `unauthGuardService`.

`web` and `jslib` will need to be bumped. `browser` doesn't use this.