### PR TITLE
Remove null check in ElectronStorageService.Save

### DIFF
--- a/electron/src/services/electronStorage.service.ts
+++ b/electron/src/services/electronStorage.service.ts
@@ -46,9 +46,6 @@ export class ElectronStorageService implements StorageService {
     }
 
     save(key: string, obj: any): Promise<any> {
-        if (obj == null) {
-            return Promise.resolve();
-        }
         if (obj instanceof Set) {
             obj = Array.from(obj);
         }


### PR DESCRIPTION
## Objective

In the latest hotfix version (1.28.1), users are unable to set the vault timeout to "Never". It always reverts to the last saved option.

## Cause

#461 solved a syncing error by:
1. providing a default value for a potentially `undefined` property
2. adding a `null` check so that we don't try to save `undefined` values in the future.

However, there are cases where we do want to save `null` to storage - in particular, the "Never" vault timeout option has a value of `null`. The original syncing error was actually thrown by saving an `undefined` value, not `null`, so the check should've been `obj === undefined`.

However, with the benefit of hindsight, I think:
* in hotfixes, we should only make the minimum changes required to solve the issue. The syncing error was solved by change 1. Change 2 was aimed at avoiding similar issues in the future and should've been left on `master` (not cherry-picked to `rc`), so it could have the benefit of full regression testing.
* if we're trying to save an `undefined` value then this may point to a larger problem in the code, and I no longer think that we should try to handle it gracefully in the storage service.

# Code changes

Remove the `null` check.

**Note: this will need to be cherry-picked to `rc` and `desktop` will need to be updated.**