### PR TITLE
Log full error for better debugging support

### DIFF
--- a/angular/src/directives/api-action.directive.ts
+++ b/angular/src/directives/api-action.directive.ts
@@ -35,6 +35,7 @@ export class ApiActionDirective implements OnChanges {
                 this.logService.error('Captcha required error response: ' + e.getSingleMessage());
                 return;
             }
+            this.logService?.error(`Received API exception: ${e}`);
             this.validationService.showError(e);
         });
     }


### PR DESCRIPTION
# Overview

`api-action.directive` is generally used to wrap all of our api calls and handle element loading indicators / errors. Adding logging here will improve debugging efforts by providing a more permanent history of api errors and potentially recording more information than the user-friendly message.