### PR TITLE
Add missing dependency 'duo_web_sdk' in jslib/angular/package.json

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "tslint 'src/**/*.ts' 'spec/**/*.ts' --fix"
   },
   "devDependencies": {
+    "@types/duo_web_sdk": "^2.7.1",
     "rimraf": "^3.0.2",
     "typescript": "4.1.5"
   },
@@ -34,6 +35,7 @@
     "@angular/platform-browser-dynamic": "^11.2.11",
     "@angular/router": "^11.2.11",
     "@bitwarden/jslib-common": "file:../common",
+    "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
     "ngx-infinite-scroll": "10.0.1",
     "rxjs": "6.6.7",
     "tldjs": "^2.3.1",


### PR DESCRIPTION
## Objective
While setting up my dev-environment I encountered an issue with 'duo_web_sdk' not resolving when running 'npm i' on for example the desktop or browser repo. This occurs spefically on the following component: `angular/src/components/two-factor.component.ts`

This happens because the `jslib/angular`-package does not include a dependency for `duo_web_sdk`.

The error should've been caught earlier through our Github Build Action, but as nothing in `jslib` (common, spec, etc.) depends on `jslib/angular` it doesn't get built (no output in `/dist`)

The behaviour has also been reported in #440.

For our other repo this is usually not an issue as `duo_web_sdk` is included as a dependency on the web, browser and desktop projects, but actually not necessary to include it on a higher level project.

Resolves #440

After this is merged, we can also remove the dependency on `duo_web_sdk` in the web, browser and desktop.

## Code Changes
- **package.json**: Added `@types/duo_web_sdk` as a dev-dependency, added `duo_web_sdk` as a dependency.
