### PR TITLE
Add support for setting tray icon in Linux.

### DIFF
--- a/electron/src/electronConstants.ts
+++ b/electron/src/electronConstants.ts
@@ -3,6 +3,7 @@ export class ElectronConstants {
     static readonly enableCloseToTrayKey: string = 'enableCloseToTray';
     static readonly enableTrayKey: string = 'enableTray';
     static readonly enableStartToTrayKey: string = 'enableStartToTrayKey';
+    static readonly trayIconKey: string = 'trayIconKey';
     static readonly enableAlwaysOnTopKey: string = 'enableAlwaysOnTopKey';
     static readonly minimizeOnCopyToClipboardKey: string = 'minimizeOnCopyToClipboardKey';
     static readonly enableBiometric: string = 'enabledBiometric';


### PR DESCRIPTION
The icon used for the tray is the same as the application icon which has a blue background, this does not match other tray icons on most Linux desktop themes which are monochromatic.

Electron does not provide an easy way to set an icon that can be adapted to the current theme in Linux so this allows the user to pick an icon that matches the theme.

This change also fixes an issue with showing/hiding the main window when clicking on the tray icon.

Electron on Linux does not support the 'right-click' event on the tray icon, setting that event overwrites the 'click' event.

Setting a context menu on the tray automatically registers a 'right-click' event handler that shows the context menu.

Community discussion link: https://community.bitwarden.com/t/add-support-for-changing-the-tray-icon/32207