### PR TITLE
Add backwards compatability for new local hashing method

### DIFF
--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -42,9 +42,8 @@ export class ExportComponent {
             return;
         }
 
-        const keyHash = await this.cryptoService.hashPassword(this.masterPassword, null, HashPurpose.LocalAuthorization);
-        const storedKeyHash = await this.cryptoService.getKeyHash();
-        if (storedKeyHash != null && keyHash != null && storedKeyHash === keyHash) {
+        const passwordValid = await this.cryptoService.compareAndUpdateKeyHash(this.masterPassword, null);
+        if (passwordValid) {
             try {
                 this.formPromise = this.getExportData();
                 const data = await this.formPromise;

--- a/common/src/abstractions/crypto.service.ts
+++ b/common/src/abstractions/crypto.service.ts
@@ -16,6 +16,7 @@ export abstract class CryptoService {
     setOrgKeys: (orgs: ProfileOrganizationResponse[]) => Promise<{}>;
     getKey: (keySuffix?: KeySuffixOptions) => Promise<SymmetricCryptoKey>;
     getKeyHash: () => Promise<string>;
+    compareAndUpdateKeyHash: (masterPassword: string, key: SymmetricCryptoKey) => Promise<boolean>;
     getEncKey: (key?: SymmetricCryptoKey) => Promise<SymmetricCryptoKey>;
     getPublicKey: () => Promise<ArrayBuffer>;
     getPrivateKey: () => Promise<ArrayBuffer>;

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -139,6 +139,7 @@ export class CryptoService implements CryptoServiceAbstraction {
                 return true;
             }
 
+            // TODO: remove serverKeyHash check in 1-2 releases after everyone's keyHash has been updated
             const serverKeyHash = await this.hashPassword(masterPassword, key, HashPurpose.ServerAuthorization);
             if (serverKeyHash != null && storedKeyHash === serverKeyHash) {
                 await this.setKeyHash(localKeyHash);

--- a/common/src/services/passwordReprompt.service.ts
+++ b/common/src/services/passwordReprompt.service.ts
@@ -16,13 +16,7 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
 
     async showPasswordPrompt() {
         const passwordValidator = async (value: string) => {
-            const keyHash = await this.cryptoService.hashPassword(value, null, HashPurpose.LocalAuthorization);
-            const storedKeyHash = await this.cryptoService.getKeyHash();
-
-            if (storedKeyHash == null || keyHash == null || storedKeyHash !== keyHash) {
-                return false;
-            }
-            return true;
+            return await this.cryptoService.compareAndUpdateKeyHash(value, null);
         };
 
         return this.platformUtilService.showPasswordDialog(this.i18nService.t('passwordConfirmation'), this.i18nService.t('passwordConfirmationDesc'), passwordValidator);

--- a/common/src/services/passwordReprompt.service.ts
+++ b/common/src/services/passwordReprompt.service.ts
@@ -15,8 +15,8 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
     }
 
     async showPasswordPrompt() {
-        const passwordValidator = async (value: string) => {
-            return await this.cryptoService.compareAndUpdateKeyHash(value, null);
+        const passwordValidator = (value: string) => {
+            return this.cryptoService.compareAndUpdateKeyHash(value, null);
         };
 
         return this.platformUtilService.showPasswordDialog(this.i18nService.t('passwordConfirmation'), this.i18nService.t('passwordConfirmationDesc'), passwordValidator);


### PR DESCRIPTION
## Objective

Follow up work from #404. Changing the local password hashing method would have stopped users from unlocking after the update (at least until they logged out and back in again). This checks to see whether they're using an outdated hash and updates it gracefully.