### PR TITLE
Fixes and cleanup for policyAppliesToUser

### DIFF
--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -125,7 +125,7 @@ export class Organization {
     }
 
     get canManagePolicies() {
-        return this.isAdmin || this.permissions.managePolicies;
+        return this.isAdmin || this.permissions.managePolicies || this.isProviderUser;
     }
 
     get canManageUsers() {

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -89,7 +89,7 @@ export class Organization {
     }
 
     get isOwner() {
-        return this.type === OrganizationUserType.Owner;
+        return this.type === OrganizationUserType.Owner || this.isProviderUser;
     }
 
     get canAccessBusinessPortal() {
@@ -125,7 +125,7 @@ export class Organization {
     }
 
     get canManagePolicies() {
-        return this.isAdmin || this.permissions.managePolicies || this.isProviderUser;
+        return this.isAdmin || this.permissions.managePolicies;
     }
 
     get canManageUsers() {

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -183,7 +183,7 @@ export class PolicyService implements PolicyServiceAbstraction {
             filteredPolicies = policies.filter(p => p.enabled);
         }
 
-        var policySet = new Set(filteredPolicies.map(p => p.organizationId));
+        const policySet = new Set(filteredPolicies.map(p => p.organizationId));
 
         return organizations.some(o =>
             o.enabled &&

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -174,7 +174,7 @@ export class PolicyService implements PolicyServiceAbstraction {
     async policyAppliesToUser(policyType: PolicyType, policyFilter?: (policy: Policy) => boolean) {
         const policies = await this.getAll(policyType);
         const organizations = await this.userService.getAllOrganizations();
-        var filteredPolicies;
+        let filteredPolicies;
 
         if (policyFilter != null) {
             filteredPolicies = policies.filter(p => p.enabled && policyFilter(p));

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -172,21 +172,18 @@ export class PolicyService implements PolicyServiceAbstraction {
     }
 
     async policyAppliesToUser(policyType: PolicyType, policyFilter?: (policy: Policy) => boolean) {
-        if (policyFilter == null) {
-            policyFilter = (policy: Policy) => true;
-        }
-
         const policies = await this.getAll(policyType);
         const organizations = await this.userService.getAllOrganizations();
+        var filteredPolicies;
 
-        const filteredPolicies = policies
-            .filter(p =>
-                p.enabled &&
-                p.type === policyType &&
-                policyFilter(p))
-            .map(p => p.organizationId);
+        if (policyFilter != null) {
+            filteredPolicies = policies.filter(p => p.enabled && policyFilter(p));
+        }
+        else {
+            filteredPolicies = policies.filter(p => p.enabled);
+        }
 
-        const policySet = new Set(filteredPolicies);
+        var policySet = new Set(filteredPolicies.map(p => p.organizationId));
 
         return organizations.some(o =>
             o.enabled &&


### PR DESCRIPTION
## Objective

Tweak some of the changes I made in https://github.com/bitwarden/jslib/pull/466.

## Code changes

This PR has 2 minor follow-up fixes:

1. Include providerUsers as "owners" of an org (this reflects the server-side logic discussed [here](https://github.com/bitwarden/server/pull/1536#issuecomment-910471316))
2. In `policyService.policyAppliesToUser`:
   * Remove the redundant `policyType` filter - this is already done in the call to `this.GetAll`
   * Refactor so that we're not using a passthrough function for `policyFilter` - that would still involve checking that `true == true` for every policy, when we could just skip it altogether.