### PR TITLE
Add node tests to pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,8 @@ jobs:
           name: test-coverage
           path: coverage/
 
+      - name: Run Node tests
+        run: npm run test:node
 
   check-failures:
     name: Check for failures


### PR DESCRIPTION
# Overview

Asana Ticket (kinda): https://app.asana.com/0/1169444489336079/1201245609926305

We're not currently running the node-only tests in pipeline and we should. I'm working on #524, which add tests to the electron suite, which is not included in karma tests.