### PR TITLE
Add missing locale entry for AZ language

### DIFF
--- a/common/src/services/i18n.service.ts
+++ b/common/src/services/i18n.service.ts
@@ -8,6 +8,7 @@ export class I18nService implements I18nServiceAbstraction {
     collator: Intl.Collator;
     localeNames = new Map<string, string>([
         ['af', 'Afrikaans'],
+        ['az', 'Azərbaycanca'],
         ['be', 'Беларуская'],
         ['bg', 'български'],
         ['ca', 'català'],


### PR DESCRIPTION
For the AZ language that was added I while back by Trey, we where missing a translation for the language selection dropdown in the web client.

So I added it.

![image](https://user-images.githubusercontent.com/2670567/130134328-47b64497-0472-4ef4-9dc8-4e2b463972eb.png)
