### PR TITLE
Use both instanceof and constructor name as type identification

### DIFF
--- a/angular/src/directives/api-action.directive.ts
+++ b/angular/src/directives/api-action.directive.ts
@@ -31,7 +31,7 @@ export class ApiActionDirective implements OnChanges {
         }, (e: any) => {
             this.el.nativeElement.loading = false;
 
-            if (e instanceof ErrorResponse && (e as ErrorResponse).captchaRequired) {
+            if ((e instanceof ErrorResponse || e.constructor.name === "ErrorResponse") && (e as ErrorResponse).captchaRequired) {
                 this.logService.error('Captcha required error response: ' + e.getSingleMessage());
                 return;
             }

--- a/angular/src/directives/api-action.directive.ts
+++ b/angular/src/directives/api-action.directive.ts
@@ -31,7 +31,7 @@ export class ApiActionDirective implements OnChanges {
         }, (e: any) => {
             this.el.nativeElement.loading = false;
 
-            if ((e instanceof ErrorResponse || e.constructor.name === "ErrorResponse") && (e as ErrorResponse).captchaRequired) {
+            if ((e instanceof ErrorResponse || e.constructor.name === 'ErrorResponse') && (e as ErrorResponse).captchaRequired) {
                 this.logService.error('Captcha required error response: ' + e.getSingleMessage());
                 return;
             }


### PR DESCRIPTION
# Overview

`api-action.directive` does not display error messages on `captchaProtected` api endpoints requesting captcha verification. In the [browser](https://gitbhub.com/bitwarden/browser) project, the type of captcha-required responses was not being identified correctly. Adding a test to the constructor name as a fallback method.