### PR TITLE
Authenticate with secure storage service

### DIFF
--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -51,7 +51,8 @@ export class LockComponent implements OnInit {
         this.pinSet = await this.vaultTimeoutService.isPinLockSet();
         this.pinLock = (this.pinSet[0] && this.vaultTimeoutService.pinProtectedKey != null) || this.pinSet[1];
         this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
-        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() && (await this.cryptoService.hasKey() || !this.platformUtilsService.supportsSecureStorage());
+        this.biometricLock = await this.vaultTimeoutService.isBiometricLockSet() &&
+            (await this.cryptoService.hasKeyStored('biometric') || !this.platformUtilsService.supportsSecureStorage());
         this.biometricText = await this.storageService.get(ConstantsService.biometricText);
         this.email = await this.userService.getEmail();
         let vaultUrl = this.environmentService.getWebVaultUrl();
@@ -157,7 +158,8 @@ export class LockComponent implements OnInit {
         if (!this.biometricLock) {
             return;
         }
-        const success = await this.platformUtilsService.authenticateBiometric();
+
+        const success = (await this.cryptoService.getKey('biometric')) != null;
 
         if (success) {
             await this.doContinue();
@@ -176,6 +178,8 @@ export class LockComponent implements OnInit {
 
     private async doContinue() {
         this.vaultTimeoutService.biometricLocked = false;
+        this.vaultTimeoutService.everBeenUnlocked = true;
+        this.vaultTimeoutService.manuallyOrTimerLocked = false;
         const disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
         await this.stateService.save(ConstantsService.disableFaviconKey, !!disableFavicon);
         this.messagingService.send('unlocked');

--- a/common/src/abstractions/biometric.main.ts
+++ b/common/src/abstractions/biometric.main.ts
@@ -2,5 +2,5 @@ export abstract class BiometricMain {
     isError: boolean;
     init: () => Promise<void>;
     supportsBiometric: () => Promise<boolean>;
-    requestCreate: () => Promise<boolean>;
+    authenticateBiometric: () => Promise<boolean>;
 }

--- a/common/src/abstractions/crypto.service.ts
+++ b/common/src/abstractions/crypto.service.ts
@@ -5,6 +5,7 @@ import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
 
 import { KdfType } from '../enums/kdfType';
+import { KeySuffixOptions } from './storage.service';
 
 export abstract class CryptoService {
     setKey: (key: SymmetricCryptoKey) => Promise<any>;
@@ -12,7 +13,7 @@ export abstract class CryptoService {
     setEncKey: (encKey: string) => Promise<{}>;
     setEncPrivateKey: (encPrivateKey: string) => Promise<{}>;
     setOrgKeys: (orgs: ProfileOrganizationResponse[]) => Promise<{}>;
-    getKey: () => Promise<SymmetricCryptoKey>;
+    getKey: (keySuffix?: KeySuffixOptions) => Promise<SymmetricCryptoKey>;
     getKeyHash: () => Promise<string>;
     getEncKey: (key?: SymmetricCryptoKey) => Promise<SymmetricCryptoKey>;
     getPublicKey: () => Promise<ArrayBuffer>;
@@ -21,8 +22,10 @@ export abstract class CryptoService {
     getOrgKeys: () => Promise<Map<string, SymmetricCryptoKey>>;
     getOrgKey: (orgId: string) => Promise<SymmetricCryptoKey>;
     hasKey: () => Promise<boolean>;
+    hasKeyInMemory: () => boolean;
+    hasKeyStored: (keySuffix?: KeySuffixOptions) => Promise<boolean>;
     hasEncKey: () => Promise<boolean>;
-    clearKey: () => Promise<any>;
+    clearKey: (clearSecretStorage?: boolean) => Promise<any>;
     clearKeyHash: () => Promise<any>;
     clearEncKey: (memoryOnly?: boolean) => Promise<any>;
     clearKeyPair: (memoryOnly?: boolean) => Promise<any>;

--- a/common/src/abstractions/storage.service.ts
+++ b/common/src/abstractions/storage.service.ts
@@ -1,5 +1,12 @@
 export abstract class StorageService {
-    get: <T>(key: string) => Promise<T>;
-    save: (key: string, obj: any) => Promise<any>;
-    remove: (key: string) => Promise<any>;
+    get: <T>(key: string, options?: StorageServiceOptions) => Promise<T>;
+    has: (key: string, options?: StorageServiceOptions) => Promise<boolean>;
+    save: (key: string, obj: any, options?: StorageServiceOptions) => Promise<any>;
+    remove: (key: string, options?: StorageServiceOptions) => Promise<any>;
 }
+
+export interface StorageServiceOptions {
+    keySuffix: KeySuffixOptions;
+}
+
+export type KeySuffixOptions = 'auto' | 'biometric';

--- a/common/src/abstractions/vaultTimeout.service.ts
+++ b/common/src/abstractions/vaultTimeout.service.ts
@@ -2,6 +2,8 @@ import { EncString } from '../models/domain/encString';
 
 export abstract class VaultTimeoutService {
     biometricLocked: boolean;
+    manuallyOrTimerLocked: boolean;
+    everBeenUnlocked: boolean;
     pinProtectedKey: EncString;
     isLocked: () => Promise<boolean>;
     checkVaultTimeout: () => Promise<void>;

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -657,7 +657,10 @@ export class CryptoService implements CryptoServiceAbstraction {
             if (await this.shouldStoreKey('biometric')) {
                 await this.secureStorageService.save(Keys.key, key, { keySuffix: 'biometric' });
             }
-        } catch (e) { }
+        } catch (e) {
+            this.logService.error(`Encountered error while upgrading obsolete Bitwarden secure storage item:`);
+            this.logService.error(e);
+        }
 
         await this.secureStorageService.remove(Keys.key);
     }

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -643,22 +643,27 @@ export class CryptoService implements CryptoServiceAbstraction {
      * multiple, unique stored keys for each use, e.g. never logout vs. biometric authentication.
      */
     private async upgradeSecurelyStoredKey() {
-        const key = await this.secureStorageService.get<string>(Keys.key);
+        try {
+            const key = await this.secureStorageService.get<string>(Keys.key);
 
-        if (key != null) {
-            let success = true;
-            if (await this.shouldStoreKey('auto')) {
-                await this.secureStorageService.save(Keys.key, key, { keySuffix: 'auto' });
-                success = await this.secureStorageService.has(Keys.key, { keySuffix: 'auto' });
-            }
-            if (await this.shouldStoreKey('biometric')) {
-                await this.secureStorageService.save(Keys.key, key, { keySuffix: 'biometric' });
-                success &&= await this.secureStorageService.has(Keys.key, { keySuffix: 'biometric' });
-            }
+            if (key != null) {
+                let success = true;
+                if (await this.shouldStoreKey('auto')) {
+                    await this.secureStorageService.save(Keys.key, key, { keySuffix: 'auto' });
+                    success = await this.secureStorageService.has(Keys.key, { keySuffix: 'auto' });
+                }
+                if (await this.shouldStoreKey('biometric')) {
+                    await this.secureStorageService.save(Keys.key, key, { keySuffix: 'biometric' });
+                    success &&= await this.secureStorageService.has(Keys.key, { keySuffix: 'biometric' });
+                }
 
-            if (success) {
-                await this.secureStorageService.remove(Keys.key);
+                if (success) {
+                    await this.secureStorageService.remove(Keys.key);
+                }
             }
+        } catch (e) {
+            this.logService.error(`Encountered error while upgrading obsolete Bitwarden secure storage item:`);
+            this.logService.error(e);
         }
     }
 

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -259,6 +259,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
 
     async hasKeyStored(keySuffix: KeySuffixOptions): Promise<boolean> {
+        await this.upgradeSecurelyStoredKey();
         return await this.secureStorageService.has(Keys.key, { keySuffix: keySuffix });
     }
 
@@ -646,11 +647,13 @@ export class CryptoService implements CryptoServiceAbstraction {
 
         if (key != null) {
             let success = true;
-            if (this.shouldStoreKey('auto')) {
-                success = !!(await this.secureStorageService.save(Keys.key, key, { keySuffix: 'auto' }));
+            if (await this.shouldStoreKey('auto')) {
+                await this.secureStorageService.save(Keys.key, key, { keySuffix: 'auto' });
+                success = await this.secureStorageService.has(Keys.key, { keySuffix: 'auto' });
             }
-            if (this.shouldStoreKey('biometric')) {
-                success ||= !!(await this.secureStorageService.save(Keys.key, key, { keySuffix: 'biometric' }));
+            if (await this.shouldStoreKey('biometric')) {
+                await this.secureStorageService.save(Keys.key, key, { keySuffix: 'biometric' });
+                success &&= await this.secureStorageService.has(Keys.key, { keySuffix: 'biometric' });
             }
 
             if (success) {

--- a/common/src/services/system.service.ts
+++ b/common/src/services/system.service.ts
@@ -19,7 +19,9 @@ export class SystemService implements SystemServiceAbstraction {
     }
 
     startProcessReload(): void {
-        if (this.vaultTimeoutService.pinProtectedKey != null || this.reloadInterval != null) {
+        if (this.vaultTimeoutService.pinProtectedKey != null ||
+            this.vaultTimeoutService.biometricLocked ||
+            this.reloadInterval != null) {
             return;
         }
         this.cancelProcessReload();

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -17,6 +17,8 @@ import { EncString } from '../models/domain/encString';
 export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     pinProtectedKey: EncString = null;
     biometricLocked: boolean = true;
+    everBeenUnlocked: boolean = false;
+    manuallyOrTimerLocked: boolean = false;
 
     private inited = false;
 
@@ -46,9 +48,13 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
 
     // Keys aren't stored for a device that is locked or logged out.
     async isLocked(): Promise<boolean> {
+        if (await this.cryptoService.hasKeyStored('auto') && !this.everBeenUnlocked) {
+            await this.cryptoService.getKey('auto');
+        }
+
         const hasKey = await this.cryptoService.hasKey();
         if (hasKey) {
-            if (await this.isBiometricLockSet() && this.biometricLocked) {
+            if ((await this.isBiometricLockSet() && this.biometricLocked) || this.manuallyOrTimerLocked) {
                 return true;
             }
         }
@@ -102,18 +108,8 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         }
 
         this.biometricLocked = true;
-        if (allowSoftLock) {
-            const biometricLocked = await this.isBiometricLockSet();
-            if (biometricLocked && this.platformUtilsService.supportsSecureStorage()) {
-                this.messagingService.send('locked');
-                if (this.lockedCallback != null) {
-                    await this.lockedCallback();
-                }
-                return;
-            }
-        }
-
-        await this.cryptoService.clearKey();
+        this.manuallyOrTimerLocked = true;
+        await this.cryptoService.clearKey(false);
         await this.cryptoService.clearOrgKeys(true);
         await this.cryptoService.clearKeyPair(true);
         await this.cryptoService.clearEncKey(true);

--- a/electron/src/biometric.darwin.main.ts
+++ b/electron/src/biometric.darwin.main.ts
@@ -16,7 +16,7 @@ export default class BiometricDarwinMain implements BiometricMain {
         this.storageService.save(ElectronConstants.noAutoPromptBiometricsText, 'noAutoPromptTouchId');
 
         ipcMain.on('biometric', async (event: any, message: any) => {
-            event.returnValue = await this.requestCreate();
+            event.returnValue = await this.authenticateBiometric();
         });
     }
 
@@ -24,7 +24,7 @@ export default class BiometricDarwinMain implements BiometricMain {
         return Promise.resolve(systemPreferences.canPromptTouchID());
     }
 
-    async requestCreate(): Promise<boolean> {
+    async authenticateBiometric(): Promise<boolean> {
         try {
             await systemPreferences.promptTouchID(this.i18nservice.t('touchIdConsentMessage'));
             return true;

--- a/electron/src/biometric.windows.main.ts
+++ b/electron/src/biometric.windows.main.ts
@@ -30,7 +30,7 @@ export default class BiometricWindowsMain implements BiometricMain {
         this.storageService.save(ElectronConstants.noAutoPromptBiometricsText, 'noAutoPromptWindowsHello');
 
         ipcMain.on('biometric', async (event: any, message: any) => {
-            event.returnValue = await this.requestCreate();
+            event.returnValue = await this.authenticateBiometric();
         });
     }
 
@@ -40,7 +40,7 @@ export default class BiometricWindowsMain implements BiometricMain {
         return this.getAllowedAvailabilities().includes(availability);
     }
 
-    async requestCreate(): Promise<boolean> {
+    async authenticateBiometric(): Promise<boolean> {
         const module = this.getWindowsSecurityCredentialsUiModule();
         if (module == null) {
             return false;

--- a/electron/src/keytarStorageListener.ts
+++ b/electron/src/keytarStorageListener.ts
@@ -25,7 +25,7 @@ export class KeytarStorageListener {
 
                 const authenticationRequired = AuthenticatedActions.includes(message.action) &&
                     AuthRequiredSuffix === message.keySuffix;
-                const authenticated = !authenticationRequired || await this.biometricService.authenticateBiometric();
+                const authenticated = !authenticationRequired || await this.authenticateBiometric();
 
                 let val: string | boolean = null;
                 if (authenticated && message.action && message.key) {
@@ -45,5 +45,12 @@ export class KeytarStorageListener {
                 event.returnValue = null;
             }
         });
+    }
+
+    private async authenticateBiometric(): Promise<boolean> {
+        if (this.biometricService) {
+            return await this.biometricService.authenticateBiometric();
+        }
+        return false;
     }
 }

--- a/electron/src/keytarStorageListener.ts
+++ b/electron/src/keytarStorageListener.ts
@@ -6,23 +6,35 @@ import {
     setPassword,
 } from 'keytar';
 
+import { BiometricMain } from 'jslib-common/abstractions/biometric.main';
+
+const AuthRequiredSuffix = 'biometric';
+const AuthenticatedActions = ['getPassword'];
+
 export class KeytarStorageListener {
-    constructor(private serviceName: string) { }
+    constructor(private serviceName: string, private biometricService: BiometricMain) { }
 
     init() {
         ipcMain.on('keytar', async (event: any, message: any) => {
             try {
-                let val: string = null;
-                if (message.action && message.key) {
+                const serviceName = this.serviceName + '_' + message.keySuffix;
+                const authenticationRequired = AuthenticatedActions.includes(message.action) &&
+                    AuthRequiredSuffix == message.keySuffix;
+                const authenticated = !authenticationRequired || await this.biometricService.authenticateBiometric();
+
+                let val: string | boolean = null;
+                if (authenticated && message.action && message.key) {
                     if (message.action === 'getPassword') {
-                        val = await getPassword(this.serviceName, message.key);
+                        val = await getPassword(serviceName, message.key);
+                    } else if (message.action === 'hasPassword') {
+                        const result = await getPassword(serviceName, message.key);
+                        val = result != null;
                     } else if (message.action === 'setPassword' && message.value) {
-                        await setPassword(this.serviceName, message.key, message.value);
+                        await setPassword(serviceName, message.key, message.value);
                     } else if (message.action === 'deletePassword') {
-                        await deletePassword(this.serviceName, message.key);
+                        await deletePassword(serviceName, message.key);
                     }
                 }
-
                 event.returnValue = val;
             } catch {
                 event.returnValue = null;

--- a/electron/src/keytarStorageListener.ts
+++ b/electron/src/keytarStorageListener.ts
@@ -19,7 +19,7 @@ export class KeytarStorageListener {
             try {
                 const serviceName = this.serviceName + '_' + message.keySuffix;
                 const authenticationRequired = AuthenticatedActions.includes(message.action) &&
-                    AuthRequiredSuffix == message.keySuffix;
+                    AuthRequiredSuffix === message.keySuffix;
                 const authenticated = !authenticationRequired || await this.biometricService.authenticateBiometric();
 
                 let val: string | boolean = null;

--- a/electron/src/keytarStorageListener.ts
+++ b/electron/src/keytarStorageListener.ts
@@ -8,7 +8,7 @@ import {
 
 import { BiometricMain } from 'jslib-common/abstractions/biometric.main';
 
-const AuthRequiredSuffix = 'biometric';
+const AuthRequiredSuffix = '_biometric';
 const AuthenticatedActions = ['getPassword'];
 
 export class KeytarStorageListener {
@@ -17,7 +17,12 @@ export class KeytarStorageListener {
     init() {
         ipcMain.on('keytar', async (event: any, message: any) => {
             try {
-                const serviceName = this.serviceName + '_' + message.keySuffix;
+                let serviceName = this.serviceName;
+                message.keySuffix = '_' + (message.keySuffix ?? '');
+                if (message.keySuffix !== '_') {
+                    serviceName += message.keySuffix;
+                }
+
                 const authenticationRequired = AuthenticatedActions.includes(message.action) &&
                     AuthRequiredSuffix === message.keySuffix;
                 const authenticated = !authenticationRequired || await this.biometricService.authenticateBiometric();

--- a/electron/src/services/electronRendererSecureStorage.service.ts
+++ b/electron/src/services/electronRendererSecureStorage.service.ts
@@ -18,7 +18,7 @@ export class ElectronRendererSecureStorageService implements StorageService {
             key: key,
             keySuffix: options?.keySuffix ?? '',
         });
-        return Promise.resolve(val != null ? JSON.parse(val) as boolean : null);
+        return Promise.resolve(!!val);
     }
 
     async save(key: string, obj: any, options?: StorageServiceOptions): Promise<any> {

--- a/electron/src/services/electronRendererSecureStorage.service.ts
+++ b/electron/src/services/electronRendererSecureStorage.service.ts
@@ -1,29 +1,41 @@
 import { ipcRenderer } from 'electron';
 
-import { StorageService } from 'jslib-common/abstractions/storage.service';
+import { StorageService, StorageServiceOptions } from 'jslib-common/abstractions/storage.service';
 
 export class ElectronRendererSecureStorageService implements StorageService {
-    async get<T>(key: string): Promise<T> {
+    async get<T>(key: string, options?: StorageServiceOptions): Promise<T> {
         const val = ipcRenderer.sendSync('keytar', {
             action: 'getPassword',
             key: key,
+            keySuffix: options?.keySuffix ?? '',
         });
         return Promise.resolve(val != null ? JSON.parse(val) as T : null);
     }
 
-    async save(key: string, obj: any): Promise<any> {
+    async has(key: string, options?: StorageServiceOptions): Promise<boolean> {
+        const val = ipcRenderer.sendSync('keytar', {
+            action: 'hasPassword',
+            key: key,
+            keySuffix: options?.keySuffix ?? '',
+        });
+        return Promise.resolve(val != null ? JSON.parse(val) as boolean : null);
+    }
+
+    async save(key: string, obj: any, options?: StorageServiceOptions): Promise<any> {
         ipcRenderer.sendSync('keytar', {
             action: 'setPassword',
             key: key,
+            keySuffix: options?.keySuffix ?? '',
             value: JSON.stringify(obj),
         });
         return Promise.resolve();
     }
 
-    async remove(key: string): Promise<any> {
+    async remove(key: string, options?: StorageServiceOptions): Promise<any> {
         ipcRenderer.sendSync('keytar', {
             action: 'deletePassword',
             key: key,
+            keySuffix: options?.keySuffix ?? '',
         });
         return Promise.resolve();
     }

--- a/electron/src/services/electronRendererStorage.service.ts
+++ b/electron/src/services/electronRendererStorage.service.ts
@@ -10,6 +10,13 @@ export class ElectronRendererStorageService implements StorageService {
         });
     }
 
+    has(key: string): Promise<boolean> {
+        return ipcRenderer.invoke('storageService', {
+            action: 'has',
+            key: key,
+        });
+    }
+
     save(key: string, obj: any): Promise<any> {
         return ipcRenderer.invoke('storageService', {
             action: 'save',

--- a/electron/src/services/electronStorage.service.ts
+++ b/electron/src/services/electronStorage.service.ts
@@ -25,6 +25,8 @@ export class ElectronStorageService implements StorageService {
             switch (options.action) {
                 case 'get':
                     return this.get(options.key);
+                case 'has':
+                    return this.has(options.key);
                 case 'save':
                     return this.save(options.key, options.obj);
                 case 'remove':
@@ -36,6 +38,11 @@ export class ElectronStorageService implements StorageService {
     get<T>(key: string): Promise<T> {
         const val = this.store.get(key) as T;
         return Promise.resolve(val != null ? val : null);
+    }
+
+    has(key: string): Promise<boolean> {
+        const val = this.store.get(key);
+        return Promise.resolve(val != null);
     }
 
     save(key: string, obj: any): Promise<any> {

--- a/node/src/services/lowdbStorage.service.ts
+++ b/node/src/services/lowdbStorage.service.ts
@@ -84,6 +84,10 @@ export class LowdbStorageService implements StorageService {
         });
     }
 
+    has(key: string): Promise<boolean> {
+        return this.get(key).then(v => v != null);
+    }
+
     save(key: string, obj: any): Promise<any> {
         return this.lockDbFile(() => {
             this.readForNoCache();


### PR DESCRIPTION
# Overview

Split `secureStorage` key into multiple with separate keys (with the same value) to enable differential authentication of the keys.

Right now we have two use cases (1) Never unlock scenarios and (2) biometric unlock. 

### Never Lock
This option stores a copy of the vault key, which is grabbed on start to unlock the vault. No password or biometric prompt should be shown.

### Biometric unlock
This options stores a copy of the vault key, which should _always_ require biometric authentication in order to access.

These two options are split into keys stored under `Bitwarden_auto` and `Bitwarden_biometric`. 

## Context in StorageService

In order to differentially authenticate securely stored secrets, storage needs the ability to receive context in stored item requests. `StorageService` methods now have `StorageServiceOptions` passed in which provide this context. For now, it's just the suffix to the key being requested.

### KeytarListenerService

This service runs in the main process. It requires authentication prior to accessing and returning the biometric key

# Files Changed

* **lock.component.ts**:
  * Specifically request is biometric key is stored in secure storage
  * Unlock biometric by getting the biometric key. This prompts for a biometric authentication.
  * Set new lock state flags on unlock.
* **biometric.main/biometric.darwin/biometric.windows**: Rename to `authenticateBiometric` as it's more accurate to the method's action
* **crypto.service.ts**:
  * Specify which key to grab from storage if necessary.
  * Add more specific `hasKey` methods to determine if the key is in memory or stored
  * Add option to not remove keys from storage on `clearKey`
  * Update `Bitwarden` stored keys to split key structure when reading it.
* **storage.service.ts**:
  * Add context options to each method
  * Add has method which returns a boolean indicating if the key exists in storage
  * Define types for storage options and valid key types.
* **vaultTimeout.service**:
  * Add `ManuallyOrTimerLocked` flag: this flag is initially false to indicate lock is due to initial load. Otherwise, it is toggled whenever locked or unlocked.
  * Add `everBeenUnlocked` flag: this flag is initially false and toggled to true on unlocks. Ensures that auto keys are loaded only when first launched. Otherwise, we're left in a situation where a Never lock client can't even be locked manually.
  * Softlock is removed -- we want to remove keys from memory and reload for biometric locks
* **system.service.ts**: Do not auto-reload on biometric locked
* **keytarStorageListener.ts**: 
  * Change service name based on the key suffix. We can't store multiple keys under the same storage on mac, so just change the name.
  * authenticate all methods prior to execution. Constants define the authentication methods required on a suffix- and method-basis. Only requests which match `getPassword` _and_ `biometric` require any authentication (and biometric is required)
* **electronRendererSecureStorage.ts**: Pass keysuffix to the backing keytarListeningService.
* **various storage services**: Add `has` method