### PR TITLE
Feature/split manage collections permission

### DIFF
--- a/common/src/enums/permissions.ts
+++ b/common/src/enums/permissions.ts
@@ -1,14 +1,27 @@
 export enum Permissions {
-    AccessBusinessPortal,
-    AccessEventLogs,
-    AccessImportExport,
-    AccessReports,
-    ManageAllCollections,
-    ManageAssignedCollections,
-    ManageGroups,
-    ManageOrganization,
-    ManagePolicies,
-    ManageProvider,
-    ManageUsers,
-    ManageUsersPassword,
+    AccessBusinessPortal = 0,
+    AccessEventLogs = 1,
+    AccessImportExport = 2,
+    AccessReports = 3,
+    /**
+     * @deprecated Sep 29 2021: This permission has been split out to `createNewCollections`, `editAnyCollection`, and
+     * `deleteAnyCollection`. It exists here for backwards compatibility with Server versions <= 1.43.0
+     */
+    ManageAllCollections = 4,
+    /**
+     * @deprecated Sep 29 2021: This permission has been split out to `editAssignedCollections` and
+     * `deleteAssignedCollections`. It exists here for backwards compatibility with Server versions <= 1.43.0
+     */
+    ManageAssignedCollections = 5,
+    ManageGroups = 6,
+    ManageOrganization = 7,
+    ManagePolicies = 8,
+    ManageProvider = 9,
+    ManageUsers = 10,
+    ManageUsersPassword = 11,
+    CreateNewCollections = 12,
+    EditAnyCollection = 13,
+    DeleteAnyCollection = 14,
+    EditAssignedCollections = 15,
+    DeleteAssignedCollections = 16,
 }

--- a/common/src/misc/utils.ts
+++ b/common/src/misc/utils.ts
@@ -325,6 +325,10 @@ export class Utils {
         return url;
     }
 
+    static camelToPascalCase(s: string) {
+        return s.charAt(0).toUpperCase() + s.slice(1);
+    }
+
     private static validIpAddress(ipString: string): boolean {
         // tslint:disable-next-line
         const ipRegex = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;

--- a/common/src/models/api/permissionsApi.ts
+++ b/common/src/models/api/permissionsApi.ts
@@ -5,8 +5,21 @@ export class PermissionsApi extends BaseResponse {
     accessEventLogs: boolean;
     accessImportExport: boolean;
     accessReports: boolean;
+    /**
+     * @deprecated Sep 29 2021: This permission has been split out to `createNewCollections`, `editAnyCollection`, and
+     * `deleteAnyCollection`. It exists here for backwards compatibility with Server versions <= 1.43.0
+     */
     manageAllCollections: boolean;
+    createNewCollections: boolean;
+    editAnyCollection: boolean;
+    deleteAnyCollection: boolean;
+    /**
+     * @deprecated Sep 29 2021: This permission has been split out to `editAssignedCollections` and
+     * `deleteAssignedCollections`. It exists here for backwards compatibility with Server versions <= 1.43.0
+     */
     manageAssignedCollections: boolean;
+    editAssignedCollections: boolean;
+    deleteAssignedCollections: boolean;
     manageCiphers: boolean;
     manageGroups: boolean;
     manageSso: boolean;
@@ -23,8 +36,17 @@ export class PermissionsApi extends BaseResponse {
         this.accessEventLogs = this.getResponseProperty('AccessEventLogs');
         this.accessImportExport = this.getResponseProperty('AccessImportExport');
         this.accessReports = this.getResponseProperty('AccessReports');
+
+        // For backwards compatibility with Server <= 1.43.0
         this.manageAllCollections = this.getResponseProperty('ManageAllCollections');
         this.manageAssignedCollections = this.getResponseProperty('ManageAssignedCollections');
+
+        this.createNewCollections = this.getResponseProperty('CreateNewCollections');
+        this.editAnyCollection = this.getResponseProperty('EditAnyCollection');
+        this.deleteAnyCollection = this.getResponseProperty('DeleteAnyCollection');
+        this.editAssignedCollections = this.getResponseProperty('EditAssignedCollections');
+        this.deleteAssignedCollections = this.getResponseProperty('DeleteAssignedCollections');
+
         this.manageCiphers = this.getResponseProperty('ManageCiphers');
         this.manageGroups = this.getResponseProperty('ManageGroups');
         this.manageSso = this.getResponseProperty('ManageSso');

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -108,12 +108,32 @@ export class Organization {
         return this.isAdmin || this.permissions.accessReports;
     }
 
-    get canManageAllCollections() {
-        return this.isAdmin || this.permissions.manageAllCollections;
+    get canCreateNewCollections() {
+        return this.isAdmin || (this.permissions.createNewCollections ?? this.permissions.manageAllCollections);
     }
 
-    get canManageAssignedCollections() {
-        return this.isManager || this.permissions.manageAssignedCollections;
+    get canEditAnyCollection() {
+        return this.isAdmin || (this.permissions.editAnyCollection ?? this.permissions.manageAllCollections);
+    }
+
+    get canDeleteAnyCollection() {
+        return this.isAdmin || (this.permissions.deleteAnyCollection ?? this.permissions.manageAllCollections);
+    }
+
+    get canViewAllCollections() {
+        return this.canEditAnyCollection || this.canDeleteAnyCollection;
+    }
+
+    get canEditAssignedCollections() {
+        return this.isManager || (this.permissions.deleteAssignedCollections ?? this.permissions.manageAssignedCollections);
+    }
+
+    get canDeleteAssignedCollections() {
+        return this.isManager || (this.permissions.deleteAssignedCollections ?? this.permissions.manageAssignedCollections);
+    }
+
+    get canViewAssignedCollections() {
+        return this.canDeleteAssignedCollections || this.canEditAssignedCollections;
     }
 
     get canManageGroups() {


### PR DESCRIPTION
# Overview

Asana: https://app.asana.com/0/0/1201089124980371/f

jslib work to split out collection permissions into create, edit, delete permissions.

# Files Changed
* **permissions.ts**: Deprecate old permissions, assigned numbers to permissions to allow for eventually removing deprecated permissions.
* **utils.ts**: Add helper to convert camelCase to PascalCase. Used to convert id attributes to name attributes.
* **permissionsApi.ts**: Add new permissions parsing. Keep the old, server provides them for backwards compatibility and if new permissions are null, we fallback to the manage permissions.
* **organization.ts**: Provide new permissions helpers. Fallback to manage permissions if new ones are null.