### PR TITLE
"Autofill on Page Load" options - minor tweak for backwards compatability

### DIFF
--- a/src/services/cipher.service.ts
+++ b/src/services/cipher.service.ts
@@ -1106,7 +1106,7 @@ export class CipherService implements CipherServiceAbstraction {
             if (autofillOnPageLoad) {
                 const autofillOnPageLoadDefault = await this.storageService.get(ConstantsService.autoFillOnPageLoadDefaultKey);
                 ciphers = ciphers.filter(cipher => cipher.login.autofillOnPageLoad ||
-                        (cipher.login.autofillOnPageLoad === null && autofillOnPageLoadDefault));
+                        (cipher.login.autofillOnPageLoad == null && autofillOnPageLoadDefault));
                 if (ciphers.length === 0) {
                     return null;
                 }


### PR DESCRIPTION
## Objective

Minor tweak to #199. If a newer client is running against an older server, #199 will break autofill on page load entirely. That's because `cipher.login.autofillOnPageLoad` will not exist on the server model, and it will be `undefined` instead of `null` when parsed by the client. I was using strict comparison to detect if the property was null (`cipher.login.autofillOnPageLoad === null`).

Although we don't really intend people to be running old servers, I thought this could save CS some tickets if self-hosted folks get their versions out of step. The new feature won't fully work, but it won't break the existing functionality either.

## Code changes

Use less strict equality checking, so that `null` and `undefined` are treated the same way.

Browser will need to be bumped.