### PR TITLE
Add Send-Id header for access requests

### DIFF
--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -436,7 +436,11 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest, apiUrl?: string): Promise<SendFileDownloadDataResponse> {
-        const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true, apiUrl);
+        const addSendIdHeader = (headers: Headers) => {
+            headers.set('Send-Id', send.id);
+        }
+        const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true,
+            apiUrl, addSendIdHeader);
         return new SendFileDownloadDataResponse(r);
     }
 

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -428,10 +428,12 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     async postSendAccess(id: string, request: SendAccessRequest, apiUrl?: string): Promise<SendAccessResponse> {
-        const r = await this.send('POST', '/sends/access/' + id, request, false, true, apiUrl);
+        const addSendIdHeader = (headers: Headers) => {
+            headers.set('Send-Id', id);
+        }
+        const r = await this.send('POST', '/sends/access/' + id, request, false, true, apiUrl, addSendIdHeader);
         return new SendAccessResponse(r);
     }
-
 
     async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest, apiUrl?: string): Promise<SendFileDownloadDataResponse> {
         const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true, apiUrl);
@@ -1353,7 +1355,8 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     private async send(method: 'GET' | 'POST' | 'PUT' | 'DELETE', path: string, body: any,
-        authed: boolean, hasResponse: boolean, apiUrl?: string): Promise<any> {
+        authed: boolean, hasResponse: boolean, apiUrl?: string,
+        alterHeaders?: (headers: Headers) => void): Promise<any> {
         apiUrl = Utils.isNullOrWhitespace(apiUrl) ? this.apiBaseUrl : apiUrl;
         const headers = new Headers({
             'Device-Type': this.deviceType,
@@ -1387,6 +1390,9 @@ export class ApiService implements ApiServiceAbstraction {
         }
         if (hasResponse) {
             headers.set('Accept', 'application/json');
+        }
+        if (alterHeaders != null) {
+            alterHeaders(headers);
         }
 
         requestInit.headers = headers;

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -430,7 +430,7 @@ export class ApiService implements ApiServiceAbstraction {
     async postSendAccess(id: string, request: SendAccessRequest, apiUrl?: string): Promise<SendAccessResponse> {
         const addSendIdHeader = (headers: Headers) => {
             headers.set('Send-Id', id);
-        }
+        };
         const r = await this.send('POST', '/sends/access/' + id, request, false, true, apiUrl, addSendIdHeader);
         return new SendAccessResponse(r);
     }
@@ -438,7 +438,7 @@ export class ApiService implements ApiServiceAbstraction {
     async getSendFileDownloadData(send: SendAccessView, request: SendAccessRequest, apiUrl?: string): Promise<SendFileDownloadDataResponse> {
         const addSendIdHeader = (headers: Headers) => {
             headers.set('Send-Id', send.id);
-        }
+        };
         const r = await this.send('POST', '/sends/' + send.id + '/access/file/' + send.file.id, request, false, true,
             apiUrl, addSendIdHeader);
         return new SendFileDownloadDataResponse(r);


### PR DESCRIPTION
## Objective
Add a `Send-Id` header for Send access requests. This will allow for better rate limiting.

## Code changes
* apiService - add `Send-Id` header on Send access requests. This new parameter on `apiService.send` should also let other api calls implement similar functionality if required.