### PR TITLE
Use deviceType to discern icon to grab from icon server for events

### DIFF
--- a/common/src/models/view/eventView.ts
+++ b/common/src/models/view/eventView.ts
@@ -1,9 +1,11 @@
+import { DeviceType } from '../../enums';
 import { EventType } from '../../enums/eventType';
 
 export class EventView {
     message: string;
     humanReadableMessage: string;
     appIcon: string;
+    deviceType: DeviceType;
     appName: string;
     userId: string;
     userName: string;
@@ -17,6 +19,7 @@ export class EventView {
         this.humanReadableMessage = data.humanReadableMessage;
         this.appIcon = data.appIcon;
         this.appName = data.appName;
+        this.deviceType = data.deviceType;
         this.userId = data.userId;
         this.userName = data.userName;
         this.userEmail = data.userEmail;


### PR DESCRIPTION
# Overview

Events all use [FontAwesome brand icons](https://www.w3schools.com/icons/fontawesome_icons_brand.asp), which are all monochrome. We already have infrastructure in place to grab favicons for websites, which tend to be brand icons.

This PR is used in conjunction with bitwarden/web#1023 to enable favicons for certain event device types.

# Files changed
* **eventView.ts**: Return device type as part of the event. This is used to determine favicon loading.