### PR TITLE
Bulk confirm

### DIFF
--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -101,8 +101,8 @@ import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorR
 import { ListResponse } from '../models/response/listResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { OrganizationSubscriptionResponse } from '../models/response/organizationSubscriptionResponse';
-import { OrganizationUserBulkConfirmResponse } from '../models/response/organizationUserBulkConfirmResponse';
 import { OrganizationUserBulkPublicKeyResponse } from '../models/response/organizationUserBulkPublicKeyResponse';
+import { OrganizationUserBulkResponse } from '../models/response/organizationUserBulkResponse';
 import {
     OrganizationUserDetailsResponse,
     OrganizationUserUserDetailsResponse,
@@ -276,14 +276,14 @@ export abstract class ApiService {
     getOrganizationUsers: (organizationId: string) => Promise<ListResponse<OrganizationUserUserDetailsResponse>>;
     postOrganizationUserInvite: (organizationId: string, request: OrganizationUserInviteRequest) => Promise<any>;
     postOrganizationUserReinvite: (organizationId: string, id: string) => Promise<any>;
-    postManyOrganizationUserReinvite: (organizationId: string, request: OrganizationUserBulkRequest) => Promise<any>;
+    postManyOrganizationUserReinvite: (organizationId: string, request: OrganizationUserBulkRequest) => Promise<ListResponse<OrganizationUserBulkResponse>>;
     postOrganizationUserAccept: (organizationId: string, id: string,
         request: OrganizationUserAcceptRequest) => Promise<any>;
     postOrganizationUserConfirm: (organizationId: string, id: string,
         request: OrganizationUserConfirmRequest) => Promise<any>;
     postOrganizationUsersPublicKey: (organizationId: string, request: OrganizationUserBulkRequest) =>
         Promise<ListResponse<OrganizationUserBulkPublicKeyResponse>>;
-    postOrganizationUserBulkConfirm: (organizationId: string, request: OrganizationUserBulkConfirmRequest) => Promise<ListResponse<OrganizationUserBulkConfirmResponse>>;
+    postOrganizationUserBulkConfirm: (organizationId: string, request: OrganizationUserBulkConfirmRequest) => Promise<ListResponse<OrganizationUserBulkResponse>>;
 
     putOrganizationUser: (organizationId: string, id: string, request: OrganizationUserUpdateRequest) => Promise<any>;
     putOrganizationUserGroups: (organizationId: string, id: string,
@@ -291,7 +291,7 @@ export abstract class ApiService {
     putOrganizationUserResetPasswordEnrollment: (organizationId: string, userId: string,
         request: OrganizationUserResetPasswordEnrollmentRequest) => Promise<any>;
     deleteOrganizationUser: (organizationId: string, id: string) => Promise<any>;
-    deleteManyOrganizationUsers: (organizationId: string, request: OrganizationUserBulkRequest) => Promise<any>;
+    deleteManyOrganizationUsers: (organizationId: string, request: OrganizationUserBulkRequest) => Promise<ListResponse<OrganizationUserBulkResponse>>;
 
     getSync: () => Promise<SyncResponse>;
     postImportDirectory: (organizationId: string, request: ImportDirectoryRequest) => Promise<any>;

--- a/src/abstractions/api.service.ts
+++ b/src/abstractions/api.service.ts
@@ -35,6 +35,7 @@ import { OrganizationTaxInfoUpdateRequest } from '../models/request/organization
 import { OrganizationUpdateRequest } from '../models/request/organizationUpdateRequest';
 import { OrganizationUpgradeRequest } from '../models/request/organizationUpgradeRequest';
 import { OrganizationUserAcceptRequest } from '../models/request/organizationUserAcceptRequest';
+import { OrganizationUserBulkConfirmRequest } from '../models/request/organizationUserBulkConfirmRequest';
 import { OrganizationUserBulkRequest } from '../models/request/organizationUserBulkRequest';
 import { OrganizationUserConfirmRequest } from '../models/request/organizationUserConfirmRequest';
 import { OrganizationUserInviteRequest } from '../models/request/organizationUserInviteRequest';
@@ -100,6 +101,8 @@ import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorR
 import { ListResponse } from '../models/response/listResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { OrganizationSubscriptionResponse } from '../models/response/organizationSubscriptionResponse';
+import { OrganizationUserBulkConfirmResponse } from '../models/response/organizationUserBulkConfirmResponse';
+import { OrganizationUserBulkPublicKeyResponse } from '../models/response/organizationUserBulkPublicKeyResponse';
 import {
     OrganizationUserDetailsResponse,
     OrganizationUserUserDetailsResponse,
@@ -278,6 +281,10 @@ export abstract class ApiService {
         request: OrganizationUserAcceptRequest) => Promise<any>;
     postOrganizationUserConfirm: (organizationId: string, id: string,
         request: OrganizationUserConfirmRequest) => Promise<any>;
+    postOrganizationUsersPublicKey: (organizationId: string, request: OrganizationUserBulkRequest) =>
+        Promise<ListResponse<OrganizationUserBulkPublicKeyResponse>>;
+    postOrganizationUserBulkConfirm: (organizationId: string, request: OrganizationUserBulkConfirmRequest) => Promise<ListResponse<OrganizationUserBulkConfirmResponse>>;
+
     putOrganizationUser: (organizationId: string, id: string, request: OrganizationUserUpdateRequest) => Promise<any>;
     putOrganizationUserGroups: (organizationId: string, id: string,
         request: OrganizationUserUpdateGroupsRequest) => Promise<any>;

--- a/src/models/request/organizationUserBulkConfirmRequest.ts
+++ b/src/models/request/organizationUserBulkConfirmRequest.ts
@@ -5,7 +5,7 @@ type OrganizationUserBulkRequestEntry = {
 
 export class OrganizationUserBulkConfirmRequest {
     keys: OrganizationUserBulkRequestEntry[];
-    
+
     constructor(keys: OrganizationUserBulkRequestEntry[]) {
         this.keys = keys;
     }

--- a/src/models/request/organizationUserBulkConfirmRequest.ts
+++ b/src/models/request/organizationUserBulkConfirmRequest.ts
@@ -5,4 +5,8 @@ type OrganizationUserBulkRequestEntry = {
 
 export class OrganizationUserBulkConfirmRequest {
     keys: OrganizationUserBulkRequestEntry[];
+    
+    constructor(keys: OrganizationUserBulkRequestEntry[]) {
+        this.keys = keys;
+    }
 }

--- a/src/models/request/organizationUserBulkConfirmRequest.ts
+++ b/src/models/request/organizationUserBulkConfirmRequest.ts
@@ -1,0 +1,8 @@
+type OrganizationUserBulkRequestEntry = {
+    id: string;
+    key: string;
+};
+
+export class OrganizationUserBulkConfirmRequest {
+    keys: OrganizationUserBulkRequestEntry[];
+}

--- a/src/models/response/organizationUserBulkConfirmResponse.ts
+++ b/src/models/response/organizationUserBulkConfirmResponse.ts
@@ -1,0 +1,12 @@
+import { BaseResponse } from './baseResponse';
+
+export class OrganizationUserBulkConfirmResponse extends BaseResponse {
+    id: string;
+    error: string;
+
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.error = this.getResponseProperty('Error');
+    }
+}

--- a/src/models/response/organizationUserBulkPublicKeyResponse.ts
+++ b/src/models/response/organizationUserBulkPublicKeyResponse.ts
@@ -1,0 +1,12 @@
+import { BaseResponse } from './baseResponse';
+
+export class OrganizationUserBulkPublicKeyResponse extends BaseResponse {
+    id: string;
+    key: string;
+
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.key = this.getResponseProperty('Key');
+    }
+}

--- a/src/models/response/organizationUserBulkResponse.ts
+++ b/src/models/response/organizationUserBulkResponse.ts
@@ -1,6 +1,6 @@
 import { BaseResponse } from './baseResponse';
 
-export class OrganizationUserBulkConfirmResponse extends BaseResponse {
+export class OrganizationUserBulkResponse extends BaseResponse {
     id: string;
     error: string;
 

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -107,8 +107,8 @@ import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorR
 import { ListResponse } from '../models/response/listResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { OrganizationSubscriptionResponse } from '../models/response/organizationSubscriptionResponse';
-import { OrganizationUserBulkConfirmResponse } from '../models/response/organizationUserBulkConfirmResponse';
 import { OrganizationUserBulkPublicKeyResponse } from '../models/response/organizationUserBulkPublicKeyResponse';
+import { OrganizationUserBulkResponse } from '../models/response/organizationUserBulkResponse';
 import {
     OrganizationUserDetailsResponse,
     OrganizationUserUserDetailsResponse,
@@ -805,8 +805,9 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/organizations/' + organizationId + '/users/' + id + '/reinvite', null, true, false);
     }
 
-    postManyOrganizationUserReinvite(organizationId: string, request: OrganizationUserBulkRequest): Promise<any> {
-        return this.send('POST', '/organizations/' + organizationId + '/users/reinvite', request, true, false);
+    async postManyOrganizationUserReinvite(organizationId: string, request: OrganizationUserBulkRequest): Promise<ListResponse<OrganizationUserBulkResponse>> {
+        const r = await this.send('POST', '/organizations/' + organizationId + '/users/reinvite', request, true, true);
+        return new ListResponse(r, OrganizationUserBulkResponse);
     }
 
     postOrganizationUserAccept(organizationId: string, id: string,
@@ -825,9 +826,9 @@ export class ApiService implements ApiServiceAbstraction {
         return new ListResponse(r, OrganizationUserBulkPublicKeyResponse);
     }
 
-    async postOrganizationUserBulkConfirm(organizationId: string, request: OrganizationUserBulkConfirmRequest): Promise<ListResponse<OrganizationUserBulkConfirmResponse>> {
+    async postOrganizationUserBulkConfirm(organizationId: string, request: OrganizationUserBulkConfirmRequest): Promise<ListResponse<OrganizationUserBulkResponse>> {
         const r = await this.send('POST',  '/organizations/' + organizationId + '/users/confirm', request, true, true);
-        return new ListResponse(r, OrganizationUserBulkConfirmResponse);
+        return new ListResponse(r, OrganizationUserBulkResponse);
     }
 
     putOrganizationUser(organizationId: string, id: string, request: OrganizationUserUpdateRequest): Promise<any> {
@@ -849,8 +850,9 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('DELETE', '/organizations/' + organizationId + '/users/' + id, null, true, false);
     }
 
-    deleteManyOrganizationUsers(organizationId: string, request: OrganizationUserBulkRequest): Promise<any> {
-        return this.send('DELETE', '/organizations/' + organizationId + '/users', request, true, false);
+    async deleteManyOrganizationUsers(organizationId: string, request: OrganizationUserBulkRequest): Promise<ListResponse<OrganizationUserBulkResponse>> {
+        const r = await this.send('DELETE', '/organizations/' + organizationId + '/users', request, true, true);
+        return new ListResponse(r, OrganizationUserBulkResponse);
     }
 
     // Plan APIs

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -39,6 +39,7 @@ import { OrganizationTaxInfoUpdateRequest } from '../models/request/organization
 import { OrganizationUpdateRequest } from '../models/request/organizationUpdateRequest';
 import { OrganizationUpgradeRequest } from '../models/request/organizationUpgradeRequest';
 import { OrganizationUserAcceptRequest } from '../models/request/organizationUserAcceptRequest';
+import { OrganizationUserBulkConfirmRequest } from '../models/request/organizationUserBulkConfirmRequest';
 import { OrganizationUserBulkRequest } from '../models/request/organizationUserBulkRequest';
 import { OrganizationUserConfirmRequest } from '../models/request/organizationUserConfirmRequest';
 import { OrganizationUserInviteRequest } from '../models/request/organizationUserInviteRequest';
@@ -106,6 +107,8 @@ import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorR
 import { ListResponse } from '../models/response/listResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { OrganizationSubscriptionResponse } from '../models/response/organizationSubscriptionResponse';
+import { OrganizationUserBulkConfirmResponse } from '../models/response/organizationUserBulkConfirmResponse';
+import { OrganizationUserBulkPublicKeyResponse } from '../models/response/organizationUserBulkPublicKeyResponse';
 import {
     OrganizationUserDetailsResponse,
     OrganizationUserUserDetailsResponse,
@@ -815,6 +818,16 @@ export class ApiService implements ApiServiceAbstraction {
         request: OrganizationUserConfirmRequest): Promise<any> {
         return this.send('POST', '/organizations/' + organizationId + '/users/' + id + '/confirm',
             request, true, false);
+    }
+
+    async postOrganizationUsersPublicKey(organizationId: string, request: OrganizationUserBulkRequest): Promise<ListResponse<OrganizationUserBulkPublicKeyResponse>> {
+        const r = await this.send('POST', '/organizations/' + organizationId + '/users/public-keys', request, true, true);
+        return new ListResponse(r, OrganizationUserBulkPublicKeyResponse);
+    }
+
+    async postOrganizationUserBulkConfirm(organizationId: string, request: OrganizationUserBulkConfirmRequest): Promise<ListResponse<OrganizationUserBulkConfirmResponse>> {
+        const r = await this.send('POST',  '/organizations/' + organizationId + '/users/confirm', request, true, true);
+        return new ListResponse(r, OrganizationUserBulkConfirmResponse);
     }
 
     putOrganizationUser(organizationId: string, id: string, request: OrganizationUserUpdateRequest): Promise<any> {


### PR DESCRIPTION
## Objective
Confirming multiple users is currently time consuming and involves multiple steps. This PR adds two new endpoints, one for retrieving the public key of multiple organization users, and another for confirming multiple users.

Related: https://github.com/bitwarden/server/pull/1345