### PR TITLE
Ensure icon component state is reset

### DIFF
--- a/angular/src/components/icon.component.ts
+++ b/angular/src/components/icon.component.ts
@@ -42,6 +42,10 @@ export class IconComponent implements OnChanges {
     }
 
     async ngOnChanges() {
+        // Components may be re-used when using cdk-virtual-scroll. Which puts the component in a weird state,
+        // to avoid this we reset all state variables.
+        this.image = null;
+        this.fallbackImage = null;
         this.imageEnabled = !(await this.stateService.get<boolean>(ConstantsService.disableFaviconKey));
         this.load();
     }


### PR DESCRIPTION
## Objective
Virtual-scroll reuses components, which causes the icon component to have a weird state, where `image` is set for non login items. To avoid this, I reset the state variables on change detection.

Note: This will be cherry picked to `rc` and into `desktop`.