### PR TITLE
[Reset Password] Update Crypto and Policy services

### DIFF
--- a/src/abstractions/crypto.service.ts
+++ b/src/abstractions/crypto.service.ts
@@ -43,7 +43,7 @@ export abstract class CryptoService {
     encrypt: (plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey) => Promise<EncString>;
     encryptToBytes: (plainValue: ArrayBuffer, key?: SymmetricCryptoKey) => Promise<EncArrayBuffer>;
     rsaEncrypt: (data: ArrayBuffer, publicKey?: ArrayBuffer) => Promise<EncString>;
-    rsaDecrypt: (encValue: string) => Promise<ArrayBuffer>;
+    rsaDecrypt: (encValue: string, privateKeyValue?: ArrayBuffer) => Promise<ArrayBuffer>;
     decryptToBytes: (encString: EncString, key?: SymmetricCryptoKey) => Promise<ArrayBuffer>;
     decryptToUtf8: (encString: EncString, key?: SymmetricCryptoKey) => Promise<string>;
     decryptFromBytes: (encBuf: ArrayBuffer, key: SymmetricCryptoKey) => Promise<ArrayBuffer>;

--- a/src/abstractions/policy.service.ts
+++ b/src/abstractions/policy.service.ts
@@ -6,6 +6,9 @@ import { ResetPasswordPolicyOptions } from '../models/domain/resetPasswordPolicy
 
 import { PolicyType } from '../enums/policyType';
 
+import { ListResponse } from '../models/response/listResponse';
+import { PolicyResponse } from '../models/response/policyResponse';
+
 export abstract class PolicyService {
     policyCache: Policy[];
 
@@ -16,5 +19,6 @@ export abstract class PolicyService {
     getMasterPasswordPolicyOptions: (policies?: Policy[]) => Promise<MasterPasswordPolicyOptions>;
     evaluateMasterPassword: (passwordStrength: number, newPassword: string,
         enforcedPolicyOptions?: MasterPasswordPolicyOptions) => boolean;
-    getResetPasswordPolicyOptions: (policy: Policy) => ResetPasswordPolicyOptions;
+    getResetPasswordPolicyOptions: (policies: Policy[], orgId: string) => [ResetPasswordPolicyOptions, boolean];
+    mapPoliciesFromToken: (policiesResponse: ListResponse<PolicyResponse>) => Policy[];
 }

--- a/src/services/crypto.service.ts
+++ b/src/services/crypto.service.ts
@@ -446,7 +446,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         return new EncString(EncryptionType.Rsa2048_OaepSha1_B64, Utils.fromBufferToB64(encBytes));
     }
 
-    async rsaDecrypt(encValue: string): Promise<ArrayBuffer> {
+    async rsaDecrypt(encValue: string, privateKeyValue?: ArrayBuffer): Promise<ArrayBuffer> {
         const headerPieces = encValue.split('.');
         let encType: EncryptionType = null;
         let encPieces: string[];
@@ -477,7 +477,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         }
 
         const data = Utils.fromB64ToArray(encPieces[0]).buffer;
-        const privateKey = await this.getPrivateKey();
+        const privateKey = privateKeyValue ?? await this.getPrivateKey();
         if (privateKey == null) {
             throw new Error('No private key.');
         }

--- a/src/services/policy.service.ts
+++ b/src/services/policy.service.ts
@@ -6,9 +6,12 @@ import { PolicyData } from '../models/data/policyData';
 
 import { MasterPasswordPolicyOptions } from '../models/domain/masterPasswordPolicyOptions';
 import { Policy } from '../models/domain/policy';
+import { ResetPasswordPolicyOptions } from '../models/domain/resetPasswordPolicyOptions';
 
 import { PolicyType } from '../enums/policyType';
-import { ResetPasswordPolicyOptions } from '../models/domain/resetPasswordPolicyOptions';
+
+import { ListResponse } from '../models/response/listResponse';
+import { PolicyResponse } from '../models/response/policyResponse';
 
 const Keys = {
     policiesPrefix: 'policies_',
@@ -140,13 +143,25 @@ export class PolicyService implements PolicyServiceAbstraction {
         return true;
     }
 
-    getResetPasswordPolicyOptions(policy: Policy): ResetPasswordPolicyOptions {
+    getResetPasswordPolicyOptions(policies: Policy[], orgId: string): [ResetPasswordPolicyOptions, boolean] {
         const resetPasswordPolicyOptions = new ResetPasswordPolicyOptions();
 
-        if (policy != null && policy.enabled && policy.data != null) {
-            resetPasswordPolicyOptions.autoEnrollEnabled = policy.data.autoEnrollEnabled;
+        if (policies == null || orgId == null) {
+            return [resetPasswordPolicyOptions, false];
         }
 
-        return resetPasswordPolicyOptions;
+        const policy = policies.find(p => p.organizationId === orgId && p.type === PolicyType.ResetPassword && p.enabled);
+        resetPasswordPolicyOptions.autoEnrollEnabled = policy?.data?.autoEnrollEnabled ?? false;
+
+        return [resetPasswordPolicyOptions, policy?.enabled ?? false];
+    }
+
+    mapPoliciesFromToken(policiesResponse: ListResponse<PolicyResponse>): Policy[] {
+        if (policiesResponse == null || policiesResponse.data == null) {
+            return null;
+        }
+
+        const policiesData = policiesResponse.data.map(p => new PolicyData(p));
+        return policiesData.map(p => new Policy(p));
     }
 }


### PR DESCRIPTION
## Objective
> Allow `Crypto` service to `rsaDecrypt` with a passed-in private key instead of inferring user's private key. Update/add a couple of helper methods to reduce redundant code during policy by token retrieval/parsing.

## Code Changes
- **abstractions/crypto.service**: Updated method signature to pass in nullable private key value
- **abstractions/policy.service**: Update `getResetPasswordPolicyOptions` method signature to accept an `orgId` and return a tuple. Create `mapPoliciesFromToken` to take an api response and map the data to expected objects.
- **crypto.service**: Passed in private key will be used to decrypt unless its null -> will fallback to existing behavior and decrypt using the user's private key.
- **policy.service**: `getResetPasswordPolicyOptions` will now parse all policies for the user and find the desired result. The policy options will be returned along with the policy's enabled state. `mapPoliciesFromToken` takes a response object and maps it to an array of `Policy` in order to be used at the UI level.