### PR TITLE
Move policy checks within policyService

### DIFF
--- a/angular/src/components/send/add-edit.component.ts
+++ b/angular/src/components/send/add-edit.component.ts
@@ -103,7 +103,7 @@ export class AddEditComponent implements OnInit {
 
     async load() {
         this.disableSend = await this.policyService.policyAppliesToUser(PolicyType.DisableSend);
-        this.disableHideEmail = await this.policyService.policyAppliesToUser(PolicyType.SendOptions, null,
+        this.disableHideEmail = await this.policyService.policyAppliesToUser(PolicyType.SendOptions,
             p => p.data.disableHideEmail);
 
         this.canAccessPremium = await this.userService.canAccessPremium();

--- a/angular/src/components/send/add-edit.component.ts
+++ b/angular/src/components/send/add-edit.component.ts
@@ -7,7 +7,6 @@ import {
     Output
 } from '@angular/core';
 
-import { OrganizationUserStatusType } from 'jslib-common/enums/organizationUserStatusType';
 import { PolicyType } from 'jslib-common/enums/policyType';
 import { SendType } from 'jslib-common/enums/sendType';
 
@@ -103,24 +102,9 @@ export class AddEditComponent implements OnInit {
     }
 
     async load() {
-        const disableSendPolicies = await this.policyService.getAll(PolicyType.DisableSend);
-        const organizations = await this.userService.getAllOrganizations();
-        this.disableSend = organizations.some(o => {
-            return o.enabled &&
-                o.status === OrganizationUserStatusType.Confirmed &&
-                o.usePolicies &&
-                !o.canManagePolicies &&
-                disableSendPolicies.some(p => p.organizationId === o.id && p.enabled);
-        });
-
-        const sendOptionsPolicies = await this.policyService.getAll(PolicyType.SendOptions);
-        this.disableHideEmail = await organizations.some(o => {
-            return o.enabled &&
-                o.status === OrganizationUserStatusType.Confirmed &&
-                o.usePolicies &&
-                !o.canManagePolicies &&
-                sendOptionsPolicies.some(p => p.organizationId === o.id && p.enabled && p.data.disableHideEmail);
-        });
+        this.disableSend = await this.policyService.policyAppliesToUser(PolicyType.DisableSend);
+        this.disableHideEmail = await this.policyService.policyAppliesToUser(PolicyType.SendOptions, null,
+            p => p.data.disableHideEmail);
 
         this.canAccessPremium = await this.userService.canAccessPremium();
         this.emailVerified = await this.userService.getEmailVerified();

--- a/angular/src/components/send/send.component.ts
+++ b/angular/src/components/send/send.component.ts
@@ -51,15 +51,7 @@ export class SendComponent implements OnInit {
         protected policyService: PolicyService, protected userService: UserService) { }
 
     async ngOnInit() {
-        const policies = await this.policyService.getAll(PolicyType.DisableSend);
-        const organizations = await this.userService.getAllOrganizations();
-        this.disableSend = organizations.some(o => {
-            return o.enabled &&
-                o.status === OrganizationUserStatusType.Confirmed &&
-                o.usePolicies &&
-                !o.canManagePolicies &&
-                policies.some(p => p.organizationId === o.id && p.enabled);
-        });
+        this.disableSend = await this.policyService.policyAppliesToUser(PolicyType.DisableSend);
     }
 
     async load(filter: (send: SendView) => boolean = null) {

--- a/common/src/abstractions/policy.service.ts
+++ b/common/src/abstractions/policy.service.ts
@@ -22,6 +22,5 @@ export abstract class PolicyService {
         enforcedPolicyOptions?: MasterPasswordPolicyOptions) => boolean;
     getResetPasswordPolicyOptions: (policies: Policy[], orgId: string) => [ResetPasswordPolicyOptions, boolean];
     mapPoliciesFromToken: (policiesResponse: ListResponse<PolicyResponse>) => Policy[];
-    policyAppliesToUser: (policyType: PolicyType, organizationId?: string,
-        policyFilter?: (policy: Policy) => boolean) => Promise<boolean>;
+    policyAppliesToUser: (policyType: PolicyType, policyFilter?: (policy: Policy) => boolean) => Promise<boolean>;
 }

--- a/common/src/abstractions/policy.service.ts
+++ b/common/src/abstractions/policy.service.ts
@@ -1,7 +1,6 @@
 import { PolicyData } from '../models/data/policyData';
 
 import { MasterPasswordPolicyOptions } from '../models/domain/masterPasswordPolicyOptions';
-import { Organization } from '../models/domain/organization';
 import { Policy } from '../models/domain/policy';
 import { ResetPasswordPolicyOptions } from '../models/domain/resetPasswordPolicyOptions';
 

--- a/common/src/abstractions/policy.service.ts
+++ b/common/src/abstractions/policy.service.ts
@@ -1,19 +1,21 @@
 import { PolicyData } from '../models/data/policyData';
 
 import { MasterPasswordPolicyOptions } from '../models/domain/masterPasswordPolicyOptions';
+import { Organization } from '../models/domain/organization';
 import { Policy } from '../models/domain/policy';
 import { ResetPasswordPolicyOptions } from '../models/domain/resetPasswordPolicyOptions';
 
-import { PolicyType } from '../enums/policyType';
-
 import { ListResponse } from '../models/response/listResponse';
 import { PolicyResponse } from '../models/response/policyResponse';
+
+import { PolicyType } from '../enums/policyType';
 
 export abstract class PolicyService {
     policyCache: Policy[];
 
     clearCache: () => void;
     getAll: (type?: PolicyType) => Promise<Policy[]>;
+    getPolicyForOrganization: (policyType: PolicyType, organizationId: string) => Promise<Policy>;
     replace: (policies: { [id: string]: PolicyData; }) => Promise<any>;
     clear: (userId: string) => Promise<any>;
     getMasterPasswordPolicyOptions: (policies?: Policy[]) => Promise<MasterPasswordPolicyOptions>;
@@ -21,4 +23,6 @@ export abstract class PolicyService {
         enforcedPolicyOptions?: MasterPasswordPolicyOptions) => boolean;
     getResetPasswordPolicyOptions: (policies: Policy[], orgId: string) => [ResetPasswordPolicyOptions, boolean];
     mapPoliciesFromToken: (policiesResponse: ListResponse<PolicyResponse>) => Policy[];
+    policyAppliesToUser: (policyType: PolicyType, organizationId?: string,
+        policyFilter?: (policy: Policy) => boolean) => Promise<boolean>;
 }

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -137,6 +137,6 @@ export class Organization {
     }
 
     get isExemptFromPolicies() {
-        return this.isAdmin;
+        return this.canManagePolicies;
     }
 }

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -135,4 +135,8 @@ export class Organization {
     get canManageUsersPassword() {
         return this.isAdmin || this.permissions.manageResetPassword;
     }
+
+    get isExemptFromPolicies() {
+        return this.canManagePolicies;
+    }
 }

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -137,6 +137,6 @@ export class Organization {
     }
 
     get isExemptFromPolicies() {
-        return this.canManagePolicies;
+        return this.isAdmin;
     }
 }

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -190,7 +190,7 @@ export class PolicyService implements PolicyServiceAbstraction {
 
         return organizations.some(o =>
             o.enabled &&
-            o.status === OrganizationUserStatusType.Confirmed &&
+            o.status !== OrganizationUserStatusType.Invited &&
             o.usePolicies &&
             !o.isExemptFromPolicies &&
             policySet.has(o.id));

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -171,37 +171,29 @@ export class PolicyService implements PolicyServiceAbstraction {
         return policiesData.map(p => new Policy(p));
     }
 
-    async policyAppliesToUser(policyType: PolicyType, organizationId?: string,
-        policyFilter?: (policy: Policy) => boolean) {
+    async policyAppliesToUser(policyType: PolicyType, policyFilter?: (policy: Policy) => boolean) {
 
         if (policyFilter == null) {
             policyFilter = (policy: Policy) => true;
         }
 
-        // Check if any organization's policy applies to user
-        if (organizationId == null) {
-            const policies = await this.getAll(policyType);
-            const organizations = await this.userService.getAllOrganizations();
+        const policies = await this.getAll(policyType);
+        const organizations = await this.userService.getAllOrganizations();
 
-            const filteredPolicies = policies
-                .filter(p =>
-                    p.enabled &&
-                    p.type === policyType &&
-                    policyFilter(p))
-                .map(p => p.organizationId);
+        const filteredPolicies = policies
+            .filter(p =>
+                p.enabled &&
+                p.type === policyType &&
+                policyFilter(p))
+            .map(p => p.organizationId);
 
-            const policySet = new Set(filteredPolicies);
+        const policySet = new Set(filteredPolicies);
 
-            return organizations.some(o =>
-                o.enabled &&
-                o.status === OrganizationUserStatusType.Confirmed &&
-                o.usePolicies &&
-                !o.isExemptFromPolicies &&
-                policySet.has(o.id));
-        }
-
-        // Check if a specific organization's policy applies to user
-
-
+        return organizations.some(o =>
+            o.enabled &&
+            o.status === OrganizationUserStatusType.Confirmed &&
+            o.usePolicies &&
+            !o.isExemptFromPolicies &&
+            policySet.has(o.id));
     }
 }

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -172,7 +172,6 @@ export class PolicyService implements PolicyServiceAbstraction {
     }
 
     async policyAppliesToUser(policyType: PolicyType, policyFilter?: (policy: Policy) => boolean) {
-
         if (policyFilter == null) {
             policyFilter = (policy: Policy) => true;
         }

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -190,7 +190,7 @@ export class PolicyService implements PolicyServiceAbstraction {
 
         return organizations.some(o =>
             o.enabled &&
-            o.status !== OrganizationUserStatusType.Invited &&
+            o.status >= OrganizationUserStatusType.Accepted &&
             o.usePolicies &&
             !o.isExemptFromPolicies &&
             policySet.has(o.id));


### PR DESCRIPTION
## Objective

We have lots of duplicate logic when we check whether a policy applies to a user. Here's a typical example:

```typescript
        const disableSendPolicies = await this.policyService.getAll(PolicyType.DisableSend);
        const organizations = await this.userService.getAllOrganizations();
        this.disableSend = organizations.some(o => {
            return o.enabled &&
                o.status === OrganizationUserStatusType.Confirmed &&
                o.usePolicies &&
                !o.canManagePolicies &&
                disableSendPolicies.some(p => p.organizationId === o.id && p.enabled);
        });
```

This is repeated throughout various components. It's a good candidate to standardize and lift up into `policyService`.

## Code changes
* policyService - 
   * add `PolicyAppliesToUser` method. This finds whether a given `policyType` (from any organization) applies to a user.
   * note: `PolicyAppliesToUser` will "apply" a policy from the time the user **accepts** an organization invite. This is a change to some current logic, which applies policies from the time the user is **confirmed**. I've made this change because the server checks for policy compliance at the time the user accepts the invite (e.g. do they have 2FA enabled), so we don't want the user changing their settings in the window between accepting & being confirmed. This concern doesn't necessarily apply to all policies, but I think it should be consistent. The principle could be: when you accept an organization invite, you accept their policies, even if you haven't been confirmed yet.
   * add `getPolicyForOrganization` method. This gets a specific `policyType` for a specific organization, rather than having to call `getAll` and then filtering.
* organization model - add `isExemptFromPolicies` getter. This avoids any confusion about the criteria for exemption, and gives us a single place to change it.
  * note: in clients, we were generally using `canManagePolicies` as the test for whether a user is exempt, but on the server we were using `OrganizationUserType == Admin || OrganizationUserType == Owner` in most (but not all) places. This test should be consistent, and as the server is the stricter test (because it doesn't exempt users with custom permissions to manage policies), I've used that test in the clients as well. That also aligns with [what our documentation says](https://bitwarden.com/help/article/policies/). However, there are arguments for each alternative, so I'm open to discussion here. It's a real mix at the moment. But whatever we choose should be consistent and correctly documented.
* cipher `add-edit.component.ts` - previously, if the Personal Ownership policy was enabled (prohibiting personal ownership), the default owner for new items would be the first organization with the Personal Ownership policy enabled. I can kind of see the logic here, but I don't think it's intuitive or particularly important, and it wasn't compatible with this refactor - so I removed it. Now it'll just default to the first organization in an alphabetical list, which seems more straightforward.
* * all other changes - refactor existing logic to use the new methods. When reviewing, please double check that I haven't actually changed any business logic other than what's mentioned here.

## Related changes
Most policy logic is in jslib, but there are some minor changes in:
* web: https://github.com/bitwarden/web/pull/1149
* browser: https://github.com/bitwarden/browser/pull/2036