### PR TITLE
Generalize token refreshing to include reauth by api key

### DIFF
--- a/common/src/abstractions/token.service.ts
+++ b/common/src/abstractions/token.service.ts
@@ -2,11 +2,15 @@ export abstract class TokenService {
     token: string;
     decodedToken: any;
     refreshToken: string;
-    setTokens: (accessToken: string, refreshToken: string) => Promise<any>;
+    setTokens: (accessToken: string, refreshToken: string, clientIdClientSecret: [string, string]) => Promise<any>;
     setToken: (token: string) => Promise<any>;
     getToken: () => Promise<string>;
     setRefreshToken: (refreshToken: string) => Promise<any>;
     getRefreshToken: () => Promise<string>;
+    setClientId: (clientId: string) => Promise<any>;
+    getClientId: () => Promise<string>;
+    setClientSecret: (clientSecret: string) => Promise<any>;
+    getClientSecret: () => Promise<string>;
     toggleTokens: () => Promise<any>;
     setTwoFactorToken: (token: string, email: string) => Promise<any>;
     getTwoFactorToken: (email: string) => Promise<string>;

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -280,7 +280,7 @@ export class AuthService implements AuthServiceAbstraction {
 
         let emailPassword: string[] = [];
         let codeCodeVerifier: string[] = [];
-        let clientIdClientSecret: string[] = [];
+        let clientIdClientSecret: [string, string] = [null, null];
 
         if (email != null && hashedPassword != null) {
             emailPassword = [email, hashedPassword];
@@ -344,7 +344,7 @@ export class AuthService implements AuthServiceAbstraction {
             await this.tokenService.setTwoFactorToken(tokenResponse.twoFactorToken, email);
         }
 
-        await this.tokenService.setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
+        await this.tokenService.setTokens(tokenResponse.accessToken, tokenResponse.refreshToken, clientIdClientSecret);
         await this.userService.setInformation(this.tokenService.getUserId(), this.tokenService.getEmail(),
             tokenResponse.kdf, tokenResponse.kdfIterations);
         if (this.setCryptoKeys) {

--- a/node/src/services/nodeApi.service.ts
+++ b/node/src/services/nodeApi.service.ts
@@ -17,8 +17,9 @@ import { TokenService } from 'jslib-common/abstractions/token.service';
 export class NodeApiService extends ApiService {
     constructor(tokenService: TokenService, platformUtilsService: PlatformUtilsService,
         environmentService: EnvironmentService, logoutCallback: (expired: boolean) => Promise<void>,
-        customUserAgent: string = null) {
+        customUserAgent: string = null, apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>) {
         super(tokenService, platformUtilsService, environmentService, logoutCallback, customUserAgent);
+        this.apiKeyRefresh = apiKeyRefresh;
     }
 
     nativeFetch(request: Request): Promise<Response> {


### PR DESCRIPTION
# Overview

API Key-based authentication does not return a refresh token. Because of this, even after unlocking, it is not possible to work with your vault as syncing requires a refresh. Even if it didn't, auth tokens have a limited lifetime and should be valid until `bw logout` is called.

The fix is to generalize refresh to mean either refreshing via refresh token (the current method) OR refreshing via stored api key credentials (this PR).

# Files Changed
* **TokenService**: Add `clientId` and `clientSecret` to tokens being handled by the service. Treat them in the same way as `accessToken` and `refreshToken`.
* **api.service**: update referesh endpoint to `doAuthRefresh`, which determines the refresh method based on tokens stored in `tokenService`. Prefers refresh flow, but falls back to api-key based authentication to renew our access token. This is done through a callback provided  by the `NodeApiService`. If no callback is provided, error.
* **auth.service**: give clientIdClientSecret to token service for storage. These are only populated if api login is done.
* **nodeApi.service**: Set the api refresh callback. Only CLI is using api keys so this should be a good place to set to minimize changes in other repos.

# Testing

We'll need to validate login/sync/list/edit/lock/logout for both login methods (user+pass, api key)
* please verify that the keys `apikey_clientId` and `apikey_clientSecret` only appear in `data.json` if api key is used to log in.
* Please verify that the above keys are removed upon logout but **not** lock
  *  you will find `cat ~/Library/Application\ Support/Bitwarden\ CLI/data.json | grep client` helpful in the above tasks