### PR TITLE
Password reprompt fixes

### DIFF
--- a/src/angular/components/add-edit.component.ts
+++ b/src/angular/components/add-edit.component.ts
@@ -436,7 +436,7 @@ export class AddEditComponent implements OnInit {
     async toggleCardNumber() {
         this.showCardNumber = !this.showCardNumber;
         if (this.showCardNumber) {
-            this.eventService.collect(EventType.Cipher_ClientToggledCardCodeVisible, this.cipherId);
+            this.eventService.collect(EventType.Cipher_ClientToggledCardNumberVisible, this.cipherId);
         }
     }
 

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -353,6 +353,9 @@ export class ViewComponent implements OnDestroy, OnInit {
         this.totpCode = null;
         this.cipher = null;
         this.showPassword = false;
+        this.showCardNumber = false;
+        this.showCardCode = false;
+        this.passwordReprompted = false;
         if (this.totpInterval) {
             clearInterval(this.totpInterval);
         }

--- a/src/angular/components/view.component.ts
+++ b/src/angular/components/view.component.ts
@@ -286,6 +286,9 @@ export class ViewComponent implements OnDestroy, OnInit {
     }
 
     async downloadAttachment(attachment: AttachmentView) {
+        if (!await this.promptPassword()) {
+            return;
+        }
         const a = (attachment as any);
         if (a.downloading) {
             return;


### PR DESCRIPTION
## Objective
Bugfixes for the password reprompt discovered during QA.

### Code Changes
- **src/angular/components/add-edit.component.ts**: Wrong event
- **src/angular/components/view.component.ts**: Reset `showCardNumber`, `showCardCode` and `passwordReprompted` fields when cleaning up. Add password prompt before downloading attachments.
