### PR TITLE
Use apikey client secret as captcha validation

### DIFF
--- a/common/src/abstractions/auth.service.ts
+++ b/common/src/abstractions/auth.service.ts
@@ -20,7 +20,7 @@ export abstract class AuthService {
     logInTwoFactor: (twoFactorProvider: TwoFactorProviderType, twoFactorToken: string,
         remember?: boolean) => Promise<AuthResult>;
     logInComplete: (email: string, masterPassword: string, twoFactorProvider: TwoFactorProviderType,
-        twoFactorToken: string, remember?: boolean) => Promise<AuthResult>;
+        twoFactorToken: string, remember?: boolean, captchaToken?: string) => Promise<AuthResult>;
     logInSsoComplete: (code: string, codeVerifier: string, redirectUrl: string,
         twoFactorProvider: TwoFactorProviderType, twoFactorToken: string, remember?: boolean) => Promise<AuthResult>;
     logInApiKeyComplete: (clientId: string, clientSecret: string, twoFactorProvider: TwoFactorProviderType,

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -151,14 +151,14 @@ export class AuthService implements AuthServiceAbstraction {
     }
 
     async logInComplete(email: string, masterPassword: string, twoFactorProvider: TwoFactorProviderType,
-        twoFactorToken: string, remember?: boolean): Promise<AuthResult> {
+        twoFactorToken: string, remember?: boolean, captchaToken?: string): Promise<AuthResult> {
         this.selectedTwoFactorProviderType = null;
         const key = await this.makePreloginKey(masterPassword, email);
         const hashedPassword = await this.cryptoService.hashPassword(masterPassword, key);
         const localHashedPassword = await this.cryptoService.hashPassword(masterPassword, key,
             HashPurpose.LocalAuthorization);
         return await this.logInHelper(email, hashedPassword, localHashedPassword, null, null, null, null, null, key,
-            twoFactorProvider, twoFactorToken, remember);
+            twoFactorProvider, twoFactorToken, remember, captchaToken);
     }
 
     async logInSsoComplete(code: string, codeVerifier: string, redirectUrl: string,

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -21,6 +21,7 @@ import { MessageResponse } from '../models/response/messageResponse';
 
 import { NodeUtils } from 'jslib-common/misc/nodeUtils';
 import { Utils } from 'jslib-common/misc/utils';
+import { ErrorResponse } from 'jslib-common/models/response/errorResponse';
 
 // tslint:disable-next-line
 const open = require('open');
@@ -30,6 +31,7 @@ export class LoginCommand {
     protected success: () => Promise<MessageResponse>;
     protected canInteract: boolean;
     protected clientId: string;
+    protected clientSecret: string;
 
     private ssoRedirectUri: string = null;
 
@@ -51,32 +53,9 @@ export class LoginCommand {
         let clientSecret: string = null;
 
         if (options.apikey != null) {
-            const storedClientId: string = process.env.BW_CLIENTID;
-            const storedClientSecret: string = process.env.BW_CLIENTSECRET;
-            if (storedClientId == null) {
-                if (this.canInteract) {
-                    const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
-                        type: 'input',
-                        name: 'clientId',
-                        message: 'client_id:',
-                    });
-                    clientId = answer.clientId;
-                } else {
-                    clientId = null;
-                }
-            } else {
-                clientId = storedClientId;
-            }
-            if (this.canInteract && storedClientSecret == null) {
-                const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
-                    type: 'input',
-                    name: 'clientSecret',
-                    message: 'client_secret:',
-                });
-                clientSecret = answer.clientSecret;
-            } else {
-                clientSecret = storedClientSecret;
-            }
+            const apiIdentifiers = await this.apiIdentifiers();
+            clientId = apiIdentifiers.clientId;
+            clientSecret = apiIdentifiers.clientSecret;
         } else if (options.sso != null && this.canInteract) {
             const passwordOptions: any = {
                 type: 'password',
@@ -156,7 +135,7 @@ export class LoginCommand {
                         twoFactorMethod, twoFactorToken, false);
                 } else {
                     response = await this.authService.logInComplete(email, password, twoFactorMethod,
-                        twoFactorToken, false);
+                        twoFactorToken, false, this.clientSecret);
                 }
             } else {
                 if (clientId != null && clientSecret != null) {
@@ -167,8 +146,27 @@ export class LoginCommand {
                     response = await this.authService.logIn(email, password);
                 }
                 if (response.captchaSiteKey) {
-                    return Response.badRequest('Your authentication request appears to be coming from a bot\n' +
-                        'Please log in using your API key (https://bitwarden.com/help/article/cli/#using-an-api-key)');
+                    const badCaptcha = Response.badRequest('Your authentication request appears to be coming from a bot\n' +
+                        'Please use your API key to validate this request and ensure BW_CLIENTSECRET is correct, if set\n' +
+                        '(https://bitwarden.com/help/article/cli/#using-an-api-key)');
+
+                    try {
+                        const clientSecret = await this.apiClientSecret(true);
+                        if (Utils.isNullOrWhitespace(clientSecret)) {
+                            return badCaptcha;
+                        }
+
+                        const secondResponse = await this.authService.logInComplete(email, password, twoFactorMethod,
+                            twoFactorToken, false, clientSecret);
+                        response = secondResponse;
+                    } catch (e) {
+                        if ((e instanceof ErrorResponse || e.constructor.name === 'ErrorResponse') &&
+                            (e as ErrorResponse).message.includes("Captcha is invalid")) {
+                            return badCaptcha;
+                        } else {
+                            throw e;
+                        }
+                    }
                 }
                 if (response.twoFactor) {
                     let selectedProvider: any = null;
@@ -256,6 +254,55 @@ export class LoginCommand {
         } catch (e) {
             return Response.error(e);
         }
+    }
+
+    private async apiClientId(): Promise<string> {
+        let clientId: string = null;
+
+        const storedClientId: string = process.env.BW_CLIENTID;
+        if (storedClientId == null) {
+            if (this.canInteract) {
+                const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
+                    type: 'input',
+                    name: 'clientId',
+                    message: 'client_id:',
+                });
+                clientId = answer.clientId;
+            } else {
+                clientId = null;
+            }
+        } else {
+            clientId = storedClientId;
+        }
+
+        return clientId;
+    }
+
+    private async apiClientSecret(isAdditionalAuthentication: boolean = false): Promise<string> {
+        const additionalAuthenticationMessage = 'Additional authentication required.\nAPI key ';
+        let clientSecret: string = null;
+
+        const storedClientSecret: string = this.clientSecret || process.env.BW_CLIENTSECRET;
+        if (this.canInteract && storedClientSecret == null) {
+            const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
+                type: 'input',
+                name: 'clientSecret',
+                message: (isAdditionalAuthentication ? additionalAuthenticationMessage : '') + 'client_secret:',
+
+            });
+            clientSecret = answer.clientSecret;
+        } else {
+            clientSecret = storedClientSecret;
+        }
+
+        return clientSecret;
+    }
+
+    private async apiIdentifiers(): Promise<{ clientId: string, clientSecret: string; }> {
+        return {
+            clientId: await this.apiClientId(),
+            clientSecret: await this.apiClientSecret(),
+        };
     }
 
     private async getSsoCode(codeChallenge: string, state: string): Promise<string> {


### PR DESCRIPTION
# Overview

Requires https://github.com/bitwarden/server/pull/1509

Handles captcha in login command as requiring a correct apikey client secret. This can be from environment variables in order to allow automated, un-monitored scripts a chance to still word despite captcha challenges.

# Files Changed
* **auth.service**: Add captcha token to `logInComplete` helper. This helper is used in CLI to allow pre-empting a 2fa.
* **login.command**: 
  * break out api client secret and client id 
  * if captcha is requires, request clientSecret
  * if another auth request fails, throw some instructions (**Note:** I've requested a help page for CLI captcha, the url will need updating)