### PR TITLE
Set default ownership if Personal Ownership policy applies

### DIFF
--- a/angular/src/components/add-edit.component.ts
+++ b/angular/src/components/add-edit.component.ts
@@ -150,18 +150,21 @@ export class AddEditComponent implements OnInit {
     }
 
     async init() {
-        const myEmail = await this.userService.getEmail();
-        this.ownershipOptions.push({ name: myEmail, value: null });
+        if (await this.policyService.policyAppliesToUser(PolicyType.PersonalOwnership)) {
+            this.allowPersonal = false;
+        } else {
+            const myEmail = await this.userService.getEmail();
+            this.ownershipOptions.push({ name: myEmail, value: null });
+        }
+
         const orgs = await this.userService.getAllOrganizations();
         orgs.sort(Utils.getSortFunction(this.i18nService, 'name')).forEach(o => {
             if (o.enabled && o.status === OrganizationUserStatusType.Confirmed) {
                 this.ownershipOptions.push({ name: o.name, value: o.id });
             }
         });
-
-        if (this.allowPersonal && await this.policyService.policyAppliesToUser(PolicyType.PersonalOwnership)) {
-            this.allowPersonal = false;
-            this.ownershipOptions.splice(0, 1);
+        if (!this.allowPersonal) {
+            this.organizationId = this.ownershipOptions[0].value;
         }
 
         this.writeableCollections = await this.loadCollections();


### PR DESCRIPTION
## Objective

Fix regression from the policy checking refactor: if the Personal Ownership policy applies, the `Ownership` dropdown does not have a default value, preventing you from saving the new item.

## Code changes
* reorder existing code so that we don't have to `splice` out the personal ownership option unnecessarily (just don't add it in the first place)
* set default value to `organizationId`.

