### PR TITLE
[SSO Auto Enroll] Auto Enroll status retrieval

### DIFF
--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -65,11 +65,13 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
 
         // Automatic Enrollment Detection
         if (this.identifier != null) {
-            const org = await this.userService.getOrganizationByIdentifier(this.identifier);
-            this.orgId = org?.id;
-            const policyList = await this.policyService.getAll(PolicyType.ResetPassword);
-            const policyResult = this.policyService.getResetPasswordPolicyOptions(policyList, this.orgId);
-            this.resetPasswordAutoEnroll = policyResult[1] && policyResult[0].autoEnrollEnabled;
+            try {
+                const response = await this.apiService.getOrganizationAutoEnrollStatus(this.identifier);
+                this.orgId = response.id;
+                this.resetPasswordAutoEnroll = response.autoEnrollEnabled;
+            } catch {
+                this.platformUtilsService.showToast('error', null, this.i18nService.t('errorOccurred'));
+            }
         }
 
         super.ngOnInit();

--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -68,7 +68,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
             try {
                 const response = await this.apiService.getOrganizationAutoEnrollStatus(this.identifier);
                 this.orgId = response.id;
-                this.resetPasswordAutoEnroll = response.autoEnrollEnabled;
+                this.resetPasswordAutoEnroll = response.resetPasswordEnabled;
             } catch {
                 this.platformUtilsService.showToast('error', null, this.i18nService.t('errorOccurred'));
             }

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -114,6 +114,7 @@ import { IdentityCaptchaResponse } from '../models/response/identityCaptchaRespo
 import { IdentityTokenResponse } from '../models/response/identityTokenResponse';
 import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorResponse';
 import { ListResponse } from '../models/response/listResponse';
+import { OrganizationAutoEnrollStatusResponse } from '../models/response/organizationAutoEnrollStatusResponse';
 import { OrganizationKeysResponse } from '../models/response/organizationKeysResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { OrganizationSubscriptionResponse } from '../models/response/organizationSubscriptionResponse';
@@ -370,6 +371,7 @@ export abstract class ApiService {
     getOrganizationSubscription: (id: string) => Promise<OrganizationSubscriptionResponse>;
     getOrganizationLicense: (id: string, installationId: string) => Promise<any>;
     getOrganizationTaxInfo: (id: string) => Promise<TaxInfoResponse>;
+    getOrganizationAutoEnrollStatus: (identifier: string) => Promise<OrganizationAutoEnrollStatusResponse>;
     postOrganization: (request: OrganizationCreateRequest) => Promise<OrganizationResponse>;
     putOrganization: (id: string, request: OrganizationUpdateRequest) => Promise<OrganizationResponse>;
     putOrganizationTaxInfo: (id: string, request: OrganizationTaxInfoUpdateRequest) => Promise<any>;

--- a/common/src/models/response/organizationAutoEnrollStatusResponse.ts
+++ b/common/src/models/response/organizationAutoEnrollStatusResponse.ts
@@ -1,0 +1,12 @@
+import { BaseResponse } from './baseResponse';
+
+export class OrganizationAutoEnrollStatusResponse extends BaseResponse {
+    id: string;
+    autoEnrollEnabled: boolean;
+
+    constructor(response: any) {
+        super(response);
+        this.id = this.getResponseProperty('Id');
+        this.autoEnrollEnabled = this.getResponseProperty('AutoEnrollEnabled');
+    }
+}

--- a/common/src/models/response/organizationAutoEnrollStatusResponse.ts
+++ b/common/src/models/response/organizationAutoEnrollStatusResponse.ts
@@ -2,11 +2,11 @@ import { BaseResponse } from './baseResponse';
 
 export class OrganizationAutoEnrollStatusResponse extends BaseResponse {
     id: string;
-    autoEnrollEnabled: boolean;
+    resetPasswordEnabled: boolean;
 
     constructor(response: any) {
         super(response);
         this.id = this.getResponseProperty('Id');
-        this.autoEnrollEnabled = this.getResponseProperty('AutoEnrollEnabled');
+        this.resetPasswordEnabled = this.getResponseProperty('ResetPasswordEnabled');
     }
 }

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -118,6 +118,7 @@ import {
 import { IdentityTokenResponse } from '../models/response/identityTokenResponse';
 import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorResponse';
 import { ListResponse } from '../models/response/listResponse';
+import { OrganizationAutoEnrollStatusResponse } from '../models/response/organizationAutoEnrollStatusResponse';
 import { OrganizationKeysResponse } from '../models/response/organizationKeysResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { OrganizationSubscriptionResponse } from '../models/response/organizationSubscriptionResponse';
@@ -163,7 +164,6 @@ import { UserKeyResponse } from '../models/response/userKeyResponse';
 import { EnvironmentService } from '../abstractions';
 import { IdentityCaptchaResponse } from '../models/response/identityCaptchaResponse';
 import { SendAccessView } from '../models/view/sendAccessView';
-import { OrganizationAutoEnrollStatusResponse } from '../models/response/organizationAutoEnrollStatusResponse';
 
 export class ApiService implements ApiServiceAbstraction {
     protected apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>;

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -163,6 +163,7 @@ import { UserKeyResponse } from '../models/response/userKeyResponse';
 import { EnvironmentService } from '../abstractions';
 import { IdentityCaptchaResponse } from '../models/response/identityCaptchaResponse';
 import { SendAccessView } from '../models/view/sendAccessView';
+import { OrganizationAutoEnrollStatusResponse } from '../models/response/organizationAutoEnrollStatusResponse';
 
 export class ApiService implements ApiServiceAbstraction {
     protected apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>;
@@ -810,6 +811,11 @@ export class ApiService implements ApiServiceAbstraction {
         const r = await this.send('GET', '/organizations/' + organizationId + '/users/' + id +
             '/reset-password-details', null, true, true);
         return new OrganizationUserResetPasswordDetailsReponse(r);
+    }
+
+    async getOrganizationAutoEnrollStatus(identifier: string): Promise<OrganizationAutoEnrollStatusResponse> {
+        const r = await this.send('GET', '/organizations/' + identifier + '/auto-enroll-status', null, true, true);
+        return new OrganizationAutoEnrollStatusResponse(r);
     }
 
     postOrganizationUserInvite(organizationId: string, request: OrganizationUserInviteRequest): Promise<any> {


### PR DESCRIPTION
## Objective
> Add the latest `Auto Enroll` status `API` and updated the flow for information retrieval in regards to the `Organization ID` and `AutoEnrollEnabled` boolean.

## Code Changes
- **set-password.component**: Update the flow to use the newly available `API`
- **api.service**: Added new `GetOrganizationAutoEnrollStatus` method
- **organizationAutoEnrollStatusResponse**: Added response object for newly created `API`

## Dependency
- [Server - Add Auto Enroll status API](https://github.com/bitwarden/server/pull/1583)

## Notes
- Will be merged into `master` and `rc`