### PR TITLE
Provide information to set webauthn allow in html template

### DIFF
--- a/angular/src/components/two-factor.component.ts
+++ b/angular/src/components/two-factor.component.ts
@@ -44,6 +44,10 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
     onSuccessfulLogin: () => Promise<any>;
     onSuccessfulLoginNavigate: () => Promise<any>;
 
+    get webAuthnAllow(): string {
+        return `publickey-credentials-get ${this.environmentService.getWebVaultUrl()}`;
+    }
+
     protected loginRoute = 'login';
     protected successRoute = 'vault';
 

--- a/common/src/misc/webauthn_iframe.ts
+++ b/common/src/misc/webauthn_iframe.ts
@@ -1,6 +1,8 @@
 import { I18nService } from '../abstractions/i18n.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
+
 import { IFrameComponent } from './iframe_component';
+import { Utils } from './utils';
 
 export class WebAuthnIFrame extends IFrameComponent {
     constructor(win: Window, webVaultUrl: string, private webAuthnNewTab: boolean,
@@ -20,7 +22,9 @@ export class WebAuthnIFrame extends IFrameComponent {
             this.platformUtilsService.launchUri(`${this.webVaultUrl}/webauthn-fallback-connector.html?${params}`);
         } else {
             super.initComponent(params);
-            this.iframe.allow = 'publickey-credentials-get ' + new URL(this.webVaultUrl).origin;
+            if (Utils.isNullOrWhitespace(this.iframe.allow)) {
+                this.iframe.allow = 'publickey-credentials-get ' + new URL(this.webVaultUrl).origin;
+            }
         }
     }
 }


### PR DESCRIPTION
# Overview

Fixes: https://app.asana.com/0/0/1200719554428331/f

Chrome has begun refusing to load our webauthn iframe in browser. This appears to be due to either a race condition or an intentional block to adding an `allow` attribute to the iframe in javascript.

This PR provides a getter to provide the necessary allow directive to the `html` template.

# Files Changed
* **two-factor.ts**: Provide the necessary allow statement for webauthn
* **webauthn_iframe.ts**: only set allow if it's not already present.

# Upgrade path

I believe this requires no upgrade considerations. The `webauthn_iframe` component should be run on the client making the iframe and appending the `allow` attribute. This flow is complicated, though, so a second brain to validate, would be good.