### PR TITLE
Persist API key creds for token refresh.

### DIFF
--- a/common/src/abstractions/apiKey.service.ts
+++ b/common/src/abstractions/apiKey.service.ts
@@ -1,6 +1,8 @@
 export abstract class ApiKeyService {
-    setInformation: (clientId: string) => Promise<any>;
+    setInformation: (clientId: string, clientSecret: string) => Promise<any>;
     clear: () => Promise<any>;
+    getClientId: () => Promise<string>;
+    getClientSecret: () => Promise<string>;
     getEntityType: () => Promise<string>;
     getEntityId: () => Promise<string>;
     isAuthenticated: () => Promise<boolean>;

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -1312,8 +1312,8 @@ export class ApiService implements ApiServiceAbstraction {
     async getActiveBearerToken(): Promise<string> {
         let accessToken = await this.tokenService.getToken();
         if (this.tokenService.tokenNeedsRefresh()) {
-            const tokenResponse = await this.doRefreshToken();
-            accessToken = tokenResponse.accessToken;
+            await this.doRefreshToken();
+            accessToken = await this.tokenService.getToken();
         }
         return accessToken;
     }
@@ -1427,7 +1427,7 @@ export class ApiService implements ApiServiceAbstraction {
         return new ErrorResponse(responseJson, response.status, tokenError);
     }
 
-    private async doRefreshToken(): Promise<IdentityTokenResponse> {
+    protected async doRefreshToken(): Promise<void> {
         const refreshToken = await this.tokenService.getRefreshToken();
         if (refreshToken == null || refreshToken === '') {
             throw new Error();
@@ -1458,7 +1458,6 @@ export class ApiService implements ApiServiceAbstraction {
             const responseJson = await response.json();
             const tokenResponse = new IdentityTokenResponse(responseJson);
             await this.tokenService.setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
-            return tokenResponse;
         } else {
             const error = await this.handleError(response, true, true);
             return Promise.reject(error);

--- a/common/src/services/apiKey.service.ts
+++ b/common/src/services/apiKey.service.ts
@@ -6,6 +6,7 @@ import { Utils } from '../misc/utils';
 
 const Keys = {
     clientId: 'clientId',
+    clientSecret: 'clientSecret',
     entityType: 'entityType',
     entityId: 'entityId',
 };
@@ -13,13 +14,15 @@ const Keys = {
 
 export class ApiKeyService implements ApiKeyServiceAbstraction {
     private clientId: string;
+    private clientSecret: string;
     private entityType: string;
     private entityId: string;
 
     constructor(private tokenService: TokenService, private storageService: StorageService) { }
 
-    async setInformation(clientId: string) {
+    async setInformation(clientId: string, clientSecret: string) {
         this.clientId = clientId;
+        this.clientSecret = clientSecret
         const idParts = clientId.split('.');
 
         if (idParts.length !== 2 || !Utils.isGuid(idParts[1])) {
@@ -31,6 +34,21 @@ export class ApiKeyService implements ApiKeyServiceAbstraction {
         await this.storageService.save(Keys.clientId, this.clientId);
         await this.storageService.save(Keys.entityId, this.entityId);
         await this.storageService.save(Keys.entityType, this.entityType);
+        await this.storageService.save(Keys.clientSecret, this.clientSecret);
+    }
+
+    async getClientId(): Promise<string> {
+        if (this.clientId == null) {
+            this.clientId = await this.storageService.get<string>(Keys.clientId);
+        }
+        return this.clientId;
+    }
+
+    async getClientSecret(): Promise<string> {
+        if (this.clientSecret == null) {
+            this.clientSecret = await this.storageService.get<string>(Keys.clientSecret);
+        }
+        return this.clientSecret;
     }
 
     async getEntityType(): Promise<string> {
@@ -49,10 +67,11 @@ export class ApiKeyService implements ApiKeyServiceAbstraction {
 
     async clear(): Promise<any> {
         await this.storageService.remove(Keys.clientId);
+        await this.storageService.remove(Keys.clientSecret);
         await this.storageService.remove(Keys.entityId);
         await this.storageService.remove(Keys.entityType);
 
-        this.clientId = this.entityId = this.entityType = null;
+        this.clientId = this.clientSecret = this.entityId = this.entityType = null;
     }
 
     async isAuthenticated(): Promise<boolean> {

--- a/common/src/services/apiKey.service.ts
+++ b/common/src/services/apiKey.service.ts
@@ -22,7 +22,7 @@ export class ApiKeyService implements ApiKeyServiceAbstraction {
 
     async setInformation(clientId: string, clientSecret: string) {
         this.clientId = clientId;
-        this.clientSecret = clientSecret
+        this.clientSecret = clientSecret;
         const idParts = clientId.split('.');
 
         if (idParts.length !== 2 || !Utils.isGuid(idParts[1])) {


### PR DESCRIPTION
# Overview

Linked to bitwarden/directory-connector#135

#382 and bitwarden/directory-connector#121 switched authentication to organization API key flow. However, this authentication does not include refresh tokens.

This is groundwork for persisting api key credentials and overriding token refresh with simply re-authenticating with api key creds.

> Note: This PR will need to be cherry-picked into `rc` and subsequently into the clients. Please evaluate accordingly

# Files Changed
* **apiKey.service.ts**: Persist and retrieve api key credentials
* **api.service.ts**: Update `doRefreshToken` private method to return nothing, and allow for inherited override. Return signature change is due to auth flow not receiving an `IdentityResponse` from the `apiService`. At any rate, we were only interested in grabbing the new token, which can be done from `TokenService`.