### PR TITLE
Fix missing refresh method in ciphers.component

### DIFF
--- a/angular/src/components/ciphers.component.ts
+++ b/angular/src/components/ciphers.component.ts
@@ -42,6 +42,10 @@ export class CiphersComponent {
         await this.load(filter, deleted);
     }
 
+    async refresh() {
+        await this.reload(this.filter, this.deleted);
+    }
+
     async applyFilter(filter: (cipher: CipherView) => boolean = null) {
         this.filter = filter;
         await this.search(null);


### PR DESCRIPTION
## Objective

I refactored the base `ciphers.component.ts` in #436, but was too aggressive in taking stuff out.

The `refresh` method is used by all clients, so I've added it back into `jslib`.