### PR TITLE
Add null check to electronStorageService.Save

### DIFF
--- a/common/src/models/response/profileResponse.ts
+++ b/common/src/models/response/profileResponse.ts
@@ -33,7 +33,7 @@ export class ProfileResponse extends BaseResponse {
         this.key = this.getResponseProperty('Key');
         this.privateKey = this.getResponseProperty('PrivateKey');
         this.securityStamp = this.getResponseProperty('SecurityStamp');
-        this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset');
+        this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset') ?? false;
 
         const organizations = this.getResponseProperty('Organizations');
         if (organizations != null) {

--- a/common/src/models/response/profileResponse.ts
+++ b/common/src/models/response/profileResponse.ts
@@ -33,7 +33,7 @@ export class ProfileResponse extends BaseResponse {
         this.key = this.getResponseProperty('Key');
         this.privateKey = this.getResponseProperty('PrivateKey');
         this.securityStamp = this.getResponseProperty('SecurityStamp');
-        this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset') ?? false;
+        this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset');
 
         const organizations = this.getResponseProperty('Organizations');
         if (organizations != null) {

--- a/electron/src/services/electronStorage.service.ts
+++ b/electron/src/services/electronStorage.service.ts
@@ -50,10 +50,9 @@ export class ElectronStorageService implements StorageService {
             return Promise.resolve();
         }
         if (obj instanceof Set) {
-        	obj = Array.from(obj);
+            obj = Array.from(obj);
         }
         this.store.set(key, obj);
-        }
         return Promise.resolve();
     }
 

--- a/electron/src/services/electronStorage.service.ts
+++ b/electron/src/services/electronStorage.service.ts
@@ -46,10 +46,12 @@ export class ElectronStorageService implements StorageService {
     }
 
     save(key: string, obj: any): Promise<any> {
-        if (obj instanceof Set) {
-            obj = Array.from(obj);
+        if (obj != null) {
+            if (obj instanceof Set) {
+                obj = Array.from(obj);
+            }
+            this.store.set(key, obj);
         }
-        this.store.set(key, obj);
         return Promise.resolve();
     }
 

--- a/electron/src/services/electronStorage.service.ts
+++ b/electron/src/services/electronStorage.service.ts
@@ -46,11 +46,13 @@ export class ElectronStorageService implements StorageService {
     }
 
     save(key: string, obj: any): Promise<any> {
-        if (obj != null) {
-            if (obj instanceof Set) {
-                obj = Array.from(obj);
-            }
-            this.store.set(key, obj);
+        if (obj == null) {
+            return Promise.resolve();
+        }
+        if (obj instanceof Set) {
+        	obj = Array.from(obj);
+        }
+        this.store.set(key, obj);
         }
         return Promise.resolve();
     }


### PR DESCRIPTION
## Objective

Fix https://github.com/bitwarden/desktop/issues/1033. The latest desktop release cannot sync with older self-hosted servers. 

This is because the client is expecting a `ForcePasswordReset` property on the http sync response. Because that property doesn't exist and no other default value is provided, the client passes an `undefined` value to `electronStorageService`, which then throws an error when it tries to save.

## Code changes

In my brief testing, other Angular clients do not appear to be affected by this bug, so I assume they tolerate saving `null` or `undefined` values. Therefore, I've added a null check to `electronStorageService` to bring it into line with other storage services.

I've also added a default value, because we really should be doing that either way.

**Note:** this will need to be cherry-picked to `rc` and `desktop/rc` will need to be updated.