### PR TITLE
Add pipe to format 16-digit credit card numbers in groups of 4

### DIFF
--- a/angular/src/pipes/credit-card-number.pipe.ts
+++ b/angular/src/pipes/credit-card-number.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'creditCardNumber' })
+export class CreditCardNumberPipe implements PipeTransform {
+    transform(creditCardNumber: string): string {
+        // See https://baymard.com/checkout-usability/credit-card-patterns for
+        // all possible credit card spacing patterns. For now, we just handle
+        // the common 4-4-4-4 spacing of 16-digit card numbers.
+        if (creditCardNumber.length === 16) {
+            return [
+                creditCardNumber.slice(0, 4),
+                creditCardNumber.slice(4, 8),
+                creditCardNumber.slice(8, 12),
+                creditCardNumber.slice(12),
+            ].join(' ');
+        }
+
+        return creditCardNumber;
+    }
+}


### PR DESCRIPTION
# Objective

This PR adds a pipe which formats 16-digit credit card numbers in 4 groups of 4 digits each for better readability.

## Community Forum Posts

Feature request post: https://community.bitwarden.com/t/display-card-numbers-in-groups-to-make-them-easier-to-read/12042

GitHub contribution post: https://community.bitwarden.com/t/display-card-numbers-in-groups-to-make-them-easier-to-read/31541

## Related PRs

https://github.com/bitwarden/browser/pull/1940
