### PR TITLE
Add Slack notifications constraint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
       - build
     steps:
       - name: Check if any job failed
+        if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') }}
         env:
           CLOC_STATUS: ${{ needs.cloc.result }}
           BUILD_STATUS: ${{ needs.build.result }}


### PR DESCRIPTION
This PR constrains failure notifications to `master` and `rc` branches.