### PR TITLE
Add get key from storage for ensuring biometric browser integration

### DIFF
--- a/common/src/abstractions/crypto.service.ts
+++ b/common/src/abstractions/crypto.service.ts
@@ -14,6 +14,7 @@ export abstract class CryptoService {
     setEncPrivateKey: (encPrivateKey: string) => Promise<{}>;
     setOrgKeys: (orgs: ProfileOrganizationResponse[]) => Promise<{}>;
     getKey: (keySuffix?: KeySuffixOptions) => Promise<SymmetricCryptoKey>;
+    getKeyFromStorage: (keySuffix: KeySuffixOptions) => Promise<SymmetricCryptoKey>;
     getKeyHash: () => Promise<string>;
     getEncKey: (key?: SymmetricCryptoKey) => Promise<SymmetricCryptoKey>;
     getPublicKey: () => Promise<ArrayBuffer>;

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -99,7 +99,18 @@ export class CryptoService implements CryptoServiceAbstraction {
         if (this.key != null) {
             return this.key;
         }
+
         keySuffix ||= 'auto';
+        const symmetricKey = await this.getKeyFromStorage(keySuffix);
+
+        if (symmetricKey != null) {
+            this.setKey(symmetricKey);
+        }
+
+        return symmetricKey;
+    }
+
+    async getKeyFromStorage(keySuffix: KeySuffixOptions): Promise<SymmetricCryptoKey> {
         const key = await this.retrieveKeyFromStorage(keySuffix);
         if (key != null) {
 
@@ -111,10 +122,9 @@ export class CryptoService implements CryptoServiceAbstraction {
                 return null;
             }
 
-            this.setKey(symmetricKey);
+            return symmetricKey;
         }
-
-        return key == null ? null : this.key;
+        return null;
     }
 
     async getKeyHash(): Promise<string> {


### PR DESCRIPTION
# Overview

@Hinton noticed some issues with biometric unlock from browser introduced in #402 and bitwarden/desktop#946.

Namely, the normal `getKey` method was being used, which will use a key stored in memory, if available, and set the key to memory if not. We don't want that behavior for biometric unlock -- it should _always_ prompt.

This requires a new method, `getKeyFromStorage`, which always retrieves the requested key from secure storage.

# Files Changed
* **crypto.service**: Add new `getKeyFromStorage` method to abstraction and implementation. `getKey` uses this method to retrieve from storage.