### PR TITLE
[SSO] Set password auto enroll update

### DIFF
--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -108,8 +108,8 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
                     const publicKey = Utils.fromB64ToArray(response.publicKey);
 
                     // RSA Encrypt user's encKey.key with organization public key
-                    const encKey = await this.cryptoService.getEncKey();
-                    const encryptedKey = await this.cryptoService.rsaEncrypt(encKey.key, publicKey.buffer);
+                    const userEncKey = await this.cryptoService.getEncKey();
+                    const encryptedKey = await this.cryptoService.rsaEncrypt(userEncKey.key, publicKey.buffer);
 
                     // Create request and execute enrollment
                     const resetRequest = new OrganizationUserResetPasswordEnrollmentRequest();

--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -36,7 +36,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
     hint: string = '';
     identifier: string = null;
     orgId: string;
-    resetPassswordAutoEnroll = false;
+    resetPasswordAutoEnroll = false;
 
     onSuccessfulChangePassword: () => Promise<any>;
     successRoute = 'vault';
@@ -68,7 +68,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
         this.orgId = org?.id;
         const policyList = await this.policyService.getAll(PolicyType.ResetPassword);
         const policyResult = this.policyService.getResetPasswordPolicyOptions(policyList, this.orgId);
-        this.resetPassswordAutoEnroll = policyResult[1] && policyResult[0].autoEnrollEnabled;
+        this.resetPasswordAutoEnroll = policyResult[1] && policyResult[0].autoEnrollEnabled;
 
         super.ngOnInit();
     }
@@ -96,7 +96,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
 
         // Make API call(s)
         try {
-            if (this.resetPassswordAutoEnroll) {
+            if (this.resetPasswordAutoEnroll) {
                 this.formPromise = this.apiService.setPassword(request).then(async () => {
                     await this.onSetPasswordSuccess(key, encKey, keys);
                     return this.apiService.getOrganizationKeys(this.orgId);

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -21,6 +21,7 @@ export abstract class UserService {
     isAuthenticated: () => Promise<boolean>;
     canAccessPremium: () => Promise<boolean>;
     getOrganization: (id: string) => Promise<Organization>;
+    getOrganizationByIdentifier: (identifier: string) => Promise<Organization>;
     getAllOrganizations: () => Promise<Organization[]>;
     replaceOrganizations: (organizations: { [id: string]: OrganizationData; }) => Promise<any>;
     clearOrganizations: (userId: string) => Promise<any>;

--- a/common/src/models/request/setPasswordRequest.ts
+++ b/common/src/models/request/setPasswordRequest.ts
@@ -10,4 +10,15 @@ export class SetPasswordRequest {
     kdf: KdfType;
     kdfIterations: number;
     orgIdentifier: string;
+
+    constructor(masterPasswordHash: string, key: string, masterPasswordHint: string, kdf: KdfType,
+        kdfIterations: number, orgIdentifier: string, keys: KeysRequest) {
+        this.masterPasswordHash = masterPasswordHash;
+        this.key = key;
+        this.masterPasswordHint = masterPasswordHint;
+        this.kdf = kdf;
+        this.kdfIterations = kdfIterations;
+        this.orgIdentifier = orgIdentifier;
+        this.keys = keys;
+    }
 }

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -168,7 +168,7 @@ export class UserService implements UserServiceAbstraction {
 
     async getOrganizationByIdentifier(identifier: string): Promise<Organization> {
         const organizations = await this.getAllOrganizations();
-        if (organizations == null || organizations.length == 0) {
+        if (organizations == null || organizations.length === 0) {
             return null;
         }
 

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -166,6 +166,15 @@ export class UserService implements UserServiceAbstraction {
         return new Organization(organizations[id]);
     }
 
+    async getOrganizationByIdentifier(identifier: string): Promise<Organization> {
+        const organizations = await this.getAllOrganizations();
+        if (organizations == null || organizations.length == 0) {
+            return null;
+        }
+
+        return organizations.find(o => o.identifier === identifier);
+    }
+
     async getAllOrganizations(): Promise<Organization[]> {
         const userId = await this.getUserId();
         const organizations = await this.storageService.get<{ [id: string]: OrganizationData; }>(


### PR DESCRIPTION
## Objective
> Fix the following issue: Non-invited users who are created JIT are not being auto-enrolled into the organization's reset password functionality.

## Code Changes
- **set-password.component.ts**: Added new conditional that checks whether or not the user needs to be auto-enrolled in reset password.
- **user.service.ts**: Added new method that will retrieve an organization via `identifier`
