### PR TITLE
Use 2 iterations for local password hashing

### DIFF
--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -9,7 +9,9 @@ import { EventService } from 'jslib-common/abstractions/event.service';
 import { ExportService } from 'jslib-common/abstractions/export.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+
 import { EventType } from 'jslib-common/enums/eventType';
+import { HashPurpose } from 'jslib-common/enums/hashPurpose';
 
 @Directive()
 export class ExportComponent {
@@ -40,7 +42,7 @@ export class ExportComponent {
             return;
         }
 
-        const keyHash = await this.cryptoService.hashPassword(this.masterPassword, null);
+        const keyHash = await this.cryptoService.hashPassword(this.masterPassword, null, HashPurpose.LocalAuthorization);
         const storedKeyHash = await this.cryptoService.getKeyHash();
         if (storedKeyHash != null && keyHash != null && storedKeyHash === keyHash) {
             try {

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -21,6 +21,8 @@ import { PasswordVerificationRequest } from 'jslib-common/models/request/passwor
 
 import { Utils } from 'jslib-common/misc/utils';
 
+import { HashPurpose } from 'jslib-common/enums/hashPurpose';
+
 @Directive()
 export class LockComponent implements OnInit {
     masterPassword: string = '';
@@ -109,22 +111,25 @@ export class LockComponent implements OnInit {
             }
         } else {
             const key = await this.cryptoService.makeKey(this.masterPassword, this.email, kdf, kdfIterations);
-            const keyHash = await this.cryptoService.hashPassword(this.masterPassword, key);
+            const localKeyHash = await this.cryptoService.hashPassword(this.masterPassword, key,
+                HashPurpose.LocalAuthorization);
 
             let passwordValid = false;
 
-            if (keyHash != null) {
+            if (localKeyHash != null) {
                 const storedKeyHash = await this.cryptoService.getKeyHash();
                 if (storedKeyHash != null) {
-                    passwordValid = storedKeyHash === keyHash;
+                    passwordValid = storedKeyHash === localKeyHash;
                 } else {
                     const request = new PasswordVerificationRequest();
-                    request.masterPasswordHash = keyHash;
+                    const serverKeyHash = await this.cryptoService.hashPassword(this.masterPassword, key,
+                        HashPurpose.ServerAuthorization);
+                    request.masterPasswordHash = serverKeyHash;
                     try {
                         this.formPromise = this.apiService.postAccountVerifyPassword(request);
                         await this.formPromise;
                         passwordValid = true;
-                        await this.cryptoService.setKeyHash(keyHash);
+                        await this.cryptoService.setKeyHash(localKeyHash);
                     } catch { }
                 }
             }

--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -22,6 +22,7 @@ import { SetPasswordRequest } from 'jslib-common/models/request/setPasswordReque
 
 import { ChangePasswordComponent as BaseChangePasswordComponent } from './change-password.component';
 
+import { HashPurpose } from 'jslib-common/enums/hashPurpose';
 import { KdfType } from 'jslib-common/enums/kdfType';
 
 @Directive()
@@ -86,9 +87,12 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
             await this.userService.setInformation(await this.userService.getUserId(), await this.userService.getEmail(),
                 this.kdf, this.kdfIterations);
             await this.cryptoService.setKey(key);
-            await this.cryptoService.setKeyHash(masterPasswordHash);
             await this.cryptoService.setEncKey(encKey[1].encryptedString);
             await this.cryptoService.setEncPrivateKey(keys[1].encryptedString);
+
+            const localKeyHash = await this.cryptoService.hashPassword(this.masterPassword, key,
+                HashPurpose.LocalAuthorization);
+            await this.cryptoService.setKeyHash(localKeyHash);
 
             if (this.onSuccessfulChangePassword != null) {
                 this.onSuccessfulChangePassword();

--- a/common/src/abstractions/crypto.service.ts
+++ b/common/src/abstractions/crypto.service.ts
@@ -4,6 +4,7 @@ import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
 import { ProfileOrganizationResponse } from '../models/response/profileOrganizationResponse';
 
+import { HashPurpose } from '../enums/hashPurpose';
 import { KdfType } from '../enums/kdfType';
 
 export abstract class CryptoService {
@@ -37,7 +38,7 @@ export abstract class CryptoService {
     makeKeyPair: (key?: SymmetricCryptoKey) => Promise<[string, EncString]>;
     makePinKey: (pin: string, salt: string, kdf: KdfType, kdfIterations: number) => Promise<SymmetricCryptoKey>;
     makeSendKey: (keyMaterial: ArrayBuffer) => Promise<SymmetricCryptoKey>;
-    hashPassword: (password: string, key: SymmetricCryptoKey) => Promise<string>;
+    hashPassword: (password: string, key: SymmetricCryptoKey, hashPurpose?: HashPurpose) => Promise<string>;
     makeEncKey: (key: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, EncString]>;
     remakeEncKey: (key: SymmetricCryptoKey, encKey?: SymmetricCryptoKey) => Promise<[SymmetricCryptoKey, EncString]>;
     encrypt: (plainValue: string | ArrayBuffer, key?: SymmetricCryptoKey) => Promise<EncString>;

--- a/common/src/enums/hashPurpose.ts
+++ b/common/src/enums/hashPurpose.ts
@@ -1,0 +1,4 @@
+export enum HashPurpose {
+    ServerAuthorization = 1,
+    LocalAuthorization = 2,
+}

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -345,7 +345,7 @@ export class AuthService implements AuthServiceAbstraction {
             if (key != null) {
                 await this.cryptoService.setKey(key);
             }
-            if (hashedPassword != null) {
+            if (localHashedPassword != null) {
                 await this.cryptoService.setKeyHash(localHashedPassword);
             }
 

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -1,6 +1,7 @@
 import * as bigInt from 'big-integer';
 
 import { EncryptionType } from '../enums/encryptionType';
+import { HashPurpose } from '../enums/hashPurpose';
 import { KdfType } from '../enums/kdfType';
 
 import { EncArrayBuffer } from '../models/domain/encArrayBuffer';
@@ -372,7 +373,7 @@ export class CryptoService implements CryptoServiceAbstraction {
         return new SymmetricCryptoKey(sendKey);
     }
 
-    async hashPassword(password: string, key: SymmetricCryptoKey): Promise<string> {
+    async hashPassword(password: string, key: SymmetricCryptoKey, hashPurpose?: HashPurpose): Promise<string> {
         if (key == null) {
             key = await this.getKey();
         }
@@ -380,7 +381,8 @@ export class CryptoService implements CryptoServiceAbstraction {
             throw new Error('Invalid parameters.');
         }
 
-        const hash = await this.cryptoFunctionService.pbkdf2(key.key, password, 'sha256', 1);
+        const iterations = hashPurpose === HashPurpose.LocalAuthorization ? 2 : 1;
+        const hash = await this.cryptoFunctionService.pbkdf2(key.key, password, 'sha256', iterations);
         return Utils.fromBufferToB64(hash);
     }
 

--- a/common/src/services/passwordReprompt.service.ts
+++ b/common/src/services/passwordReprompt.service.ts
@@ -4,6 +4,8 @@ import { CryptoService } from '../abstractions/crypto.service';
 import { I18nService } from '../abstractions/i18n.service';
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from '../abstractions/passwordReprompt.service';
 
+import { HashPurpose } from '../enums/hashPurpose';
+
 export class PasswordRepromptService implements PasswordRepromptServiceAbstraction {
     constructor(private i18nService: I18nService, private cryptoService: CryptoService,
         private platformUtilService: PlatformUtilsService) { }
@@ -14,7 +16,7 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
 
     async showPasswordPrompt() {
         const passwordValidator = async (value: string) => {
-            const keyHash = await this.cryptoService.hashPassword(value, null);
+            const keyHash = await this.cryptoService.hashPassword(value, null, HashPurpose.LocalAuthorization);
             const storedKeyHash = await this.cryptoService.getKeyHash();
 
             if (storedKeyHash == null || keyHash == null || storedKeyHash !== keyHash) {


### PR DESCRIPTION
## Objective

Use different iteration count for password hashing when it's for front-end authentication vs. server authentication. See rationale and approach here: https://app.asana.com/0/1169444489336079/1200436665343464/f