### PR TITLE
Move custom fields to separate components

### DIFF
--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -25,6 +25,7 @@ import { FieldType } from 'jslib-common/enums/fieldType';
 @Directive()
 export class AddEditCustomFieldsComponent implements OnChanges {
     @Input() cipher: CipherView;
+    @Input() thisCipherType: CipherType;
     @Input() editMode: boolean;
 
     addFieldType: FieldType = FieldType.Text;
@@ -46,7 +47,7 @@ export class AddEditCustomFieldsComponent implements OnChanges {
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        if (changes.cipher.currentValue != changes.cipher.previousValue) {
+        if (changes.thisCipherType.currentValue !== changes.thisCipherType.previousValue) {
             this.setLinkedFieldOptions();
         }
     }
@@ -91,7 +92,13 @@ export class AddEditCustomFieldsComponent implements OnChanges {
     }
 
     private setLinkedFieldOptions() {
+        // Secure notes do not support Linked fields
         if (this.cipher.type === CipherType.SecureNote) {
+            this.cipher.fields.forEach(f => {
+                if (f.type === FieldType.Linked) {
+                    this.removeField(f);
+                }
+            });
             return;
         }
 

--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -19,8 +19,8 @@ import {
 } from 'jslib-common/models/view';
 
 import { CipherType } from 'jslib-common/enums/cipherType';
-import { FieldType } from 'jslib-common/enums/fieldType';
 import { EventType } from 'jslib-common/enums/eventType';
+import { FieldType } from 'jslib-common/enums/fieldType';
 
 @Directive()
 export class AddEditCustomFieldsComponent implements OnChanges {
@@ -36,7 +36,7 @@ export class AddEditCustomFieldsComponent implements OnChanges {
     fieldType = FieldType;
     eventType = EventType;
 
-    constructor(private i18nService: I18nService, private eventService: EventService) { 
+    constructor(private i18nService: I18nService, private eventService: EventService) {
         this.addFieldTypeOptions = [
             { name: i18nService.t('cfTypeText'), value: FieldType.Text },
             { name: i18nService.t('cfTypeHidden'), value: FieldType.Hidden },

--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -1,8 +1,6 @@
 import {
     Directive,
     Input,
-    OnChanges,
-    SimpleChanges,
 } from '@angular/core';
 
 import {
@@ -23,14 +21,12 @@ import { EventType } from 'jslib-common/enums/eventType';
 import { FieldType } from 'jslib-common/enums/fieldType';
 
 @Directive()
-export class AddEditCustomFieldsComponent implements OnChanges {
+export class AddEditCustomFieldsComponent {
     @Input() cipher: CipherView;
-    @Input() thisCipherType: CipherType;
     @Input() editMode: boolean;
 
     addFieldType: FieldType = FieldType.Text;
     addFieldTypeOptions: any[];
-    addFieldLinkedTypeOption: any;
     linkedFieldOptions: any[] = [];
 
     cipherType = CipherType;
@@ -43,13 +39,6 @@ export class AddEditCustomFieldsComponent implements OnChanges {
             { name: i18nService.t('cfTypeHidden'), value: FieldType.Hidden },
             { name: i18nService.t('cfTypeBoolean'), value: FieldType.Boolean },
         ];
-        this.addFieldLinkedTypeOption = { name: this.i18nService.t('cfTypeLinked'), value: FieldType.Linked };
-    }
-
-    ngOnChanges(changes: SimpleChanges) {
-        if (changes.thisCipherType.currentValue !== changes.thisCipherType.previousValue) {
-            this.setLinkedFieldOptions();
-        }
     }
 
     addField() {
@@ -60,10 +49,6 @@ export class AddEditCustomFieldsComponent implements OnChanges {
         const f = new FieldView();
         f.type = this.addFieldType;
         f.newField = true;
-
-        if (f.type === FieldType.Linked) {
-            f.value = this.linkedFieldOptions[0].value;
-        }
 
         this.cipher.fields.push(f);
     }
@@ -89,22 +74,5 @@ export class AddEditCustomFieldsComponent implements OnChanges {
 
     drop(event: CdkDragDrop<string[]>) {
         moveItemInArray(this.cipher.fields, event.previousIndex, event.currentIndex);
-    }
-
-    private setLinkedFieldOptions() {
-        // Secure notes do not support Linked fields
-        if (this.cipher.type === CipherType.SecureNote) {
-            this.cipher.fields.forEach(f => {
-                if (f.type === FieldType.Linked) {
-                    this.removeField(f);
-                }
-            });
-            return;
-        }
-
-        this.linkedFieldOptions = [];
-        for (const [key] of Object.entries(this.cipher.linkedFieldOptions)) {
-            this.linkedFieldOptions.push({ name: this.i18nService.t(this.cipher.getLinkedFieldi18nKey(key)), value: key });
-        }
     }
 }

--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -1,0 +1,103 @@
+import {
+    Directive,
+    Input,
+    OnChanges,
+    SimpleChanges,
+} from '@angular/core';
+
+import {
+    CdkDragDrop,
+    moveItemInArray,
+} from '@angular/cdk/drag-drop';
+
+import { EventService } from 'jslib-common/abstractions/event.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+
+import {
+    CipherView,
+    FieldView,
+} from 'jslib-common/models/view';
+
+import { CipherType } from 'jslib-common/enums/cipherType';
+import { FieldType } from 'jslib-common/enums/fieldType';
+import { EventType } from 'jslib-common/enums/eventType';
+
+@Directive()
+export class AddEditCustomFieldsComponent implements OnChanges {
+    @Input() cipher: CipherView;
+    @Input() editMode: boolean;
+
+    addFieldType: FieldType = FieldType.Text;
+    addFieldTypeOptions: any[];
+    addFieldLinkedTypeOption: any;
+    linkedFieldOptions: any[] = [];
+
+    cipherType = CipherType;
+    fieldType = FieldType;
+    eventType = EventType;
+
+    constructor(private i18nService: I18nService, private eventService: EventService) { 
+        this.addFieldTypeOptions = [
+            { name: i18nService.t('cfTypeText'), value: FieldType.Text },
+            { name: i18nService.t('cfTypeHidden'), value: FieldType.Hidden },
+            { name: i18nService.t('cfTypeBoolean'), value: FieldType.Boolean },
+        ];
+        this.addFieldLinkedTypeOption = { name: this.i18nService.t('cfTypeLinked'), value: FieldType.Linked };
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes.cipher.currentValue != changes.cipher.previousValue) {
+            this.setLinkedFieldOptions();
+        }
+    }
+
+    addField() {
+        if (this.cipher.fields == null) {
+            this.cipher.fields = [];
+        }
+
+        const f = new FieldView();
+        f.type = this.addFieldType;
+        f.newField = true;
+
+        if (f.type === FieldType.Linked) {
+            f.value = this.linkedFieldOptions[0].value;
+        }
+
+        this.cipher.fields.push(f);
+    }
+
+    removeField(field: FieldView) {
+        const i = this.cipher.fields.indexOf(field);
+        if (i > -1) {
+            this.cipher.fields.splice(i, 1);
+        }
+    }
+
+    toggleFieldValue(field: FieldView) {
+        const f = (field as any);
+        f.showValue = !f.showValue;
+        if (this.editMode && f.showValue) {
+            this.eventService.collect(EventType.Cipher_ClientToggledHiddenFieldVisible, this.cipher.id);
+        }
+    }
+
+    trackByFunction(index: number, item: any) {
+        return index;
+    }
+
+    drop(event: CdkDragDrop<string[]>) {
+        moveItemInArray(this.cipher.fields, event.previousIndex, event.currentIndex);
+    }
+
+    private setLinkedFieldOptions() {
+        if (this.cipher.type === CipherType.SecureNote) {
+            return;
+        }
+
+        this.linkedFieldOptions = [];
+        for (const [key] of Object.entries(this.cipher.linkedFieldOptions)) {
+            this.linkedFieldOptions.push({ name: this.i18nService.t(this.cipher.getLinkedFieldi18nKey(key)), value: key });
+        }
+    }
+}

--- a/angular/src/components/add-edit.component.ts
+++ b/angular/src/components/add-edit.component.ts
@@ -9,7 +9,6 @@ import {
 import { CipherRepromptType } from 'jslib-common/enums/cipherRepromptType';
 import { CipherType } from 'jslib-common/enums/cipherType';
 import { EventType } from 'jslib-common/enums/eventType';
-import { FieldType } from 'jslib-common/enums/fieldType';
 import { OrganizationUserStatusType } from 'jslib-common/enums/organizationUserStatusType';
 import { PolicyType } from 'jslib-common/enums/policyType';
 import { SecureNoteType } from 'jslib-common/enums/secureNoteType';
@@ -32,7 +31,6 @@ import { Cipher } from 'jslib-common/models/domain/cipher';
 import { CardView } from 'jslib-common/models/view/cardView';
 import { CipherView } from 'jslib-common/models/view/cipherView';
 import { CollectionView } from 'jslib-common/models/view/collectionView';
-import { FieldView } from 'jslib-common/models/view/fieldView';
 import { FolderView } from 'jslib-common/models/view/folderView';
 import { IdentityView } from 'jslib-common/models/view/identityView';
 import { LoginUriView } from 'jslib-common/models/view/loginUriView';
@@ -71,7 +69,6 @@ export class AddEditComponent implements OnInit {
     showCardNumber: boolean = false;
     showCardCode: boolean = false;
     cipherType = CipherType;
-    fieldType = FieldType;
     typeOptions: any[];
     cardBrandOptions: any[];
     cardExpMonthOptions: any[];

--- a/angular/src/components/add-edit.component.ts
+++ b/angular/src/components/add-edit.component.ts
@@ -1,8 +1,4 @@
 import {
-    CdkDragDrop,
-    moveItemInArray,
-} from '@angular/cdk/drag-drop';
-import {
     Directive,
     EventEmitter,
     Input,
@@ -76,12 +72,10 @@ export class AddEditComponent implements OnInit {
     showCardCode: boolean = false;
     cipherType = CipherType;
     fieldType = FieldType;
-    addFieldType: FieldType = FieldType.Text;
     typeOptions: any[];
     cardBrandOptions: any[];
     cardExpMonthOptions: any[];
     identityTitleOptions: any[];
-    addFieldTypeOptions: any[];
     uriMatchOptions: any[];
     ownershipOptions: any[] = [];
     autofillOnPageLoadOptions: any[];
@@ -137,11 +131,6 @@ export class AddEditComponent implements OnInit {
             { name: i18nService.t('mrs'), value: i18nService.t('mrs') },
             { name: i18nService.t('ms'), value: i18nService.t('ms') },
             { name: i18nService.t('dr'), value: i18nService.t('dr') },
-        ];
-        this.addFieldTypeOptions = [
-            { name: i18nService.t('cfTypeText'), value: FieldType.Text },
-            { name: i18nService.t('cfTypeHidden'), value: FieldType.Hidden },
-            { name: i18nService.t('cfTypeBoolean'), value: FieldType.Boolean },
         ];
         this.uriMatchOptions = [
             { name: i18nService.t('defaultMatchDetection'), value: null },
@@ -322,24 +311,6 @@ export class AddEditComponent implements OnInit {
         }
     }
 
-    addField() {
-        if (this.cipher.fields == null) {
-            this.cipher.fields = [];
-        }
-
-        const f = new FieldView();
-        f.type = this.addFieldType;
-        f.newField = true;
-        this.cipher.fields.push(f);
-    }
-
-    removeField(field: FieldView) {
-        const i = this.cipher.fields.indexOf(field);
-        if (i > -1) {
-            this.cipher.fields.splice(i, 1);
-        }
-    }
-
     trackByFunction(index: number, item: any) {
         return index;
     }
@@ -440,14 +411,6 @@ export class AddEditComponent implements OnInit {
         }
     }
 
-    toggleFieldValue(field: FieldView) {
-        const f = (field as any);
-        f.showValue = !f.showValue;
-        if (this.editMode && f.showValue) {
-            this.eventService.collect(EventType.Cipher_ClientToggledHiddenFieldVisible, this.cipherId);
-        }
-    }
-
     toggleUriOptions(uri: LoginUriView) {
         const u = (uri as any);
         u.showOptions = u.showOptions == null && uri.match != null ? false : !u.showOptions;
@@ -456,10 +419,6 @@ export class AddEditComponent implements OnInit {
     loginUriMatchChanged(uri: LoginUriView) {
         const u = (uri as any);
         u.showOptions = u.showOptions == null ? true : u.showOptions;
-    }
-
-    drop(event: CdkDragDrop<string[]>) {
-        moveItemInArray(this.cipher.fields, event.previousIndex, event.currentIndex);
     }
 
     async organizationChanged() {

--- a/angular/src/components/view-custom-fields.component.ts
+++ b/angular/src/components/view-custom-fields.component.ts
@@ -1,0 +1,38 @@
+import {
+    Directive,
+    Input,
+} from '@angular/core';
+
+import { EventType } from 'jslib-common/enums/eventType';
+import { FieldType } from 'jslib-common/enums/fieldType';
+
+import { EventService } from 'jslib-common/abstractions/event.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { PasswordRepromptService } from 'jslib-common/abstractions/passwordReprompt.service';
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+
+import { CipherView } from 'jslib-common/models/view/cipherView';
+import { FieldView } from 'jslib-common/models/view/fieldView';
+
+@Directive()
+export class ViewCustomFieldsComponent {
+    @Input() cipher: CipherView;
+    @Input() promptPassword: () => Promise<boolean>;
+    @Input() copy: (value: string, typeI18nKey: string, aType: string) => void;
+
+    fieldType = FieldType;
+
+    constructor(private eventService: EventService) { }
+
+    async toggleFieldValue(field: FieldView) {
+        if (!await this.promptPassword()) {
+            return;
+        }
+
+        const f = (field as any);
+        f.showValue = !f.showValue;
+        if (f.showValue) {
+            this.eventService.collect(EventType.Cipher_ClientToggledHiddenFieldVisible, this.cipher.id);
+        }
+    }
+}

--- a/angular/src/components/view-custom-fields.component.ts
+++ b/angular/src/components/view-custom-fields.component.ts
@@ -7,9 +7,6 @@ import { EventType } from 'jslib-common/enums/eventType';
 import { FieldType } from 'jslib-common/enums/fieldType';
 
 import { EventService } from 'jslib-common/abstractions/event.service';
-import { I18nService } from 'jslib-common/abstractions/i18n.service';
-import { PasswordRepromptService } from 'jslib-common/abstractions/passwordReprompt.service';
-import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 
 import { CipherView } from 'jslib-common/models/view/cipherView';
 import { FieldView } from 'jslib-common/models/view/fieldView';

--- a/angular/src/components/view.component.ts
+++ b/angular/src/components/view.component.ts
@@ -234,18 +234,6 @@ export class ViewComponent implements OnDestroy, OnInit {
         }
     }
 
-    async toggleFieldValue(field: FieldView) {
-        if (!await this.promptPassword()) {
-            return;
-        }
-
-        const f = (field as any);
-        f.showValue = !f.showValue;
-        if (f.showValue) {
-            this.eventService.collect(EventType.Cipher_ClientToggledHiddenFieldVisible, this.cipherId);
-        }
-    }
-
     launch(uri: LoginUriView, cipherId?: string) {
         if (!uri.canLaunch) {
             return;


### PR DESCRIPTION
## Objective
@MGibson1 suggested in https://github.com/bitwarden/browser/pull/1963 that we move custom fields out of the `add-edit.component.ts` and into their own component. This tidies up `add-edit.component`, which already has a lot going on, and will also make the linked custom fields implementation cleaner. I'll rebase bitwarden/browser#1963 on top of this once merged.

There's less logic in `view.component.ts`, but I've split that out as well for consistency.

Note: this is a pure refactor, there are no changes to logic or behaviour in this PR.

## Code changes
* move relevant code and html from `add-edit.component` to new `add-edit-custom-field.component`
* move relevant code and html from `view.component` to new `view-custom-field.component`

Client changes:
* browser: https://github.com/bitwarden/browser/pull/2072
* web: https://github.com/bitwarden/web/pull/1192
* desktop: https://github.com/bitwarden/desktop/pull/1076