### PR TITLE
Feature/cli fail login on captcha request

### DIFF
--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -835,7 +835,7 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     async postOrganizationUserBulkConfirm(organizationId: string, request: OrganizationUserBulkConfirmRequest): Promise<ListResponse<OrganizationUserBulkResponse>> {
-        const r = await this.send('POST',  '/organizations/' + organizationId + '/users/confirm', request, true, true);
+        const r = await this.send('POST', '/organizations/' + organizationId + '/users/confirm', request, true, true);
         return new ListResponse(r, OrganizationUserBulkResponse);
     }
 
@@ -1262,7 +1262,7 @@ export class ApiService implements ApiServiceAbstraction {
     }
 
     async postProviderUserBulkConfirm(providerId: string, request: ProviderUserBulkConfirmRequest): Promise<ListResponse<ProviderUserBulkResponse>> {
-        const r = await this.send('POST',  '/providers/' + providerId + '/users/confirm', request, true, true);
+        const r = await this.send('POST', '/providers/' + providerId + '/users/confirm', request, true, true);
         return new ListResponse(r, ProviderUserBulkResponse);
     }
 

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -166,6 +166,10 @@ export class LoginCommand {
                 } else {
                     response = await this.authService.logIn(email, password);
                 }
+                if (response.captchaSiteKey) {
+                    return Response.badRequest('Your authentication request appears to be coming from a bot\n' +
+                        'Please log in using your API key (https://bitwarden.com/help/article/cli/#using-an-api-key)');
+                }
                 if (response.twoFactor) {
                     let selectedProvider: any = null;
                     const twoFactorProviders = this.authService.getSupportedTwoFactorProviders(null);


### PR DESCRIPTION
# Overview

Recover from captcha required login attempts on CLI instances with an informative message. For now, the only way around this captcha block is with an API key to log in.

Most of these changes are linter auto-fixes. The only real change is in `login.command.ts`

# Files Changed
* **login.command.ts**: Handle captcha required failures and show a helpful failure message.