### PR TITLE
Use UrlB64 encoding for auth-email header

### DIFF
--- a/common/src/misc/utils.ts
+++ b/common/src/misc/utils.ts
@@ -159,6 +159,10 @@ export class Utils {
         }
     }
 
+    static fromUtf8ToUrlB64(utfStr: string): string {
+        return Utils.fromBufferToUrlB64(Utils.fromUtf8ToArray(utfStr));
+    }
+
     static fromB64ToUtf8(b64Str: string): string {
         if (Utils.isNode || Utils.isNativeScript) {
             return Buffer.from(b64Str, 'base64').toString('utf8');

--- a/common/src/models/request/tokenRequest.ts
+++ b/common/src/models/request/tokenRequest.ts
@@ -3,6 +3,8 @@ import { TwoFactorProviderType } from '../../enums/twoFactorProviderType';
 import { CaptchaProtectedRequest } from './captchaProtectedRequest';
 import { DeviceRequest } from './deviceRequest';
 
+import { Utils } from '../../misc/utils';
+
 export class TokenRequest implements CaptchaProtectedRequest {
     email: string;
     masterPasswordHash: string;
@@ -76,7 +78,7 @@ export class TokenRequest implements CaptchaProtectedRequest {
 
     alterIdentityTokenHeaders(headers: Headers) {
         if (this.clientSecret == null && this.masterPasswordHash != null && this.email != null) {
-            headers.set('Auth-Email', this.email);
+            headers.set('Auth-Email', Utils.fromUtf8ToUrlB64(this.email));
         }
     }
 }


### PR DESCRIPTION
## Objective

Client implementation of https://github.com/bitwarden/server/pull/1503.

All Angular clients will need `jslib` bumped after merging.