### PR TITLE
Set reprompt to None if null

### DIFF
--- a/common/src/models/view/cipherView.ts
+++ b/common/src/models/view/cipherView.ts
@@ -53,7 +53,8 @@ export class CipherView implements View {
         this.collectionIds = c.collectionIds;
         this.revisionDate = c.revisionDate;
         this.deletedDate = c.deletedDate;
-        this.reprompt = c.reprompt;
+        // Old locally stored ciphers might have reprompt == null. If so set it to None.
+        this.reprompt = c.reprompt ?? CipherRepromptType.None;
     }
 
     get subTitle(): string {


### PR DESCRIPTION
## Objective
Some users reported that every item prompts for reprompt. I managed to replicate it by disabling sync, and setting each cipher to have `reprompt = null`. As a fix I've added a null check to `CipherView` which seems to solve it for me.

(A sync also solved it for me)