### PR TITLE
Fix cipher loading (missing await)

### DIFF
--- a/angular/src/components/ciphers.component.ts
+++ b/angular/src/components/ciphers.component.ts
@@ -53,12 +53,12 @@ export class CiphersComponent {
             clearTimeout(this.searchTimeout);
         }
         if (timeout == null) {
-            this.doSearch(indexedCiphers);
+            await this.doSearch(indexedCiphers);
             return;
         }
         this.searchPending = true;
         this.searchTimeout = setTimeout(async () => {
-            this.doSearch(indexedCiphers);
+            await this.doSearch(indexedCiphers);
             this.searchPending = false;
         }, timeout);
     }


### PR DESCRIPTION
## Objective

Bugfix from this refactor: https://github.com/bitwarden/jslib/pull/436

I had moved some existing code to a new method, `doSearch`. The original code was awaited, but I didn't await the calls to the new method. This means that `this.loaded` is set to `true` before loading is actually finished, and the user gets a "vault empty" sad face for a few seconds, even when they have items.