### PR TITLE
Fix OrganizationSsoResponse not behaving correctly in production

### DIFF
--- a/common/src/models/response/organization/organizationSsoResponse.ts
+++ b/common/src/models/response/organization/organizationSsoResponse.ts
@@ -10,14 +10,23 @@ export class OrganizationSsoResponse extends BaseResponse {
         super(response);
         this.enabled = this.getResponseProperty('Enabled');
         this.data = new SsoConfigApi(this.getResponseProperty('Data'));
-        this.urls = this.getResponseProperty('Urls');
+        this.urls = new SsoUrls(this.getResponseProperty('Urls'));
     }
 }
 
-type SsoUrls = {
+class SsoUrls extends BaseResponse {
     callbackPath: string;
     signedOutCallbackPath: string;
     spEntityId: string;
     spMetadataUrl: string;
     spAcsUrl: string;
-};
+
+    constructor(response: any) {
+        super(response);
+        this.callbackPath = this.getResponseProperty('CallbackPath');
+        this.signedOutCallbackPath = this.getResponseProperty('SignedOutCallbackPath');
+        this.spEntityId = this.getResponseProperty('SpEntityId');
+        this.spMetadataUrl = this.getResponseProperty('SpMetadataUrl');
+        this.spAcsUrl = this.getResponseProperty('SpAcsUrl');
+    }
+}


### PR DESCRIPTION
The local development environment uses `camelCase` as the json serializer. While production uses `PascalCase`. Which caused a behavior where the previous code worked fine locally but not in QA.

Note: Will be cherry picked to `rc`