### PR TITLE
[Reset Password v1] Refactor ForcePasswordReset into AuthResult

### DIFF
--- a/angular/src/components/login.component.ts
+++ b/angular/src/components/login.component.ts
@@ -39,9 +39,11 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     onSuccessfulLogin: () => Promise<any>;
     onSuccessfulLoginNavigate: () => Promise<any>;
     onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
+    onSuccessfulLoginForceResetNavigate: () => Promise<any>;
 
     protected twoFactorRoute = '2fa';
     protected successRoute = 'vault';
+    protected forcePasswordResetRoute = 'update-temp-password';
 
     constructor(protected authService: AuthService, protected router: Router,
         platformUtilsService: PlatformUtilsService, i18nService: I18nService,
@@ -102,6 +104,12 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
                     this.onSuccessfulLoginTwoFactorNavigate();
                 } else {
                     this.router.navigate([this.twoFactorRoute]);
+                }
+            } else if (response.forcePasswordReset) {
+                if (this.onSuccessfulLoginForceResetNavigate != null) {
+                    this.onSuccessfulLoginForceResetNavigate();
+                } else {
+                    this.router.navigate([this.forcePasswordResetRoute]);
                 }
             } else {
                 const disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);

--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -31,10 +31,12 @@ export class SsoComponent {
     onSuccessfulLoginNavigate: () => Promise<any>;
     onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
     onSuccessfulLoginChangePasswordNavigate: () => Promise<any>;
+    onSuccessfulLoginForceResetNavigate: () => Promise<any>;
 
     protected twoFactorRoute = '2fa';
     protected successRoute = 'lock';
     protected changePasswordRoute = 'set-password';
+    protected forcePasswordResetRoute = 'update-temp-password';
     protected clientId: string;
     protected redirectUri: string;
     protected state: string;
@@ -160,6 +162,12 @@ export class SsoComponent {
                             identifier: orgIdFromState,
                         },
                     });
+                }
+            } else if (response.forcePasswordReset) {
+                if (this.onSuccessfulLoginForceResetNavigate != null) {
+                    this.onSuccessfulLoginForceResetNavigate();
+                } else {
+                    this.router.navigate([this.forcePasswordResetRoute]);
                 }
             } else {
                 const disableFavicon = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);

--- a/angular/src/components/two-factor.component.ts
+++ b/angular/src/components/two-factor.component.ts
@@ -185,6 +185,9 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
         if (response.resetMasterPassword) {
             this.successRoute = 'set-password';
         }
+        if (response.forcePasswordReset) {
+            this.successRoute = 'update-temp-password';
+        }
         if (this.onSuccessfulLoginNavigate != null) {
             this.onSuccessfulLoginNavigate();
         } else {

--- a/common/src/models/domain/authResult.ts
+++ b/common/src/models/domain/authResult.ts
@@ -4,5 +4,6 @@ export class AuthResult {
     twoFactor: boolean = false;
     captchaSiteKey: string = '';
     resetMasterPassword: boolean = false;
+    forcePasswordReset: boolean = false;
     twoFactorProviders: Map<TwoFactorProviderType, { [key: string]: string; }> = null;
 }

--- a/common/src/models/response/identityTokenResponse.ts
+++ b/common/src/models/response/identityTokenResponse.ts
@@ -14,6 +14,7 @@ export class IdentityTokenResponse extends BaseResponse {
     twoFactorToken: string;
     kdf: KdfType;
     kdfIterations: number;
+    forcePasswordReset: boolean;
 
     constructor(response: any) {
         super(response);
@@ -28,5 +29,6 @@ export class IdentityTokenResponse extends BaseResponse {
         this.twoFactorToken = this.getResponseProperty('TwoFactorToken');
         this.kdf = this.getResponseProperty('Kdf');
         this.kdfIterations = this.getResponseProperty('KdfIterations');
+        this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset');
     }
 }

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -340,6 +340,7 @@ export class AuthService implements AuthServiceAbstraction {
 
         const tokenResponse = response as IdentityTokenResponse;
         result.resetMasterPassword = tokenResponse.resetMasterPassword;
+        result.forcePasswordReset = tokenResponse.forcePasswordReset;
         if (tokenResponse.twoFactorToken != null) {
             await this.tokenService.setTwoFactorToken(tokenResponse.twoFactorToken, email);
         }


### PR DESCRIPTION
## Objective
> Refactor the Force Password Reset flow to lift dependency on full sync in downstream clients

## Code Changes
- **login.component**: Added conditional/options for navigation when forcing a password reset is necessary
- **sso.component**:  Added conditional/options for navigation when forcing a password reset is necessary
- **two-factor.component**: Added conditional for when forcing a password reset is necessary
- **authResult**: Added `forcePasswordReset` boolean
- **identityTokenResponse**: Added `forcePasswordReset` boolean
- **auth.service**: Added `forcePasswordReset` to the `AuthResult` response object