### PR TITLE
Add support for --cleanexit option

### DIFF
--- a/src/cli/baseProgram.ts
+++ b/src/cli/baseProgram.ts
@@ -21,10 +21,11 @@ export abstract class BaseProgram {
                     this.writeLn(chalk.redBright(response.message), true, true);
                 }
             }
+            const exitCode = process.env.BW_CLEANEXIT ? 0 : 1;
             if (exitImmediately) {
-                process.exit(1);
+                process.exit(exitCode);
             } else {
-                process.exitCode = 1;
+                process.exitCode = exitCode;
             }
             return;
         }


### PR DESCRIPTION
## Objective

Fix https://github.com/bitwarden/cli/issues/283:

> When using --response the exitcode should always be 0 when valid JSON is outputted, because the command was successful, even if the results being returned indicate a non-success.

We currently set the exit code according to the `response.success` value. For example, if the user tries to retrieve a folder with `bw get folder "my folder"` and the folder is not found, it will exit with an error code of 1 because `response.success === false`.

This PR adds a new option, `--cleanexit`, which will force the program to exit with a success error code (0) in this case.

## Code changes

* jslib: set exit code to `0` if `--cleanexit` is set. My understanding is that if there is an actual error thrown, it would have already bailed out by this point, so we won't be overriding any genuine error codes here.
* cli: add `--cleanexit` option with help text (https://github.com/bitwarden/cli/pull/309)
* bwdc: add `--cleanexit` option with help text (https://github.com/bitwarden/directory-connector/pull/122)

jslib will need to be merged first.

CC: @cmaahs - thanks for the info & suggestions in your initial ticket.