### PR TITLE
Simplify `isLocked` and fix interaction between Never lock and no prompt biometr

### DIFF
--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -182,7 +182,6 @@ export class LockComponent implements OnInit {
     private async doContinue() {
         this.vaultTimeoutService.biometricLocked = false;
         this.vaultTimeoutService.everBeenUnlocked = true;
-        this.vaultTimeoutService.manuallyOrTimerLocked = false;
         const disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
         await this.stateService.save(ConstantsService.disableFaviconKey, !!disableFavicon);
         this.messagingService.send('unlocked');

--- a/common/src/abstractions/vaultTimeout.service.ts
+++ b/common/src/abstractions/vaultTimeout.service.ts
@@ -2,7 +2,6 @@ import { EncString } from '../models/domain/encString';
 
 export abstract class VaultTimeoutService {
     biometricLocked: boolean;
-    manuallyOrTimerLocked: boolean;
     everBeenUnlocked: boolean;
     pinProtectedKey: EncString;
     isLocked: () => Promise<boolean>;


### PR DESCRIPTION
# Overview

Vault should be locked if key is not in memory. Key is loaded on startup if auto key exists.

> Note: This PR will be cherry-picked to `rc` as well as propagated to all jslib clients (and cherry-picked there) prior to the upcoming release. Please evaluate accordingly.

# Files Changed
* **vaultTimeoutService**: 
  * `biometricLocked was overriding never lock in situations where never lock, biometric unlock, and do not prompt biometric on start were set. 
  * The new `hasKeyInMemory` method can be used to reliably detect when the vault is locked -- the key shouldn't be in memory in a locked vault. There is also logic to handle startup conditions with "Never lock" set.
  * The above changes make `manuallyOrTimerLocked` obsolete.
* **other**: remove references to `manuallyOrTimerLocked`