### PR TITLE
Use encrypted filename filename in Cipher attachment upload blob name

### DIFF
--- a/common/src/abstractions/fileUpload.service.ts
+++ b/common/src/abstractions/fileUpload.service.ts
@@ -6,6 +6,6 @@ import { SendFileUploadDataResponse } from '../models/response/sendFileUploadDat
 export abstract class FileUploadService {
     uploadSendFile: (uploadData: SendFileUploadDataResponse, fileName: EncString,
         encryptedFileData: EncArrayBuffer) => Promise<any>;
-    uploadCipherAttachment: (admin: boolean, uploadData: AttachmentUploadDataResponse, fileName: string,
+    uploadCipherAttachment: (admin: boolean, uploadData: AttachmentUploadDataResponse, fileName: EncString,
         encryptedFileData: EncArrayBuffer) => Promise<any>;
 }

--- a/common/src/services/cipher.service.ts
+++ b/common/src/services/cipher.service.ts
@@ -638,7 +638,7 @@ export class CipherService implements CipherServiceAbstraction {
         try {
             const uploadDataResponse = await this.apiService.postCipherAttachment(cipher.id, request);
             response = admin ? uploadDataResponse.cipherMiniResponse : uploadDataResponse.cipherResponse;
-            await this.fileUploadService.uploadCipherAttachment(admin, uploadDataResponse, filename, encData);
+            await this.fileUploadService.uploadCipherAttachment(admin, uploadDataResponse, encFileName, encData);
         } catch (e) {
             if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404 || (e as ErrorResponse).statusCode === 405) {
                 response = await this.legacyServerAttachmentFileUpload(admin, cipher.id, encFileName, encData, dataEncKey[1]);

--- a/common/src/services/fileUpload.service.ts
+++ b/common/src/services/fileUpload.service.ts
@@ -47,12 +47,13 @@ export class FileUploadService implements FileUploadServiceAbstraction {
         }
     }
 
-    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: string, encryptedFileData: EncArrayBuffer) {
+    async uploadCipherAttachment(admin: boolean, uploadData: AttachmentUploadDataResponse, encryptedFileName: EncString,
+        encryptedFileData: EncArrayBuffer) {
         const response = admin ? uploadData.cipherMiniResponse : uploadData.cipherResponse;
         try {
             switch (uploadData.fileUploadType) {
                 case FileUploadType.Direct:
-                    await this.bitwardenFileUploadService.upload(encryptedFileName, encryptedFileData,
+                    await this.bitwardenFileUploadService.upload(encryptedFileName.encryptedString, encryptedFileData,
                         fd => this.apiService.postAttachmentFile(response.id, uploadData.attachmentId, fd));
                     break;
                 case FileUploadType.Azure:


### PR DESCRIPTION
# Overview

We are naming our direct-to-bitwarden upload blobs a cleartext filename. This value is just thrown away on our server, but this PR fixes that but and specifies the type to be an encrypted string to prevent this in the future.

# Files Changed
* **fileUpload.service.ts**: Correct fileName type to EncString, forcing an encrypted string so we can't mess this up again.
* **cipher.service**: Change the filename over to the encrypted version.