### PR TITLE
Resolve biometric error dissapearing before being read

### DIFF
--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -166,6 +166,8 @@ export class LockComponent implements OnInit {
         if (success) {
             await this.doContinue();
         }
+
+        return success;
     }
 
     togglePassword() {

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -156,7 +156,7 @@ export class LockComponent implements OnInit {
         }
     }
 
-    async unlockBiometric() {
+    async unlockBiometric(): Promise<boolean> {
         if (!this.biometricLock) {
             return;
         }


### PR DESCRIPTION
## Objective

In the browser extension, primarily on Safari the error message for biometrics sometimes disappears before it can be read. To resolve this, I needed to only close the dialog if the action was successful, which requires to know the status of the unlock operation.