### PR TITLE
Add encKey validation for org import/export

### DIFF
--- a/src/importers/bitwardenJsonImporter.ts
+++ b/src/importers/bitwardenJsonImporter.ts
@@ -38,8 +38,9 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
 
     private async parseEncrypted() {
         if (this.results.encKeyValidation_DO_NOT_EDIT != null) {
+            const orgKey = await this.cryptoService.getOrgKey(this.organizationId);
             const encKeyValidation = new EncString(this.results.encKeyValidation_DO_NOT_EDIT);
-            const encKeyValidationDecrypt = await this.cryptoService.decryptToUtf8(encKeyValidation);
+            const encKeyValidationDecrypt = await this.cryptoService.decryptToUtf8(encKeyValidation, orgKey);
             if (encKeyValidationDecrypt === null) {
                 this.result.success = false;
                 this.result.errorMessage = this.i18nService.t('importEncKeyError');

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -289,8 +289,12 @@ export class ExportService implements ExportServiceAbstraction {
 
         await Promise.all(promises);
 
+        const orgKey = await this.cryptoService.getOrgKey(organizationId);
+        const encKeyValidation = await this.cryptoService.encrypt(Utils.newGuid(), orgKey);
+
         const jsonDoc: any = {
             encrypted: true,
+            encKeyValidation_DO_NOT_EDIT: encKeyValidation.encryptedString,
             collections: [],
             items: [],
         };


### PR DESCRIPTION
## Objective

I added a test `encString` to the top of encrypted exports in #369. This is an encrypted random GUID, which is decrypted first to test whether the `encKey` is valid (i.e. the same one used to export the data), before importing the data.

However, I didn't properly deal with organization imports & exports in #369, so this error checking is not working properly for organizations.

## Code changes

* export.service.ts: add the `encKeyValidation` value in organization exports
* bitwardenJsonImporter: pass in `orgKey` (if any) when decrypting the test string