### PR TITLE
Update package lock for duo_web_sdk in angular

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -19,17 +19,20 @@
         "@angular/platform-browser-dynamic": "^11.2.11",
         "@angular/router": "^11.2.11",
         "@bitwarden/jslib-common": "file:../common",
+        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
         "ngx-infinite-scroll": "10.0.1",
         "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zone.js": "0.11.4"
       },
       "devDependencies": {
+        "@types/duo_web_sdk": "^2.7.1",
         "rimraf": "^3.0.2",
         "typescript": "4.1.5"
       }
     },
     "../common": {
+      "name": "@bitwarden/jslib-common",
       "version": "0.0.0",
       "license": "GPL-3.0",
       "dependencies": {
@@ -40,6 +43,7 @@
         "lunr": "^2.3.9",
         "node-forge": "^0.10.0",
         "papaparse": "^5.3.0",
+        "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zxcvbn": "^4.4.2"
       },
@@ -182,6 +186,12 @@
       "integrity": "sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg==",
       "hasInstallScript": true
     },
+    "node_modules/@types/duo_web_sdk": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.1.tgz",
+      "integrity": "sha512-DePanZjFww36yGSxXwC8B3AsjrrDuPxEcufeh4gTqVsUMpCYByxjX4PERiYZdW0typzKSt9E4I14PPp+PrSIQA==",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -203,6 +213,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/duo_web_sdk": {
+      "version": "2.7.0",
+      "resolved": "git+ssh://git@github.com/duosecurity/duo_web_sdk.git#378e855ce4a1de1d1b2f7fd60465e564b3e9fbda",
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -472,6 +487,7 @@
         "node-forge": "^0.10.0",
         "papaparse": "^5.3.0",
         "rimraf": "^3.0.2",
+        "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "typescript": "4.1.5",
         "zxcvbn": "^4.4.2"
@@ -481,6 +497,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.1.0.tgz",
       "integrity": "sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg=="
+    },
+    "@types/duo_web_sdk": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.1.tgz",
+      "integrity": "sha512-DePanZjFww36yGSxXwC8B3AsjrrDuPxEcufeh4gTqVsUMpCYByxjX4PERiYZdW0typzKSt9E4I14PPp+PrSIQA==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -503,6 +525,10 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "duo_web_sdk": {
+      "version": "git+ssh://git@github.com/duosecurity/duo_web_sdk.git#378e855ce4a1de1d1b2f7fd60465e564b3e9fbda",
+      "from": "duo_web_sdk@git+https://github.com/duosecurity/duo_web_sdk.git"
     },
     "fs.realpath": {
       "version": "1.0.0",


### PR DESCRIPTION
Hi Bitwarden team!

I think recently @djsmith85 updated the `package.json` for jslib angular package (for #440), however it seems like `package-lock.json` wasn't updated.

I think it's best to save the integrity checks in the package-lock for such a crucial dependency. Please see diff.
(I double checked the checksum with `sha512sum duo_web_sdk-2.7.1.tgz | cut -f1 -d' ' | xxd -r -p | base64`)