### PR TITLE
Correct ProviderOrgCreate return type

### DIFF
--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -127,7 +127,7 @@ import { PlanResponse } from '../models/response/planResponse';
 import { PolicyResponse } from '../models/response/policyResponse';
 import { PreloginResponse } from '../models/response/preloginResponse';
 import { ProfileResponse } from '../models/response/profileResponse';
-import { ProviderOrganizationOrganizationDetailsResponse } from '../models/response/provider/providerOrganizationResponse';
+import { ProviderOrganizationOrganizationDetailsResponse, ProviderOrganizationResponse } from '../models/response/provider/providerOrganizationResponse';
 import { ProviderResponse } from '../models/response/provider/providerResponse';
 import { ProviderUserBulkPublicKeyResponse } from '../models/response/provider/providerUserBulkPublicKeyResponse';
 import { ProviderUserBulkResponse } from '../models/response/provider/providerUserBulkResponse';
@@ -407,7 +407,7 @@ export abstract class ApiService {
     deleteManyProviderUsers: (providerId: string, request: ProviderUserBulkRequest) => Promise<ListResponse<ProviderUserBulkResponse>>;
     getProviderClients: (providerId: string) => Promise<ListResponse<ProviderOrganizationOrganizationDetailsResponse>>;
     postProviderAddOrganization: (providerId: string, request: ProviderAddOrganizationRequest) => Promise<any>;
-    postProviderCreateOrganization: (providerId: string, request: OrganizationCreateRequest) => Promise<OrganizationResponse>;
+    postProviderCreateOrganization: (providerId: string, request: OrganizationCreateRequest) => Promise<ProviderOrganizationResponse>;
     deleteProviderOrganization: (providerId: string, organizationId: string) => Promise<any>;
 
     getEvents: (start: string, end: string, token: string) => Promise<ListResponse<EventResponse>>;

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -131,7 +131,7 @@ import { PlanResponse } from '../models/response/planResponse';
 import { PolicyResponse } from '../models/response/policyResponse';
 import { PreloginResponse } from '../models/response/preloginResponse';
 import { ProfileResponse } from '../models/response/profileResponse';
-import { ProviderOrganizationOrganizationDetailsResponse } from '../models/response/provider/providerOrganizationResponse';
+import { ProviderOrganizationOrganizationDetailsResponse, ProviderOrganizationResponse } from '../models/response/provider/providerOrganizationResponse';
 import { ProviderResponse } from '../models/response/provider/providerResponse';
 import { ProviderUserBulkPublicKeyResponse } from '../models/response/provider/providerUserBulkPublicKeyResponse';
 import { ProviderUserBulkResponse } from '../models/response/provider/providerUserBulkResponse';
@@ -1305,9 +1305,9 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/providers/' + providerId + '/organizations/add', request, true, false);
     }
 
-    async postProviderCreateOrganization(providerId: string, request: OrganizationCreateRequest): Promise<OrganizationResponse> {
+    async postProviderCreateOrganization(providerId: string, request: OrganizationCreateRequest): Promise<ProviderOrganizationResponse> {
         const r = await this.send('POST', '/providers/' + providerId + '/organizations', request, true, true);
-        return new OrganizationResponse(r);
+        return new ProviderOrganizationResponse(r);
     }
 
     deleteProviderOrganization(providerId: string, id: string): Promise<any> {


### PR DESCRIPTION
# Overview

The return type of the api call to create a provider organization is incorrect (https://github.com/bitwarden/server/blob/master/src/Api/Controllers/ProviderOrganizationsController.cs#L65).

This fix is part of the fix for https://app.asana.com/0/0/1200645727236036/f. Web PR is bitwarden/web#1101

# Files changed
* **api.service**: Change return type