### PR TITLE
Update help url

### DIFF
--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -147,8 +147,8 @@ export class LoginCommand {
                 }
                 if (response.captchaSiteKey) {
                     const badCaptcha = Response.badRequest('Your authentication request appears to be coming from a bot\n' +
-                        'Please use your API key to validate this request and ensure BW_CLIENTSECRET is correct, if set\n' +
-                        '(https://bitwarden.com/help/article/cli/#using-an-api-key)');
+                        'Please use your API key to validate this request and ensure BW_CLIENTSECRET is correct, if set.\n' +
+                        '(https://bitwarden.com/help/article/cli-auth-challenges)');
 
                     try {
                         const captchaClientSecret = await this.apiClientSecret(true);


### PR DESCRIPTION
# Overview

@fschillingeriv has put together a help article specifically for CLI logins that require extra authentication due to captcha (bitwarden/help#706). Update the error returned on failed captcha challenge to direct users to that site.

> Note: I'd like to cherry pick this into `rc` for the upcoming release. I believe the impact to be quite small. It would require a push to CLI `rc` as well to incorporate the changes.