### PR TITLE
add auth-email header

### DIFF
--- a/src/models/request/tokenRequest.ts
+++ b/src/models/request/tokenRequest.ts
@@ -73,4 +73,10 @@ export class TokenRequest {
 
         return obj;
     }
+
+    alterIdentityTokenHeaders(headers: Headers) {
+        if (this.clientSecret == null && this.masterPasswordHash != null && this.email != null) {
+            headers.set('Auth-Email', this.email);
+        }
+    }
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -206,6 +206,7 @@ export class ApiService implements ApiServiceAbstraction {
         if (this.customUserAgent != null) {
             headers.set('User-Agent', this.customUserAgent);
         }
+        request.alterIdentityTokenHeaders(headers);
         const response = await this.fetch(new Request(this.identityBaseUrl + '/connect/token', {
             body: this.qsStringify(request.toIdentityToken(request.clientId ?? this.platformUtilsService.identityClientId)),
             credentials: this.getCredentials(),


### PR DESCRIPTION
Adds a new request header, `auth-email`, to auth requests that includes the same value as the `username` post parameter. This will enable us to rate limit auth requested based on username to prevent things like 2FA brute forcing.