### PR TITLE
Add null checks for TrayMain.tray

### DIFF
--- a/electron/src/tray.main.ts
+++ b/electron/src/tray.main.ts
@@ -120,6 +120,10 @@ export class TrayMain {
         }
 
         this.tray = new Tray(this.icon);
+        if (this.tray == null) {
+            return;
+        }
+
         this.tray.setToolTip(this.appName);
         this.tray.on('click', () => this.toggleWindow());
         this.tray.on('right-click', () => this.tray.popUpContextMenu(this.contextMenu));
@@ -133,7 +137,7 @@ export class TrayMain {
     }
 
     updateContextMenu() {
-        if (this.contextMenu != null && this.isLinux()) {
+        if (this.contextMenu != null && this.tray != null && this.isLinux()) {
             this.tray.setContextMenu(this.contextMenu);
         }
     }


### PR DESCRIPTION
## Objective

Fix bitwarden/desktop#934, which was caused by calling `trayMain.tray.setContextMenu` when `trayMain.tray` was null. This only occurs on Linux.

`trayMain.tray` may be null if:
* the user has not enabled minimise to tray in preferences - `init()` does not call `this.showTray()`, which initialises `this.tray`
* the OS does not have a tray and therefore `this.tray` may not be initialized properly

## Code changes
* early return from `showTray()` if we can't initialize the tray properly
* extra null check on `updateContextMenu()`

I'll need to bump `jslib` on `desktop` after this is merged.