### PR TITLE
feat: radio button options

### DIFF
--- a/angular/src/components/password-generator.component.ts
+++ b/angular/src/components/password-generator.component.ts
@@ -17,6 +17,7 @@ export class PasswordGeneratorComponent implements OnInit {
     @Input() showSelect: boolean = false;
     @Output() onSelected = new EventEmitter<string>();
 
+    passTypeOptions: any[];
     options: any = {};
     password: string = '-';
     showOptions = false;
@@ -25,7 +26,12 @@ export class PasswordGeneratorComponent implements OnInit {
 
     constructor(protected passwordGenerationService: PasswordGenerationService,
         protected platformUtilsService: PlatformUtilsService, protected i18nService: I18nService,
-        private win: Window) { }
+        private win: Window) {
+            this.passTypeOptions = [
+                { name: i18nService.t('password'), value: 'password' },
+                { name: i18nService.t('passphrase'), value: 'passphrase' },
+            ];
+         }
 
     async ngOnInit() {
         const optionsResponse = await this.passwordGenerationService.getOptions();


### PR DESCRIPTION
**Feature name:**

```
Replace the drop down for password/passphrase option with a radio button choice
```

**Feature Description**

There are only two options in the drop down, would it be better to replace it with a radio button for choice?

-  Aids in discoverability: I completely missed the option for a whole year before I thought to click on the option and see what it contains.
- Less number of interactions: It would take 1 less click to get the same result

Community Forum post: https://community.bitwarden.com/t/radio-choice-password-passphrase/30636