### PR TITLE
 [Refactor] Use rxjs first instead of unsubscribe from queryParams

### DIFF
--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -4,6 +4,8 @@ import {
     Router
 } from '@angular/router';
 
+import { first } from 'rxjs/operators';
+
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
@@ -25,7 +27,6 @@ import { ChangePasswordComponent as BaseChangePasswordComponent } from './change
 
 import { HashPurpose } from 'jslib-common/enums/hashPurpose';
 import { KdfType } from 'jslib-common/enums/kdfType';
-import { PolicyType } from 'jslib-common/enums/policyType';
 
 import { Utils } from 'jslib-common/misc/utils';
 
@@ -53,13 +54,9 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
         await this.syncService.fullSync(true);
         this.syncLoading = false;
 
-        const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
+        this.route.queryParams.pipe(first()).subscribe(async qParams => {
             if (qParams.identifier != null) {
                 this.identifier = qParams.identifier;
-            }
-
-            if (queryParamsSub != null) {
-                queryParamsSub.unsubscribe();
             }
         });
 

--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -4,6 +4,8 @@ import {
     Router,
 } from '@angular/router';
 
+import { first } from 'rxjs/operators';
+
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
@@ -50,7 +52,7 @@ export class SsoComponent {
         protected passwordGenerationService: PasswordGenerationService) { }
 
     async ngOnInit() {
-        const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
+        this.route.queryParams.pipe(first()).subscribe(async qParams => {
             if (qParams.code != null && qParams.state != null) {
                 const codeVerifier = await this.storageService.get<string>(ConstantsService.ssoCodeVerifierKey);
                 const state = await this.storageService.get<string>(ConstantsService.ssoStateKey);
@@ -65,9 +67,6 @@ export class SsoComponent {
                 this.state = qParams.state;
                 this.codeChallenge = qParams.codeChallenge;
                 this.clientId = qParams.clientId;
-            }
-            if (queryParamsSub != null) {
-                queryParamsSub.unsubscribe();
             }
         });
     }


### PR DESCRIPTION
## Objective

As discussed in https://github.com/bitwarden/jslib/pull/470, we currently call `unsubscribe()` on the queryParams object from within its callback. This is a bit of an anti-pattern and can throw an error about the subscription variable being undefined.

## Code changes

Use the rxjs `first` operator instead. This will automatically unsubscribe from the observable after the first value is emitted. We should use this pattern from now on.