### PR TITLE
[bug] Set a default value for custom send deletion times in the safari extension

### DIFF
--- a/angular/src/components/send/efflux-dates.component.ts
+++ b/angular/src/components/send/efflux-dates.component.ts
@@ -183,10 +183,10 @@ export class EffluxDatesComponent implements OnInit {
         return this.safariTimePresetOptions(DateField.ExpriationDate);
     }
 
-    private get tomorrow(): Date {
-        const tomorrow = new Date();
-        tomorrow.setDate(tomorrow.getDate() + 1);
-        return tomorrow;
+    private get nextWeek(): Date {
+        const nextWeek = new Date();
+        nextWeek.setDate(nextWeek.getDate() + 7);
+        return nextWeek;
     }
 
     constructor(protected i18nService: I18nService, protected platformUtilsService: PlatformUtilsService,
@@ -253,7 +253,7 @@ export class EffluxDatesComponent implements OnInit {
 
             switch (this.browserPath) {
                 case BrowserPath.Safari:
-                    this.fallbackDeletionDate.setValue(this.tomorrow.toISOString().slice(0, 10));
+                    this.fallbackDeletionDate.setValue(this.nextWeek.toISOString().slice(0, 10));
                     this.fallbackDeletionTime.setValue(this.safariTimePresetOptions(DateField.DeletionDate)[1].twentyFourHour);
                     break;
                 default:


### PR DESCRIPTION
### Related Work
[Asana](https://app.asana.com/0/1183359552741420/1200821052763382/f)

### Bug
> Custom Send dates in Safari have a confusing UX. When the fields are initially displayed a placeholder is shown with today's date, but this can be confused as being a set in stone value for the field, and the `required` attribute doesn't work in the safari date picker polyfill in the browser extension[[1]](https://github.com/bitwarden/jslib/pull/460), so we don't get good error handling explaining this. 

### Solution
> Set a default value for custom send deletion times in the safari extension

### Solution Demo
https://user-images.githubusercontent.com/15897251/136573903-f613582d-3081-4301-a74c-e4324a7a633e.mov
