### PR TITLE
Add support for setting up component factory resolvers in modal service

### DIFF
--- a/angular/src/components/modal/dynamic-modal.component.ts
+++ b/angular/src/components/modal/dynamic-modal.component.ts
@@ -2,7 +2,6 @@ import {
     AfterViewInit,
     ChangeDetectorRef,
     Component,
-    ComponentFactoryResolver,
     ComponentRef,
     ElementRef,
     OnDestroy,
@@ -10,6 +9,8 @@ import {
     ViewChild,
     ViewContainerRef
 } from '@angular/core';
+
+import { ModalService } from '../../services/modal.service';
 
 import { ModalRef } from './modal.ref';
 
@@ -25,7 +26,7 @@ export class DynamicModalComponent implements AfterViewInit, OnDestroy {
     childComponentType: Type<any>;
     setComponentParameters: (component: any) => void;
 
-    constructor(private componentFactoryResolver: ComponentFactoryResolver, private cd: ChangeDetectorRef,
+    constructor(private modalService: ModalService, private cd: ChangeDetectorRef,
         private el: ElementRef<HTMLElement>, public modalRef: ModalRef) {}
 
     ngAfterViewInit() {
@@ -39,7 +40,7 @@ export class DynamicModalComponent implements AfterViewInit, OnDestroy {
     }
 
     loadChildComponent(componentType: Type<any>) {
-        const componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentType);
+        const componentFactory = this.modalService.resolveComponentFactory(componentType);
 
         this.modalContentRef.clear();
         this.componentRef = this.modalContentRef.createComponent(componentFactory);

--- a/angular/src/services/modal.service.ts
+++ b/angular/src/services/modal.service.ts
@@ -1,5 +1,6 @@
 import {
     ApplicationRef,
+    ComponentFactory,
     ComponentFactoryResolver,
     ComponentRef,
     EmbeddedViewRef,
@@ -22,6 +23,10 @@ export class ModalConfig<D = any> {
 @Injectable()
 export class ModalService {
     protected modalCount = 0;
+
+    // Lazy loaded modules are not available in componentFactoryResolver,
+    // therefore modules needs to manually initialize their resolvers.
+    private factoryResolvers: Map<Type<any>, ComponentFactoryResolver> = new Map();
 
     constructor(private componentFactoryResolver: ComponentFactoryResolver, private applicationRef: ApplicationRef,
         private injector: Injector) {}
@@ -49,6 +54,18 @@ export class ModalService {
         const [modalRef, _] = this.openInternal(componentType, config, true);
 
         return modalRef;
+    }
+
+    registerComponentFactoryResolver<T>(componentType: Type<T>, componentFactoryResolver: ComponentFactoryResolver): void {
+        this.factoryResolvers.set(componentType, componentFactoryResolver);
+    }
+
+    resolveComponentFactory<T>(componentType: Type<T>): ComponentFactory<T> {
+        if (this.factoryResolvers.has(componentType)) {
+            return this.factoryResolvers.get(componentType).resolveComponentFactory(componentType);
+        }
+
+        return this.componentFactoryResolver.resolveComponentFactory(componentType);
     }
 
     protected openInternal(componentType: Type<any>, config?: ModalConfig, attachToDom?: boolean):


### PR DESCRIPTION
## Objective
Lazy loaded modules are not available in the `ComponentFactoryResolver` initialized by `DynamicModalComponent`. Therefore we need a way to register component factory resolvers for the `ModalService`.