### PR TITLE
Correct typo

### DIFF
--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -334,7 +334,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     }
 
     async clearKeys(): Promise<any> {
-        await this.clearEncKey();
+        await this.clearKey();
         await this.clearKeyHash();
         await this.clearOrgKeys();
         await this.clearEncKey();


### PR DESCRIPTION
# Overview

Correct typo. This bug causes keys to never be deleted in CLI.

> Note: this will be cherry-picked into `rc` and pushed to at least CLI prior to next release. Please evaluate accordingly