### PR TITLE
[Provider] Refresh identity token on full sync

### DIFF
--- a/common/src/services/notifications.service.ts
+++ b/common/src/services/notifications.service.ts
@@ -149,7 +149,6 @@ export class NotificationsService implements NotificationsServiceAbstraction {
                 break;
             case NotificationType.SyncOrgKeys:
                 if (isAuthenticated) {
-                    await this.apiService.refreshIdentityToken();
                     await this.syncService.fullSync(true);
                     // Stop so a reconnect can be made
                     await this.signalrConnection.stop();

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -94,6 +94,7 @@ export class SyncService implements SyncServiceAbstraction {
 
         const userId = await this.userService.getUserId();
         try {
+            await this.apiService.refreshIdentityToken();
             const response = await this.apiService.getSync();
 
             await this.syncProfile(response.profile);


### PR DESCRIPTION
## Objective
Sometimes the `sync` response can be out of date with the identity token and contain organizations or providers which the user can't access yet. To resolve this I added a call to `refreshToken` while doing a full sync.

Note: I'm not certain if this will have side effects but from what I've managed to understand we usually refresh it every 5 min, so I don't see any harm in doing it more often sometimes.

### Testing Considerations
We should do some regression testing to verify the identity token can successfully be retrieved in all of our clients.

https://app.asana.com/0/1198901840263430/1200639990863109