### PR TITLE
Fix 'Cannot access variable before initialization' error in Desktop

### DIFF
--- a/angular/src/components/two-factor.component.ts
+++ b/angular/src/components/two-factor.component.ts
@@ -5,6 +5,8 @@ import {
     Router,
 } from '@angular/router';
 
+import { first } from 'rxjs/operators';
+
 import { TwoFactorProviderType } from 'jslib-common/enums/twoFactorProviderType';
 
 import { TwoFactorEmailRequest } from 'jslib-common/models/request/twoFactorEmailRequest';
@@ -65,13 +67,9 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
             return;
         }
 
-        const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
+        this.route.queryParams.pipe(first()).subscribe(qParams => {
             if (qParams.identifier != null) {
                 this.identifier = qParams.identifier;
-            }
-
-            if (queryParamsSub != null) {
-                queryParamsSub.unsubscribe();
             }
         });
 


### PR DESCRIPTION
## Objective

Fix the following error, which occurs whenever you load the 2FA screen on Desktop:

![Screen Shot 2021-08-20 at 4 14 59 pm](https://user-images.githubusercontent.com/31796059/131444326-af72b5f6-ba8c-44ec-bd3e-b155f64ded90.png)

This is because we call `queryParamsSub.unsubscribe()` from within the `subscribe()` callback. I'm not sure why this doesn't work - we use this pattern elsewhere and it works fine, it just throws this error in this specific component. 

## Code changes

* `two-factor.component.ts` - use the rxjs `first` operator to get the first emitted value. This makes unsubscribing unnecessary and (in my opinion) is the better pattern to use here.

The original pattern appears in other components but they're not causing any trouble, so I haven't changed them at this stage.