### PR TITLE
Allow renaming by adding previous names field

### DIFF
--- a/common/src/misc/utils.ts
+++ b/common/src/misc/utils.ts
@@ -292,6 +292,10 @@ export class Utils {
         return str == null || typeof str !== 'string' || str.trim() === '';
     }
 
+    static isNullOrEmpty(str: string): boolean {
+        return str == null || typeof str !== 'string' || str === '';
+    }
+
     static nameOf<T>(name: string & keyof T) {
         return name;
     }

--- a/common/src/services/i18n.service.ts
+++ b/common/src/services/i18n.service.ts
@@ -100,7 +100,7 @@ export class I18nService implements I18nServiceAbstraction {
     }
 
     getMessage(messages: any, id: string): string {
-        var result = '';
+        let result = '';
 
         if (this.localeMessages.hasOwnProperty(id) && this.localeMessages[id]) {
             result = messages[id];


### PR DESCRIPTION
# Overview

Currently, there is a hurdle to jump when renaming messages due to delay in their translation. However, if it's a simple rename, the previous translation should still exist.

This adds optional information to a message enumerating the previous names of a message, most recent first. When translating, if the actual ID isn't found, we'll use these renames to help locate a translated previous version, if it exists.

This field should only be used when changing the name of a message without substantively changing its content.

## Open Questions

I'm not 100% sure if crowdin will remove unused translations when generating new locales for us. It's probably best to keep old message IDs in our `messages.json` until crowdin has a chance to catch up to the rename.