### PR TITLE
Add support for requesting and using otp for verifying some requests

### DIFF
--- a/angular/src/components/add-edit.component.ts
+++ b/angular/src/components/add-edit.component.ts
@@ -22,6 +22,7 @@ import { FolderService } from 'jslib-common/abstractions/folder.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { LogService } from 'jslib-common/abstractions/log.service';
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
+import { PasswordRepromptService } from 'jslib-common/abstractions/passwordReprompt.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { PolicyService } from 'jslib-common/abstractions/policy.service';
 import { StateService } from 'jslib-common/abstractions/state.service';
@@ -80,6 +81,7 @@ export class AddEditComponent implements OnInit {
     currentDate = new Date();
     allowPersonal = true;
     reprompt: boolean = false;
+    canUseReprompt: boolean = true;
 
     protected writeableCollections: CollectionView[];
     private previousCipherId: string;
@@ -89,7 +91,8 @@ export class AddEditComponent implements OnInit {
         protected auditService: AuditService, protected stateService: StateService,
         protected userService: UserService, protected collectionService: CollectionService,
         protected messagingService: MessagingService, protected eventService: EventService,
-        protected policyService: PolicyService, private logService: LogService) {
+        protected policyService: PolicyService, protected passwordRepromptService: PasswordRepromptService,
+        private logService: LogService) {
         this.typeOptions = [
             { name: i18nService.t('typeLogin'), value: CipherType.Login },
             { name: i18nService.t('typeCard'), value: CipherType.Card },
@@ -169,6 +172,8 @@ export class AddEditComponent implements OnInit {
         }
 
         this.writeableCollections = await this.loadCollections();
+
+        this.canUseReprompt = await this.passwordRepromptService.enabled();
     }
 
     async load() {

--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -5,6 +5,7 @@ import {
     Output,
     ViewChild,
 } from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { EventService } from 'jslib-common/abstractions/event.service';
@@ -28,6 +29,7 @@ export class ExportComponent implements OnInit {
     format: 'json' | 'encrypted_json' | 'csv' = 'json';
     showPassword = false;
     disabledByPolicy: boolean = false;
+    secret = new FormControl();
 
     constructor(protected cryptoService: CryptoService, protected i18nService: I18nService,
         protected platformUtilsService: PlatformUtilsService, protected exportService: ExportService,
@@ -40,6 +42,9 @@ export class ExportComponent implements OnInit {
 
     async checkExportDisabled() {
         this.disabledByPolicy = await this.policyService.policyAppliesToUser(PolicyType.DisablePersonalVaultExport);
+        if (this.disabledByPolicy) {
+            this.secret.disable();
+        }
     }
 
     get encryptedFormat() {

--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -33,7 +33,7 @@ export class ExportComponent implements OnInit {
     exportForm = this.fb.group({
         format: ['json'],
         secret: [''],
-    })
+    });
 
     formatOptions = [
         { name: '.json', value: 'json' },

--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -21,7 +21,7 @@ import { VerificationType } from 'jslib-common/enums/verificationType';
 
 import { VerifyOtpRequest } from 'jslib-common/models/request/account/verifyOtpRequest';
 
-import { Verification } from './verify-master-password.component';
+import { Verification } from 'jslib-common/types/verification';
 
 @Directive()
 export class ExportComponent implements OnInit {

--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -132,6 +132,8 @@ export class ExportComponent implements OnInit {
     protected async verifySecret(): Promise<boolean> {
         const verification: Verification = this.exportForm.get('secret').value;
         if (verification?.secret == null || verification.secret === '') {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                this.i18nService.t('verificationCodeRequired'));
             return false;
         }
 

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -23,7 +23,6 @@ import { PasswordVerificationRequest } from 'jslib-common/models/request/passwor
 import { Utils } from 'jslib-common/misc/utils';
 
 import { HashPurpose } from 'jslib-common/enums/hashPurpose';
-import { VerificationType } from 'jslib-common/enums/verificationType';
 
 @Directive()
 export class LockComponent implements OnInit {
@@ -120,13 +119,10 @@ export class LockComponent implements OnInit {
             if (storedKeyHash != null) {
                 passwordValid = await this.cryptoService.compareAndUpdateKeyHash(this.masterPassword, key);
             } else {
+                const request = new PasswordVerificationRequest();
                 const serverKeyHash = await this.cryptoService.hashPassword(this.masterPassword, key,
                     HashPurpose.ServerAuthorization);
-                const request = new PasswordVerificationRequest({
-                    secret: serverKeyHash,
-                    type: VerificationType.MasterPassword,
-                });
-
+                request.masterPasswordHash = serverKeyHash;
                 try {
                     this.formPromise = this.apiService.postAccountVerifyPassword(request);
                     await this.formPromise;

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -19,7 +19,7 @@ import { ConstantsService } from 'jslib-common/services/constants.service';
 import { EncString } from 'jslib-common/models/domain/encString';
 import { SymmetricCryptoKey } from 'jslib-common/models/domain/symmetricCryptoKey';
 
-import { PasswordVerificationRequest } from 'jslib-common/models/request/passwordVerificationRequest';
+import { SecretVerificationRequest } from 'jslib-common/models/request/secretVerificationRequest';
 
 import { Utils } from 'jslib-common/misc/utils';
 
@@ -126,7 +126,7 @@ export class LockComponent implements OnInit {
             if (storedKeyHash != null) {
                 passwordValid = await this.cryptoService.compareAndUpdateKeyHash(this.masterPassword, key);
             } else {
-                const request = new PasswordVerificationRequest();
+                const request = new SecretVerificationRequest();
                 const serverKeyHash = await this.cryptoService.hashPassword(this.masterPassword, key,
                     HashPurpose.ServerAuthorization);
                 request.masterPasswordHash = serverKeyHash;

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -59,6 +59,11 @@ export class LockComponent implements OnInit {
         this.biometricText = await this.storageService.get(ConstantsService.biometricText);
         this.email = await this.userService.getEmail();
 
+        // Users with crypto agent and without biometric or pin has no MP to unlock using
+        if (await this.userService.getUsesCryptoAgent() && !(this.biometricLock || this.pinLock)) {
+            await this.vaultTimeoutService.logOut();
+        }
+
         const webVaultUrl = this.environmentService.getWebVaultUrl();
         const vaultUrl = webVaultUrl === 'https://vault.bitwarden.com' ? 'https://bitwarden.com' : webVaultUrl;
         this.webVaultHostname = Utils.getHostname(vaultUrl);

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -5,6 +5,7 @@ import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 import { LogService } from 'jslib-common/abstractions/log.service';
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
@@ -48,7 +49,8 @@ export class LockComponent implements OnInit {
         protected userService: UserService, protected cryptoService: CryptoService,
         protected storageService: StorageService, protected vaultTimeoutService: VaultTimeoutService,
         protected environmentService: EnvironmentService, protected stateService: StateService,
-        protected apiService: ApiService, private logService: LogService) { }
+        protected apiService: ApiService, private logService: LogService,
+        private keyConnectorService: KeyConnectorService) { }
 
     async ngOnInit() {
         this.pinSet = await this.vaultTimeoutService.isPinLockSet();
@@ -60,7 +62,7 @@ export class LockComponent implements OnInit {
         this.email = await this.userService.getEmail();
 
         // Users with key connector and without biometric or pin has no MP to unlock using
-        if (await this.userService.getUsesKeyConnector() && !(this.biometricLock || this.pinLock)) {
+        if (await this.keyConnectorService.getUsesKeyConnector() && !(this.biometricLock || this.pinLock)) {
             await this.vaultTimeoutService.logOut();
         }
 

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -59,8 +59,8 @@ export class LockComponent implements OnInit {
         this.biometricText = await this.storageService.get(ConstantsService.biometricText);
         this.email = await this.userService.getEmail();
 
-        // Users with crypto agent and without biometric or pin has no MP to unlock using
-        if (await this.userService.getUsesCryptoAgent() && !(this.biometricLock || this.pinLock)) {
+        // Users with key connector and without biometric or pin has no MP to unlock using
+        if (await this.userService.getUsesKeyConnector() && !(this.biometricLock || this.pinLock)) {
             await this.vaultTimeoutService.logOut();
         }
 

--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -23,6 +23,7 @@ import { PasswordVerificationRequest } from 'jslib-common/models/request/passwor
 import { Utils } from 'jslib-common/misc/utils';
 
 import { HashPurpose } from 'jslib-common/enums/hashPurpose';
+import { VerificationType } from 'jslib-common/enums/verificationType';
 
 @Directive()
 export class LockComponent implements OnInit {
@@ -119,10 +120,13 @@ export class LockComponent implements OnInit {
             if (storedKeyHash != null) {
                 passwordValid = await this.cryptoService.compareAndUpdateKeyHash(this.masterPassword, key);
             } else {
-                const request = new PasswordVerificationRequest();
                 const serverKeyHash = await this.cryptoService.hashPassword(this.masterPassword, key,
                     HashPurpose.ServerAuthorization);
-                request.masterPasswordHash = serverKeyHash;
+                const request = new PasswordVerificationRequest({
+                    secret: serverKeyHash,
+                    type: VerificationType.MasterPassword,
+                });
+
                 try {
                     this.formPromise = this.apiService.postAccountVerifyPassword(request);
                     await this.formPromise;

--- a/angular/src/components/remove-password.component.ts
+++ b/angular/src/components/remove-password.component.ts
@@ -8,8 +8,11 @@ import { ApiService } from 'jslib-common/abstractions/api.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { SyncService } from 'jslib-common/abstractions/sync.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
+
+import { ConstantsService } from 'jslib-common/services/constants.service';
 
 import { Organization } from 'jslib-common/models/domain/organization';
 
@@ -27,7 +30,7 @@ export class RemovePasswordComponent implements OnInit {
     constructor(private router: Router, private userService: UserService,
         private apiService: ApiService, private syncService: SyncService,
         private platformUtilsService: PlatformUtilsService, private i18nService: I18nService,
-        private keyConnectorService: KeyConnectorService) { }
+        private keyConnectorService: KeyConnectorService, private storageService: StorageService) { }
 
     async ngOnInit() {
         this.organization = await this.keyConnectorService.getManagingOrganization();
@@ -43,6 +46,7 @@ export class RemovePasswordComponent implements OnInit {
         try {
             await this.actionPromise;
             this.platformUtilsService.showToast('success', null, this.i18nService.t('removedMasterPassword'));
+            await this.storageService.remove(ConstantsService.convertAccountToKeyConnector);
             this.router.navigate(['']);
         } catch (e) {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e.message);
@@ -64,6 +68,7 @@ export class RemovePasswordComponent implements OnInit {
             });
             await this.actionPromise;
             this.platformUtilsService.showToast('success', null, this.i18nService.t('leftOrganization'));
+            await this.storageService.remove(ConstantsService.convertAccountToKeyConnector);
             this.router.navigate(['']);
         } catch (e) {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e);

--- a/angular/src/components/remove-password.component.ts
+++ b/angular/src/components/remove-password.component.ts
@@ -46,7 +46,7 @@ export class RemovePasswordComponent implements OnInit {
         try {
             await this.actionPromise;
             this.platformUtilsService.showToast('success', null, this.i18nService.t('removedMasterPassword'));
-            await this.storageService.remove(ConstantsService.convertAccountToKeyConnector);
+            await this.keyConnectorService.removeConvertAccountRequired();
             this.router.navigate(['']);
         } catch (e) {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e.message);
@@ -68,7 +68,7 @@ export class RemovePasswordComponent implements OnInit {
             });
             await this.actionPromise;
             this.platformUtilsService.showToast('success', null, this.i18nService.t('leftOrganization'));
-            await this.storageService.remove(ConstantsService.convertAccountToKeyConnector);
+            await this.keyConnectorService.removeConvertAccountRequired();
             this.router.navigate(['']);
         } catch (e) {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e);

--- a/angular/src/components/remove-password.component.ts
+++ b/angular/src/components/remove-password.component.ts
@@ -1,0 +1,87 @@
+import {
+    Component,
+    Directive,
+    OnInit,
+} from '@angular/core';
+import { Router } from '@angular/router';
+
+import { ApiService } from 'jslib-common/abstractions/api.service';
+import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { SyncService } from 'jslib-common/abstractions/sync.service';
+import { UserService } from 'jslib-common/abstractions/user.service';
+
+import { Organization } from 'jslib-common/models/domain/organization';
+
+import { KeyConnectorUserKeyRequest } from 'jslib-common/models/request/keyConnectorUserKeyRequest';
+
+@Directive()
+export class RemovePasswordComponent implements OnInit {
+
+    actionPromise: Promise<any>;
+    continuing: boolean = false;
+    leaving: boolean = false;
+
+    loading: boolean = true;
+    organization: Organization;
+    email: string;
+
+    constructor(private router: Router, private userService: UserService,
+        private apiService: ApiService, private cryptoService: CryptoService,
+        private syncService: SyncService, private platformUtilsService: PlatformUtilsService,
+        private i18nService: I18nService) { }
+
+    async ngOnInit() {
+        this.organization = (await this.userService.getAllOrganizations())[0];
+        this.email = await this.userService.getEmail();
+        await this.syncService.fullSync(false);
+        this.loading = false;
+    }
+
+    async convert() {
+        this.continuing = true;
+        this.actionPromise = this.convertAccount();
+
+        try {
+            await this.actionPromise;
+            this.platformUtilsService.showToast('success', null, this.i18nService.t('removedMasterPassword'));
+            this.router.navigate(['']);
+        } catch (e) {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e.message);
+        }
+    }
+
+    async leave() {
+        const confirmed = await this.platformUtilsService.showDialog(
+            this.i18nService.t('leaveOrganizationConfirmation'), this.organization.name,
+            this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
+        if (!confirmed) {
+            return false;
+        }
+
+        try {
+            this.leaving = true;
+            this.actionPromise = this.apiService.postLeaveOrganization(this.organization.id).then(() => {
+                return this.syncService.fullSync(true);
+            });
+            await this.actionPromise;
+            this.platformUtilsService.showToast('success', null, this.i18nService.t('leftOrganization'));
+            this.router.navigate(['']);
+        } catch (e) {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e);
+        }
+    }
+
+    private async convertAccount() {
+        const key = await this.cryptoService.getKey();
+        try {
+            const keyConnectorRequest = new KeyConnectorUserKeyRequest(key.encKeyB64);
+            await this.apiService.postUserKeyToKeyConnector(this.organization.keyConnectorUrl, keyConnectorRequest);
+        } catch (e) {
+            throw new Error('Unable to reach key connector');
+        }
+
+        await this.apiService.postConvertToKeyConnector();
+    }
+}

--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -183,8 +183,8 @@ export class SsoComponent {
             }
         } catch (e) {
             this.logService.error(e);
-            if (e.message === 'Unable to reach crypto agent') {
-                this.platformUtilsService.showToast('error', null, this.i18nService.t('ssoCryptoAgentUnavailable'));
+            if (e.message === 'Unable to reach key connector') {
+                this.platformUtilsService.showToast('error', null, this.i18nService.t('ssoKeyConnectorUnavailable'));
             }
         }
         this.loggingIn = false;

--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -60,7 +60,7 @@ export class SsoComponent {
                 await this.storageService.remove(ConstantsService.ssoCodeVerifierKey);
                 await this.storageService.remove(ConstantsService.ssoStateKey);
                 if (qParams.code != null && codeVerifier != null && state != null && this.checkState(state, qParams.state)) {
-                    await this.logIn(qParams.code, codeVerifier, this.getOrgIdentiferFromState(qParams.state));
+                    await this.logIn(qParams.code, codeVerifier, this.getOrgIdentifierFromState(qParams.state));
                 }
             } else if (qParams.clientId != null && qParams.redirectUri != null && qParams.state != null &&
                 qParams.codeChallenge != null) {
@@ -190,7 +190,7 @@ export class SsoComponent {
         this.loggingIn = false;
     }
 
-    private getOrgIdentiferFromState(state: string): string {
+    private getOrgIdentifierFromState(state: string): string {
         if (state === null || state === undefined) {
             return null;
         }

--- a/angular/src/components/two-factor.component.ts
+++ b/angular/src/components/two-factor.component.ts
@@ -211,7 +211,9 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
         }
 
         try {
-            const request = new TwoFactorEmailRequest(this.authService.email, this.authService.masterPasswordHash);
+            const request = new TwoFactorEmailRequest();
+            request.email = this.authService.email;
+            request.masterPasswordHash = this.authService.masterPasswordHash;
             this.emailPromise = this.apiService.postTwoFactorEmail(request);
             await this.emailPromise;
             if (doToast) {

--- a/angular/src/components/two-factor.component.ts
+++ b/angular/src/components/two-factor.component.ts
@@ -27,7 +27,6 @@ import { ConstantsService } from 'jslib-common/services/constants.service';
 
 import * as DuoWebSDK from 'duo_web_sdk';
 import { WebAuthnIFrame } from 'jslib-common/misc/webauthn_iframe';
-import { VerificationType } from 'jslib-common/enums/verificationType';
 
 @Directive()
 export class TwoFactorComponent implements OnInit, OnDestroy {
@@ -212,12 +211,9 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
         }
 
         try {
-            const masterPasswordHash = this.authService.masterPasswordHash;
-            const request = new TwoFactorEmailRequest({
-                secret: masterPasswordHash,
-                type: VerificationType.MasterPassword,
-            });
+            const request = new TwoFactorEmailRequest();
             request.email = this.authService.email;
+            request.masterPasswordHash = this.authService.masterPasswordHash;
             this.emailPromise = this.apiService.postTwoFactorEmail(request);
             await this.emailPromise;
             if (doToast) {

--- a/angular/src/components/two-factor.component.ts
+++ b/angular/src/components/two-factor.component.ts
@@ -27,6 +27,7 @@ import { ConstantsService } from 'jslib-common/services/constants.service';
 
 import * as DuoWebSDK from 'duo_web_sdk';
 import { WebAuthnIFrame } from 'jslib-common/misc/webauthn_iframe';
+import { VerificationType } from 'jslib-common/enums/verificationType';
 
 @Directive()
 export class TwoFactorComponent implements OnInit, OnDestroy {
@@ -211,9 +212,12 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
         }
 
         try {
-            const request = new TwoFactorEmailRequest();
+            const masterPasswordHash = this.authService.masterPasswordHash;
+            const request = new TwoFactorEmailRequest({
+                secret: masterPasswordHash,
+                type: VerificationType.MasterPassword,
+            });
             request.email = this.authService.email;
-            request.masterPasswordHash = this.authService.masterPasswordHash;
             this.emailPromise = this.apiService.postTwoFactorEmail(request);
             await this.emailPromise;
             if (doToast) {

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -1,0 +1,12 @@
+
+<ng-container *ngIf="!usesCryptoAgent">
+    <label for="masterPassword">{{'masterPass' | i18n}}</label>
+    <input id="masterPassword" type="password" name="MasterPasswordHash" class="form-control"
+        [formControl]="secret" required appAutofocus appInputVerbatim>
+</ng-container>
+<ng-container *ngIf="usesCryptoAgent">
+    <p>{{'verificationCodeDesc' | i18n}}</p>
+    <label for="verificationCode">{{'verificationCode' | i18n}}</label>
+    <input id="verificationCode" type="input" name="verificationCode" class="form-control"
+        [formControl]="secret" required appAutofocus appInputVerbatim>
+</ng-container>

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -5,8 +5,9 @@
 </ng-container>
 <ng-container *ngIf="usesKeyConnector">
     <div class="form-group">
-        <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOTP()"
-            [disabled]="disableRequestOTP">
+        <button type="button" class="btn btn-primary" (click)="requestOTP()" [disabled]="disableRequestOTP">
+            {{'requestVerificationCode' | i18n}}
+        </button>
     </div>
 
     <div class="form-group">

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -7,7 +7,7 @@
 <ng-container *ngIf="usesCryptoAgent">
     <div class="form-group">
         <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOtp()"
-            [disabled]="disableRequestOtp">
+            [disabled]="disableRequestOtp || disableForm">
     </div>
 
     <div class="form-group">

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -5,8 +5,8 @@
 </ng-container>
 <ng-container *ngIf="usesKeyConnector">
     <div class="form-group">
-        <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOtp()"
-            [disabled]="disableRequestOtp">
+        <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOTP()"
+            [disabled]="disableRequestOTP">
     </div>
 
     <div class="form-group">

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -1,10 +1,10 @@
 
-<ng-container *ngIf="!usesCryptoAgent">
+<ng-container *ngIf="!usesKeyConnector">
     <label for="masterPassword">{{'masterPass' | i18n}}</label>
     <input id="masterPassword" type="password" name="MasterPasswordHash" class="form-control"
         [formControl]="secret" required appAutofocus appInputVerbatim>
 </ng-container>
-<ng-container *ngIf="usesCryptoAgent">
+<ng-container *ngIf="usesKeyConnector">
     <div class="form-group">
         <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOtp()"
             [disabled]="disableRequestOtp">

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -7,7 +7,7 @@
 <ng-container *ngIf="usesCryptoAgent">
     <div class="form-group">
         <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOtp()"
-            [disabled]="disableRequestOtp || disableForm">
+            [disabled]="disableRequestOtp">
     </div>
 
     <div class="form-group">

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -1,4 +1,3 @@
-
 <ng-container *ngIf="!usesKeyConnector">
     <label for="masterPassword">{{'masterPass' | i18n}}</label>
     <input id="masterPassword" type="password" name="MasterPasswordHash" class="form-control"

--- a/angular/src/components/verify-master-password.component.html
+++ b/angular/src/components/verify-master-password.component.html
@@ -5,8 +5,14 @@
         [formControl]="secret" required appAutofocus appInputVerbatim>
 </ng-container>
 <ng-container *ngIf="usesCryptoAgent">
-    <p>{{'verificationCodeDesc' | i18n}}</p>
-    <label for="verificationCode">{{'verificationCode' | i18n}}</label>
-    <input id="verificationCode" type="input" name="verificationCode" class="form-control"
-        [formControl]="secret" required appAutofocus appInputVerbatim>
+    <div class="form-group">
+        <input type="button" class="btn btn-primary" value="Request one-time password" (click)="requestOtp()"
+            [disabled]="disableRequestOtp">
+    </div>
+
+    <div class="form-group">
+        <label for="verificationCode">{{'verificationCode' | i18n}}</label>
+        <input id="verificationCode" type="input" name="verificationCode" class="form-control"
+            [formControl]="secret" required appAutofocus appInputVerbatim>
+    </div>
 </ng-container>

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -16,8 +16,10 @@ import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { VerifyOtpRequest } from 'jslib-common/models/request/account/verifyOtpRequest';
 
+import { VerificationType } from 'jslib-common/enums/verificationType';
+
 export type Verification = {
-    type: 'MasterPassword' | 'OTP',
+    type: VerificationType,
     secret: string,
 };
 
@@ -53,7 +55,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
             }
 
             this.onChange({
-                type: this.usesCryptoAgent ? 'OTP' : 'MasterPassword',
+                type: this.usesCryptoAgent ? VerificationType.OTP : VerificationType.MasterPassword,
                 secret: secret,
             });
         });

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -1,5 +1,6 @@
 import {
     Component,
+    Input,
     OnInit,
 } from '@angular/core';
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -29,10 +30,12 @@ export type Verification = {
     ],
 })
 export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnInit {
+    @Input() disableForm = false;
+
     usesCryptoAgent: boolean = false;
     disableRequestOtp: boolean = false;
 
-    secret = new FormControl('');
+    secret = new FormControl({ value: '', disabled: this.disableForm });
 
     private onChange: (value: Verification) => void;
 
@@ -88,6 +91,10 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
         }
         
         return true;
+    }
+
+    clearSecret() {
+        this.secret.setValue('');
     }
 
     writeValue(obj: any): void {

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -28,7 +28,7 @@ import { Verification } from 'jslib-common/types/verification';
 })
 export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnInit {
     usesKeyConnector: boolean = false;
-    disableRequestOtp: boolean = false;
+    disableRequestOTP: boolean = false;
 
     secret = new FormControl('');
 
@@ -51,10 +51,10 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
         });
     }
 
-    async requestOtp() {
+    async requestOTP() {
         if (this.usesKeyConnector) {
-            this.disableRequestOtp = true;
-            await this.apiService.postAccountRequestOtp();
+            this.disableRequestOTP = true;
+            await this.apiService.postAccountRequestOTP();
         }
     }
 
@@ -71,7 +71,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
     }
 
     setDisabledState?(isDisabled: boolean): void {
-        this.disableRequestOtp = isDisabled;
+        this.disableRequestOTP = isDisabled;
         if (isDisabled) {
             this.secret.disable();
         } else {

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/forms';
 
 import { ApiService } from 'jslib-common/abstractions/api.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
+import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 
 import { VerificationType } from 'jslib-common/enums/verificationType';
 
@@ -34,10 +34,10 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
 
     private onChange: (value: Verification) => void;
 
-    constructor(private userService: UserService, private apiService: ApiService) { }
+    constructor(private keyConnectorService: KeyConnectorService, private apiService: ApiService) { }
 
     async ngOnInit() {
-        this.usesKeyConnector = await this.userService.getUsesKeyConnector();
+        this.usesKeyConnector = await this.keyConnectorService.getUsesKeyConnector();
 
         this.secret.valueChanges.subscribe(secret => {
             if (this.onChange == null) {

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -5,7 +5,12 @@ import {
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ApiService } from 'jslib-common/abstractions/api.service';
+import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
+
+import { VerifyOtpRequest } from 'jslib-common/models/request/account/verifyOtpRequest';
 
 export type Verification = {
     type: 'MasterPassword' | 'OTP',
@@ -31,7 +36,9 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
 
     private onChange: (value: Verification) => void;
 
-    constructor(private userService: UserService, private apiService: ApiService) { }
+    constructor(private userService: UserService, private apiService: ApiService,
+        private cryptoService: CryptoService, private platformUtilsService: PlatformUtilsService,
+        private i18nService: I18nService) { }
 
     async ngOnInit() {
         this.usesCryptoAgent = await this.userService.getUsesCryptoAgent();
@@ -53,6 +60,34 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
             this.disableRequestOtp = true;
             await this.apiService.postAccountRequestOtp();
         }
+    }
+
+    async verifySecret(): Promise<boolean> {
+        const showError = () => this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+            this.i18nService.t(this.usesCryptoAgent ? 'invalidVerificationCode' : 'invalidMasterPassword'));
+
+        if (this.secret.value == null || this.secret.value === '') {
+            showError();
+            return false;
+        }
+
+        if (this.usesCryptoAgent) {
+            const request = new VerifyOtpRequest(this.secret.value);
+            try {
+                await this.apiService.postAccountVerifyOtp(request);
+            } catch {
+                showError();
+                return false;
+            }
+        } else {
+            const passwordValid = await this.cryptoService.compareAndUpdateKeyHash(this.secret.value, null);
+            if (!passwordValid) {
+                showError();
+                return false;
+            }
+        }
+        
+        return true;
     }
 
     writeValue(obj: any): void {

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -27,7 +27,7 @@ import { Verification } from 'jslib-common/types/verification';
     ],
 })
 export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnInit {
-    usesCryptoAgent: boolean = false;
+    usesKeyConnector: boolean = false;
     disableRequestOtp: boolean = false;
 
     secret = new FormControl('');
@@ -37,7 +37,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
     constructor(private userService: UserService, private apiService: ApiService) { }
 
     async ngOnInit() {
-        this.usesCryptoAgent = await this.userService.getUsesCryptoAgent();
+        this.usesKeyConnector = await this.userService.getUsesKeyConnector();
 
         this.secret.valueChanges.subscribe(secret => {
             if (this.onChange == null) {
@@ -45,14 +45,14 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
             }
 
             this.onChange({
-                type: this.usesCryptoAgent ? VerificationType.OTP : VerificationType.MasterPassword,
+                type: this.usesKeyConnector ? VerificationType.OTP : VerificationType.MasterPassword,
                 secret: secret,
             });
         });
     }
 
     async requestOtp() {
-        if (this.usesCryptoAgent) {
+        if (this.usesKeyConnector) {
             this.disableRequestOtp = true;
             await this.apiService.postAccountRequestOtp();
         }

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -1,0 +1,69 @@
+import {
+    Component,
+    OnInit,
+} from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { ApiService } from 'jslib-common/abstractions/api.service';
+import { UserService } from 'jslib-common/abstractions/user.service';
+
+export type Verification = {
+    type: 'MasterPassword' | 'OTP',
+    secret: string,
+};
+
+@Component({
+    selector: 'app-verify-master-password',
+    templateUrl: 'verify-master-password.component.html',
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            multi: true,
+            useExisting: VerifyMasterPasswordComponent,
+        },
+    ],
+})
+export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnInit {
+    usesCryptoAgent: boolean = false;
+
+    secret = new FormControl('');
+
+    private onChange: (value: Verification) => void;
+
+    constructor(private userService: UserService, private apiService: ApiService) { }
+
+    async ngOnInit() {
+        this.usesCryptoAgent = await this.userService.getUsesCryptoAgent();
+
+        if (this.usesCryptoAgent) {
+            this.apiService.postAccountRequestOtp();
+        }
+
+        this.secret.valueChanges.subscribe(secret => {
+            if (this.onChange == null) {
+                return;
+            }
+
+            this.onChange({
+                type: this.usesCryptoAgent ? 'OTP' : 'MasterPassword',
+                secret: secret,
+            });
+        });
+    }
+
+    writeValue(obj: any): void {
+        // Not implemented
+    }
+
+    registerOnChange(fn: any): void {
+        this.onChange = fn;
+    }
+
+    registerOnTouched(fn: any): void {
+        // Not implemented
+    }
+
+    setDisabledState?(isDisabled: boolean): void {
+        // Not implemented
+    }
+}

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -58,10 +58,6 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
         }
     }
 
-    clearSecret() {
-        this.secret.setValue('');
-    }
-
     writeValue(obj: any): void {
         this.secret.setValue(obj);
     }

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -13,10 +13,7 @@ import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { VerificationType } from 'jslib-common/enums/verificationType';
 
-export type Verification = {
-    type: VerificationType,
-    secret: string,
-};
+import { Verification } from 'jslib-common/types/verification';
 
 @Component({
     selector: 'app-verify-master-password',

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -9,12 +9,7 @@ import {
 } from '@angular/forms';
 
 import { ApiService } from 'jslib-common/abstractions/api.service';
-import { CryptoService } from 'jslib-common/abstractions/crypto.service';
-import { I18nService } from 'jslib-common/abstractions/i18n.service';
-import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
-
-import { VerifyOtpRequest } from 'jslib-common/models/request/account/verifyOtpRequest';
 
 import { VerificationType } from 'jslib-common/enums/verificationType';
 
@@ -42,9 +37,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
 
     private onChange: (value: Verification) => void;
 
-    constructor(private userService: UserService, private apiService: ApiService,
-        private cryptoService: CryptoService, private platformUtilsService: PlatformUtilsService,
-        private i18nService: I18nService) { }
+    constructor(private userService: UserService, private apiService: ApiService) { }
 
     async ngOnInit() {
         this.usesCryptoAgent = await this.userService.getUsesCryptoAgent();
@@ -66,34 +59,6 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
             this.disableRequestOtp = true;
             await this.apiService.postAccountRequestOtp();
         }
-    }
-
-    async verifySecret(): Promise<boolean> {
-        const showError = () => this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-            this.i18nService.t(this.usesCryptoAgent ? 'invalidVerificationCode' : 'invalidMasterPassword'));
-
-        if (this.secret.value == null || this.secret.value === '') {
-            showError();
-            return false;
-        }
-
-        if (this.usesCryptoAgent) {
-            const request = new VerifyOtpRequest(this.secret.value);
-            try {
-                await this.apiService.postAccountVerifyOtp(request);
-            } catch {
-                showError();
-                return false;
-            }
-        } else {
-            const passwordValid = await this.cryptoService.compareAndUpdateKeyHash(this.secret.value, null);
-            if (!passwordValid) {
-                showError();
-                return false;
-            }
-        }
-
-        return true;
     }
 
     clearSecret() {

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -1,9 +1,12 @@
 import {
     Component,
-    Input,
     OnInit,
 } from '@angular/core';
-import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
+import {
+    ControlValueAccessor,
+    FormControl,
+    NG_VALUE_ACCESSOR,
+} from '@angular/forms';
 
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
@@ -30,12 +33,10 @@ export type Verification = {
     ],
 })
 export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnInit {
-    @Input() disableForm = false;
-
     usesCryptoAgent: boolean = false;
     disableRequestOtp: boolean = false;
 
-    secret = new FormControl({ value: '', disabled: this.disableForm });
+    secret = new FormControl('');
 
     private onChange: (value: Verification) => void;
 
@@ -89,7 +90,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -98,7 +99,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
     }
 
     writeValue(obj: any): void {
-        // Not implemented
+        this.secret.setValue(obj);
     }
 
     registerOnChange(fn: any): void {
@@ -110,6 +111,11 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
     }
 
     setDisabledState?(isDisabled: boolean): void {
-        // Not implemented
+        this.disableRequestOtp = isDisabled;
+        if (isDisabled) {
+            this.secret.disable();
+        } else {
+            this.secret.enable();
+        }
     }
 }

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -25,6 +25,7 @@ export type Verification = {
 })
 export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnInit {
     usesCryptoAgent: boolean = false;
+    disableRequestOtp: boolean = false;
 
     secret = new FormControl('');
 
@@ -34,10 +35,6 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
 
     async ngOnInit() {
         this.usesCryptoAgent = await this.userService.getUsesCryptoAgent();
-
-        if (this.usesCryptoAgent) {
-            this.apiService.postAccountRequestOtp();
-        }
 
         this.secret.valueChanges.subscribe(secret => {
             if (this.onChange == null) {
@@ -49,6 +46,13 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
                 secret: secret,
             });
         });
+    }
+
+    async requestOtp() {
+        if (this.usesCryptoAgent) {
+            this.disableRequestOtp = true;
+            await this.apiService.postAccountRequestOtp();
+        }
     }
 
     writeValue(obj: any): void {

--- a/angular/src/services/auth-guard.service.ts
+++ b/angular/src/services/auth-guard.service.ts
@@ -32,7 +32,7 @@ export class AuthGuardService implements CanActivate {
             return false;
         }
 
-        if (await this.keyConnectorService.getConvertAccountRequired()) {
+        if (!routerState.url.includes("remove-password") && await this.keyConnectorService.getConvertAccountRequired()) {
             this.router.navigate(['/remove-password']);
             return false;
         }

--- a/angular/src/services/auth-guard.service.ts
+++ b/angular/src/services/auth-guard.service.ts
@@ -32,7 +32,7 @@ export class AuthGuardService implements CanActivate {
             return false;
         }
 
-        if (!routerState.url.includes("remove-password") && await this.keyConnectorService.getConvertAccountRequired()) {
+        if (!routerState.url.includes('remove-password') && await this.keyConnectorService.getConvertAccountRequired()) {
             this.router.navigate(['/remove-password']);
             return false;
         }

--- a/angular/src/services/auth-guard.service.ts
+++ b/angular/src/services/auth-guard.service.ts
@@ -7,13 +7,16 @@ import {
 } from '@angular/router';
 
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
+import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib-common/abstractions/vaultTimeout.service';
+
+import { ConstantsService } from 'jslib-common/services/constants.service';
 
 @Injectable()
 export class AuthGuardService implements CanActivate {
     constructor(private vaultTimeoutService: VaultTimeoutService, private userService: UserService,
-        private router: Router, private messagingService: MessagingService) { }
+        private router: Router, private messagingService: MessagingService, private storageService: StorageService) { }
 
     async canActivate(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot) {
         const isAuthed = await this.userService.isAuthenticated();
@@ -28,6 +31,11 @@ export class AuthGuardService implements CanActivate {
                 this.messagingService.send('lockedUrl', { url: routerState.url });
             }
             this.router.navigate(['lock'], { queryParams: { promptBiometric: true }});
+            return false;
+        }
+
+        if (await this.storageService.get(ConstantsService.convertAccountToKeyConnector)) {
+            this.router.navigate(['/remove-password']);
             return false;
         }
 

--- a/angular/src/services/auth-guard.service.ts
+++ b/angular/src/services/auth-guard.service.ts
@@ -6,17 +6,15 @@ import {
     RouterStateSnapshot,
 } from '@angular/router';
 
+import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
-import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib-common/abstractions/vaultTimeout.service';
-
-import { ConstantsService } from 'jslib-common/services/constants.service';
 
 @Injectable()
 export class AuthGuardService implements CanActivate {
     constructor(private vaultTimeoutService: VaultTimeoutService, private userService: UserService,
-        private router: Router, private messagingService: MessagingService, private storageService: StorageService) { }
+        private router: Router, private messagingService: MessagingService, private keyConnectorService: KeyConnectorService) { }
 
     async canActivate(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot) {
         const isAuthed = await this.userService.isAuthenticated();
@@ -34,7 +32,7 @@ export class AuthGuardService implements CanActivate {
             return false;
         }
 
-        if (await this.storageService.get(ConstantsService.convertAccountToKeyConnector)) {
+        if (await this.keyConnectorService.getConvertAccountRequired()) {
             this.router.navigate(['/remove-password']);
             return false;
         }

--- a/angular/src/services/passwordReprompt.service.ts
+++ b/angular/src/services/passwordReprompt.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
+import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from 'jslib-common/abstractions/passwordReprompt.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { PasswordRepromptComponent } from '../components/password-reprompt.component';
 import { ModalService } from './modal.service';
@@ -10,7 +10,7 @@ import { ModalService } from './modal.service';
 export class PasswordRepromptService implements PasswordRepromptServiceAbstraction {
     protected component = PasswordRepromptComponent;
 
-    constructor(private modalService: ModalService, private userService: UserService) { }
+    constructor(private modalService: ModalService, private keyConnectorService: KeyConnectorService) { }
 
     protectedFields() {
         return ['TOTP', 'Password', 'H_Field', 'Card Number', 'Security Code'];
@@ -32,6 +32,6 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
     }
 
     async enabled() {
-        return !await this.userService.getUsesKeyConnector();
+        return !await this.keyConnectorService.getUsesKeyConnector();
     }
 }

--- a/angular/src/services/passwordReprompt.service.ts
+++ b/angular/src/services/passwordReprompt.service.ts
@@ -32,6 +32,6 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
     }
 
     async enabled() {
-        return !await this.userService.getUsesCryptoAgent();
+        return !await this.userService.getUsesKeyConnector();
     }
 }

--- a/angular/src/services/passwordReprompt.service.ts
+++ b/angular/src/services/passwordReprompt.service.ts
@@ -17,8 +17,7 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
     }
 
     async showPasswordPrompt() {
-        const passwordRepromptDisabled = await this.userService.getUsesCryptoAgent();
-        if (passwordRepromptDisabled) {
+        if (!await this.enabled()) {
             return true;
         }
 
@@ -30,5 +29,9 @@ export class PasswordRepromptService implements PasswordRepromptServiceAbstracti
 
         const result = await ref.onClosedPromise();
         return result === true;
+    }
+
+    async enabled() {
+        return !await this.userService.getUsesCryptoAgent();
     }
 }

--- a/angular/src/services/passwordReprompt.service.ts
+++ b/angular/src/services/passwordReprompt.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from 'jslib-common/abstractions/passwordReprompt.service';
+import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { PasswordRepromptComponent } from '../components/password-reprompt.component';
 import { ModalService } from './modal.service';
@@ -9,13 +10,18 @@ import { ModalService } from './modal.service';
 export class PasswordRepromptService implements PasswordRepromptServiceAbstraction {
     protected component = PasswordRepromptComponent;
 
-    constructor(private modalService: ModalService) { }
+    constructor(private modalService: ModalService, private userService: UserService) { }
 
     protectedFields() {
         return ['TOTP', 'Password', 'H_Field', 'Card Number', 'Security Code'];
     }
 
     async showPasswordPrompt() {
+        const passwordRepromptDisabled = await this.userService.getUsesCryptoAgent();
+        if (passwordRepromptDisabled) {
+            return true;
+        }
+
         const ref = this.modalService.open(this.component, {allowMultipleModals: true});
 
         if (ref == null) {

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -200,8 +200,8 @@ export abstract class ApiService {
     postUserApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
     postUserRotateApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
-    postAccountRequestOtp: () => Promise<void>;
-    postAccountVerifyOtp: (request: VerifyOTPRequest) => Promise<void>;
+    postAccountRequestOTP: () => Promise<void>;
+    postAccountVerifyOTP: (request: VerifyOTPRequest) => Promise<void>;
     postConvertToKeyConnector: () => Promise<void>;
 
     getFolder: (id: string) => Promise<FolderResponse>;

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -51,7 +51,6 @@ import { OrganizationUserUpdateGroupsRequest } from '../models/request/organizat
 import { OrganizationUserUpdateRequest } from '../models/request/organizationUserUpdateRequest';
 import { PasswordHintRequest } from '../models/request/passwordHintRequest';
 import { PasswordRequest } from '../models/request/passwordRequest';
-import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
 import { PaymentRequest } from '../models/request/paymentRequest';
 import { PolicyRequest } from '../models/request/policyRequest';
 import { PreloginRequest } from '../models/request/preloginRequest';
@@ -67,6 +66,7 @@ import { ProviderUserInviteRequest } from '../models/request/provider/providerUs
 import { ProviderUserUpdateRequest } from '../models/request/provider/providerUserUpdateRequest';
 import { RegisterRequest } from '../models/request/registerRequest';
 import { SeatRequest } from '../models/request/seatRequest';
+import { SecretVerificationRequest } from '../models/request/secretVerificationRequest';
 import { SelectionReadOnlyRequest } from '../models/request/selectionReadOnlyRequest';
 import { SendAccessRequest } from '../models/request/sendAccessRequest';
 import { SendRequest } from '../models/request/sendRequest';
@@ -177,8 +177,8 @@ export abstract class ApiService {
     postPassword: (request: PasswordRequest) => Promise<any>;
     setPassword: (request: SetPasswordRequest) => Promise<any>;
     postSetKeyConnectorKey: (request: SetKeyConnectorKeyRequest) => Promise<any>;
-    postSecurityStamp: (request: PasswordVerificationRequest) => Promise<any>;
-    deleteAccount: (request: PasswordVerificationRequest) => Promise<any>;
+    postSecurityStamp: (request: SecretVerificationRequest) => Promise<any>;
+    deleteAccount: (request: SecretVerificationRequest) => Promise<any>;
     getAccountRevisionDate: () => Promise<number>;
     postPasswordHint: (request: PasswordHintRequest) => Promise<any>;
     postRegister: (request: RegisterRequest) => Promise<any>;
@@ -193,12 +193,12 @@ export abstract class ApiService {
     postAccountKeys: (request: KeysRequest) => Promise<any>;
     postAccountVerifyEmail: () => Promise<any>;
     postAccountVerifyEmailToken: (request: VerifyEmailRequest) => Promise<any>;
-    postAccountVerifyPassword: (request: PasswordVerificationRequest) => Promise<any>;
+    postAccountVerifyPassword: (request: SecretVerificationRequest) => Promise<any>;
     postAccountRecoverDelete: (request: DeleteRecoverRequest) => Promise<any>;
     postAccountRecoverDeleteToken: (request: VerifyDeleteRecoverRequest) => Promise<any>;
     postAccountKdf: (request: KdfRequest) => Promise<any>;
-    postUserApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
-    postUserRotateApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
+    postUserApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
+    postUserRotateApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
     postAccountRequestOtp: () => Promise<void>;
     postAccountVerifyOtp: (request: VerifyOtpRequest) => Promise<void>;
@@ -244,7 +244,7 @@ export abstract class ApiService {
     putShareCiphers: (request: CipherBulkShareRequest) => Promise<any>;
     putCipherCollections: (id: string, request: CipherCollectionsRequest) => Promise<any>;
     putCipherCollectionsAdmin: (id: string, request: CipherCollectionsRequest) => Promise<any>;
-    postPurgeCiphers: (request: PasswordVerificationRequest, organizationId?: string) => Promise<any>;
+    postPurgeCiphers: (request: SecretVerificationRequest, organizationId?: string) => Promise<any>;
     postImportCiphers: (request: ImportCiphersRequest) => Promise<any>;
     postImportOrganizationCiphers: (organizationId: string, request: ImportOrganizationCiphersRequest) => Promise<any>;
     putDeleteCipher: (id: string) => Promise<any>;
@@ -333,15 +333,15 @@ export abstract class ApiService {
 
     getTwoFactorProviders: () => Promise<ListResponse<TwoFactorProviderResponse>>;
     getTwoFactorOrganizationProviders: (organizationId: string) => Promise<ListResponse<TwoFactorProviderResponse>>;
-    getTwoFactorAuthenticator: (request: PasswordVerificationRequest) => Promise<TwoFactorAuthenticatorResponse>;
-    getTwoFactorEmail: (request: PasswordVerificationRequest) => Promise<TwoFactorEmailResponse>;
-    getTwoFactorDuo: (request: PasswordVerificationRequest) => Promise<TwoFactorDuoResponse>;
+    getTwoFactorAuthenticator: (request: SecretVerificationRequest) => Promise<TwoFactorAuthenticatorResponse>;
+    getTwoFactorEmail: (request: SecretVerificationRequest) => Promise<TwoFactorEmailResponse>;
+    getTwoFactorDuo: (request: SecretVerificationRequest) => Promise<TwoFactorDuoResponse>;
     getTwoFactorOrganizationDuo: (organizationId: string,
-        request: PasswordVerificationRequest) => Promise<TwoFactorDuoResponse>;
-    getTwoFactorYubiKey: (request: PasswordVerificationRequest) => Promise<TwoFactorYubiKeyResponse>;
-    getTwoFactorWebAuthn: (request: PasswordVerificationRequest) => Promise<TwoFactorWebAuthnResponse>;
-    getTwoFactorWebAuthnChallenge: (request: PasswordVerificationRequest) => Promise<ChallengeResponse>;
-    getTwoFactorRecover: (request: PasswordVerificationRequest) => Promise<TwoFactorRecoverResponse>;
+        request: SecretVerificationRequest) => Promise<TwoFactorDuoResponse>;
+    getTwoFactorYubiKey: (request: SecretVerificationRequest) => Promise<TwoFactorYubiKeyResponse>;
+    getTwoFactorWebAuthn: (request: SecretVerificationRequest) => Promise<TwoFactorWebAuthnResponse>;
+    getTwoFactorWebAuthnChallenge: (request: SecretVerificationRequest) => Promise<ChallengeResponse>;
+    getTwoFactorRecover: (request: SecretVerificationRequest) => Promise<TwoFactorRecoverResponse>;
     putTwoFactorAuthenticator: (
         request: UpdateTwoFactorAuthenticatorRequest) => Promise<TwoFactorAuthenticatorResponse>;
     putTwoFactorEmail: (request: UpdateTwoFactorEmailRequest) => Promise<TwoFactorEmailResponse>;
@@ -388,8 +388,8 @@ export abstract class ApiService {
     postLeaveOrganization: (id: string) => Promise<any>;
     postOrganizationLicense: (data: FormData) => Promise<OrganizationResponse>;
     postOrganizationLicenseUpdate: (id: string, data: FormData) => Promise<any>;
-    postOrganizationApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
-    postOrganizationRotateApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
+    postOrganizationApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
+    postOrganizationRotateApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
     postOrganizationSso: (id: string, request: OrganizationSsoRequest) => Promise<OrganizationSsoResponse>;
     postOrganizationUpgrade: (id: string, request: OrganizationUpgradeRequest) => Promise<PaymentResponse>;
     postOrganizationUpdateSubscription: (id: string, request: OrganizationSubscriptionUpdateRequest) => Promise<void>;
@@ -399,7 +399,7 @@ export abstract class ApiService {
     postOrganizationVerifyBank: (id: string, request: VerifyBankRequest) => Promise<any>;
     postOrganizationCancel: (id: string) => Promise<any>;
     postOrganizationReinstate: (id: string) => Promise<any>;
-    deleteOrganization: (id: string, request: PasswordVerificationRequest) => Promise<any>;
+    deleteOrganization: (id: string, request: SecretVerificationRequest) => Promise<any>;
     getPlans: () => Promise<ListResponse<PlanResponse>>;
     getTaxRates: () => Promise<ListResponse<TaxRateResponse>>;
     getOrganizationKeys: (id: string) => Promise<OrganizationKeysResponse>;

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -1,5 +1,5 @@
 import { PolicyType } from '../enums/policyType';
-import { SetCryptoAgentKeyRequest } from '../models/request/account/setCryptoAgentKeyRequest';
+import { SetKeyConnectorKeyRequest } from '../models/request/account/setKeyConnectorKeyRequest';
 import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
 
 import { AttachmentRequest } from '../models/request/attachmentRequest';
@@ -14,7 +14,6 @@ import { CipherCreateRequest } from '../models/request/cipherCreateRequest';
 import { CipherRequest } from '../models/request/cipherRequest';
 import { CipherShareRequest } from '../models/request/cipherShareRequest';
 import { CollectionRequest } from '../models/request/collectionRequest';
-import { CryptoAgentUserKeyRequest } from '../models/request/cryptoAgentUserKeyRequest';
 import { DeleteRecoverRequest } from '../models/request/deleteRecoverRequest';
 import { EmailRequest } from '../models/request/emailRequest';
 import { EmailTokenRequest } from '../models/request/emailTokenRequest';
@@ -31,6 +30,7 @@ import { ImportCiphersRequest } from '../models/request/importCiphersRequest';
 import { ImportDirectoryRequest } from '../models/request/importDirectoryRequest';
 import { ImportOrganizationCiphersRequest } from '../models/request/importOrganizationCiphersRequest';
 import { KdfRequest } from '../models/request/kdfRequest';
+import { KeyConnectorUserKeyRequest } from '../models/request/keyConnectorUserKeyRequest';
 import { KeysRequest } from '../models/request/keysRequest';
 import { OrganizationSsoRequest } from '../models/request/organization/organizationSsoRequest';
 import { OrganizationCreateRequest } from '../models/request/organizationCreateRequest';
@@ -101,7 +101,6 @@ import {
     CollectionGroupDetailsResponse,
     CollectionResponse,
 } from '../models/response/collectionResponse';
-import { CryptoAgentUserKeyResponse } from '../models/response/cryptoAgentUserKeyResponse';
 import { DomainsResponse } from '../models/response/domainsResponse';
 import {
     EmergencyAccessGranteeDetailsResponse,
@@ -118,6 +117,7 @@ import {
 import { IdentityCaptchaResponse } from '../models/response/identityCaptchaResponse';
 import { IdentityTokenResponse } from '../models/response/identityTokenResponse';
 import { IdentityTwoFactorResponse } from '../models/response/identityTwoFactorResponse';
+import { KeyConnectorUserKeyResponse } from '../models/response/keyConnectorUserKeyResponse';
 import { ListResponse } from '../models/response/listResponse';
 import { OrganizationSsoResponse } from '../models/response/organization/organizationSsoResponse';
 import { OrganizationAutoEnrollStatusResponse } from '../models/response/organizationAutoEnrollStatusResponse';
@@ -176,7 +176,7 @@ export abstract class ApiService {
     postEmail: (request: EmailRequest) => Promise<any>;
     postPassword: (request: PasswordRequest) => Promise<any>;
     setPassword: (request: SetPasswordRequest) => Promise<any>;
-    postSetCryptoAgentKey: (request: SetCryptoAgentKeyRequest) => Promise<any>;
+    postSetKeyConnectorKey: (request: SetKeyConnectorKeyRequest) => Promise<any>;
     postSecurityStamp: (request: PasswordVerificationRequest) => Promise<any>;
     deleteAccount: (request: PasswordVerificationRequest) => Promise<any>;
     getAccountRevisionDate: () => Promise<number>;
@@ -202,7 +202,7 @@ export abstract class ApiService {
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
     postAccountRequestOtp: () => Promise<void>;
     postAccountVerifyOtp: (request: VerifyOtpRequest) => Promise<void>;
-    postConvertToCryptoAgent: () => Promise<void>;
+    postConvertToKeyConnector: () => Promise<void>;
 
     getFolder: (id: string) => Promise<FolderResponse>;
     postFolder: (request: FolderRequest) => Promise<FolderResponse>;
@@ -453,6 +453,6 @@ export abstract class ApiService {
 
     preValidateSso: (identifier: string) => Promise<boolean>;
 
-    getUserKeyFromCryptoAgent: (cryptoAgentUrl: string) => Promise<CryptoAgentUserKeyResponse>;
-    postUserKeyToCryptoAgent: (cryptoAgentUrl: string, request: CryptoAgentUserKeyRequest) => Promise<void>;
+    getUserKeyFromKeyConnector: (keyConnectorUrl: string) => Promise<KeyConnectorUserKeyResponse>;
+    postUserKeyToKeyConnector: (keyConnectorUrl: string, request: KeyConnectorUserKeyRequest) => Promise<void>;
 }

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -1,6 +1,6 @@
 import { PolicyType } from '../enums/policyType';
 import { SetKeyConnectorKeyRequest } from '../models/request/account/setKeyConnectorKeyRequest';
-import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
+import { VerifyOTPRequest } from '../models/request/account/verifyOTPRequest';
 
 import { AttachmentRequest } from '../models/request/attachmentRequest';
 
@@ -201,7 +201,7 @@ export abstract class ApiService {
     postUserRotateApiKey: (id: string, request: SecretVerificationRequest) => Promise<ApiKeyResponse>;
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
     postAccountRequestOtp: () => Promise<void>;
-    postAccountVerifyOtp: (request: VerifyOtpRequest) => Promise<void>;
+    postAccountVerifyOtp: (request: VerifyOTPRequest) => Promise<void>;
     postConvertToKeyConnector: () => Promise<void>;
 
     getFolder: (id: string) => Promise<FolderResponse>;

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -199,6 +199,7 @@ export abstract class ApiService {
     postUserApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
     postUserRotateApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
+    postAccountRequestOtp: () => Promise<void>;
 
     getFolder: (id: string) => Promise<FolderResponse>;
     postFolder: (request: FolderRequest) => Promise<FolderResponse>;

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -202,6 +202,7 @@ export abstract class ApiService {
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
     postAccountRequestOtp: () => Promise<void>;
     postAccountVerifyOtp: (request: VerifyOtpRequest) => Promise<void>;
+    postConvertToCryptoAgent: () => Promise<void>;
 
     getFolder: (id: string) => Promise<FolderResponse>;
     postFolder: (request: FolderRequest) => Promise<FolderResponse>;

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -1,5 +1,6 @@
 import { PolicyType } from '../enums/policyType';
 import { SetCryptoAgentKeyRequest } from '../models/request/account/setCryptoAgentKeyRequest';
+import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
 
 import { AttachmentRequest } from '../models/request/attachmentRequest';
 
@@ -200,6 +201,7 @@ export abstract class ApiService {
     postUserRotateApiKey: (id: string, request: PasswordVerificationRequest) => Promise<ApiKeyResponse>;
     putUpdateTempPassword: (request: UpdateTempPasswordRequest) => Promise<any>;
     postAccountRequestOtp: () => Promise<void>;
+    postAccountVerifyOtp: (request: VerifyOtpRequest) => Promise<void>;
 
     getFolder: (id: string) => Promise<FolderResponse>;
     postFolder: (request: FolderRequest) => Promise<FolderResponse>;

--- a/common/src/abstractions/auth.service.ts
+++ b/common/src/abstractions/auth.service.ts
@@ -16,7 +16,7 @@ export abstract class AuthService {
 
     logIn: (email: string, masterPassword: string, captchaToken?: string) => Promise<AuthResult>;
     logInSso: (code: string, codeVerifier: string, redirectUrl: string, orgId: string) => Promise<AuthResult>;
-    logInApiKey: (clientId: string, clientSecret: string, orgIdentifier?: string) => Promise<AuthResult>;
+    logInApiKey: (clientId: string, clientSecret: string) => Promise<AuthResult>;
     logInTwoFactor: (twoFactorProvider: TwoFactorProviderType, twoFactorToken: string,
         remember?: boolean) => Promise<AuthResult>;
     logInComplete: (email: string, masterPassword: string, twoFactorProvider: TwoFactorProviderType,

--- a/common/src/abstractions/auth.service.ts
+++ b/common/src/abstractions/auth.service.ts
@@ -16,7 +16,7 @@ export abstract class AuthService {
 
     logIn: (email: string, masterPassword: string, captchaToken?: string) => Promise<AuthResult>;
     logInSso: (code: string, codeVerifier: string, redirectUrl: string, orgId: string) => Promise<AuthResult>;
-    logInApiKey: (clientId: string, clientSecret: string) => Promise<AuthResult>;
+    logInApiKey: (clientId: string, clientSecret: string, orgIdentifier?: string) => Promise<AuthResult>;
     logInTwoFactor: (twoFactorProvider: TwoFactorProviderType, twoFactorToken: string,
         remember?: boolean) => Promise<AuthResult>;
     logInComplete: (email: string, masterPassword: string, twoFactorProvider: TwoFactorProviderType,

--- a/common/src/abstractions/environment.service.ts
+++ b/common/src/abstractions/environment.service.ts
@@ -8,6 +8,7 @@ export type Urls = {
     icons?: string;
     notifications?: string;
     events?: string;
+    keyConnector?: string;
 };
 
 export type PayPalConfig = {
@@ -26,6 +27,7 @@ export abstract class EnvironmentService {
     getApiUrl: () => string;
     getIdentityUrl: () => string;
     getEventsUrl: () => string;
+    getKeyConnectorUrl: () => string;
     setUrlsFromStorage: () => Promise<void>;
     setUrls: (urls: any, saveSettings?: boolean) => Promise<Urls>;
     getUrls: () => Urls;

--- a/common/src/abstractions/keyConnector.service.ts
+++ b/common/src/abstractions/keyConnector.service.ts
@@ -10,5 +10,5 @@ export abstract class KeyConnectorService {
     setConvertAccountRequired: (status: boolean) => Promise<void>;
     getConvertAccountRequired: () => Promise<boolean>;
     removeConvertAccountRequired: () => Promise<void>;
-    clear: () => Promise<void>
+    clear: () => Promise<void>;
 }

--- a/common/src/abstractions/keyConnector.service.ts
+++ b/common/src/abstractions/keyConnector.service.ts
@@ -1,0 +1,10 @@
+import { Organization } from '../models/domain/organization';
+
+export abstract class KeyConnectorService {
+    getAndSetKey: (url?: string) => Promise<void>;
+    getManagingOrganization: () => Promise<Organization>;
+    getUsesKeyConnector: () => Promise<boolean>;
+    migrateUser: () => Promise<void>;
+    userNeedsMigration: () => Promise<boolean>;
+    setUsesKeyConnector: (enabled: boolean) => Promise<void>;
+}

--- a/common/src/abstractions/keyConnector.service.ts
+++ b/common/src/abstractions/keyConnector.service.ts
@@ -7,4 +7,8 @@ export abstract class KeyConnectorService {
     migrateUser: () => Promise<void>;
     userNeedsMigration: () => Promise<boolean>;
     setUsesKeyConnector: (enabled: boolean) => Promise<void>;
+    setConvertAccountRequired: (status: boolean) => Promise<void>;
+    getConvertAccountRequired: () => Promise<boolean>;
+    removeConvertAccountRequired: () => Promise<void>;
+    clear: () => Promise<void>
 }

--- a/common/src/abstractions/passwordReprompt.service.ts
+++ b/common/src/abstractions/passwordReprompt.service.ts
@@ -1,4 +1,5 @@
 export abstract class PasswordRepromptService {
     protectedFields: () => string[];
     showPasswordPrompt: () => Promise<boolean>;
+    enabled: () => Promise<boolean>;
 }

--- a/common/src/abstractions/token.service.ts
+++ b/common/src/abstractions/token.service.ts
@@ -26,4 +26,5 @@ export abstract class TokenService {
     getName: () => string;
     getPremium: () => boolean;
     getIssuer: () => string;
+    getIsExternal: () => boolean;
 }

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -1,9 +1,14 @@
 import { OrganizationData } from '../models/data/organizationData';
 import { ProviderData } from '../models/data/providerData';
+
 import { Organization } from '../models/domain/organization';
 import { Provider } from '../models/domain/provider';
 
+import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
+
 import { KdfType } from '../enums/kdfType';
+
+import { Verification } from '../types/verification';
 
 export abstract class UserService {
     setInformation: (userId: string, email: string, kdf: KdfType, kdfIterations: number) => Promise<any>;
@@ -31,4 +36,6 @@ export abstract class UserService {
     getAllProviders: () => Promise<Provider[]>;
     replaceProviders: (providers: { [id: string]: ProviderData; }) => Promise<any>;
     clearProviders: (userId: string) => Promise<any>;
+    buildVerificationRequest: <T extends PasswordVerificationRequest> (verification: Verification,
+        requestClass?: new () => T, alreadyEncrypted?: boolean) => Promise<T>;
 }

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -36,4 +36,5 @@ export abstract class UserService {
     getAllProviders: () => Promise<Provider[]>;
     replaceProviders: (providers: { [id: string]: ProviderData; }) => Promise<any>;
     clearProviders: (userId: string) => Promise<any>;
+    mustConvertToKeyConnector: () => Promise<boolean>;
 }

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -36,6 +36,4 @@ export abstract class UserService {
     getAllProviders: () => Promise<Provider[]>;
     replaceProviders: (providers: { [id: string]: ProviderData; }) => Promise<any>;
     clearProviders: (userId: string) => Promise<any>;
-    buildVerificationRequest: <T extends PasswordVerificationRequest> (verification: Verification,
-        requestClass?: new () => T, alreadyEncrypted?: boolean) => Promise<T>;
 }

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -15,7 +15,7 @@ export abstract class UserService {
     setEmailVerified: (emailVerified: boolean) => Promise<any>;
     setSecurityStamp: (stamp: string) => Promise<any>;
     setForcePasswordReset: (forcePasswordReset: boolean) => Promise<any>;
-    setUsesCryptoAgent: (usesCryptoAgent: boolean) => Promise<void>;
+    setUsesKeyConnector: (usesKeyConnector: boolean) => Promise<void>;
     getUserId: () => Promise<string>;
     getEmail: () => Promise<string>;
     getSecurityStamp: () => Promise<string>;
@@ -23,7 +23,7 @@ export abstract class UserService {
     getKdfIterations: () => Promise<number>;
     getEmailVerified: () => Promise<boolean>;
     getForcePasswordReset: () => Promise<boolean>;
-    getUsesCryptoAgent: () => Promise<boolean>;
+    getUsesKeyConnector: () => Promise<boolean>;
     clear: () => Promise<any>;
     isAuthenticated: () => Promise<boolean>;
     canAccessPremium: () => Promise<boolean>;

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -10,6 +10,7 @@ export abstract class UserService {
     setEmailVerified: (emailVerified: boolean) => Promise<any>;
     setSecurityStamp: (stamp: string) => Promise<any>;
     setForcePasswordReset: (forcePasswordReset: boolean) => Promise<any>;
+    setUsesCryptoAgent: (usesCryptoAgent: boolean) => Promise<void>;
     getUserId: () => Promise<string>;
     getEmail: () => Promise<string>;
     getSecurityStamp: () => Promise<string>;
@@ -17,6 +18,7 @@ export abstract class UserService {
     getKdfIterations: () => Promise<number>;
     getEmailVerified: () => Promise<boolean>;
     getForcePasswordReset: () => Promise<boolean>;
+    getUsesCryptoAgent: () => Promise<boolean>;
     clear: () => Promise<any>;
     isAuthenticated: () => Promise<boolean>;
     canAccessPremium: () => Promise<boolean>;

--- a/common/src/abstractions/user.service.ts
+++ b/common/src/abstractions/user.service.ts
@@ -4,18 +4,13 @@ import { ProviderData } from '../models/data/providerData';
 import { Organization } from '../models/domain/organization';
 import { Provider } from '../models/domain/provider';
 
-import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
-
 import { KdfType } from '../enums/kdfType';
-
-import { Verification } from '../types/verification';
 
 export abstract class UserService {
     setInformation: (userId: string, email: string, kdf: KdfType, kdfIterations: number) => Promise<any>;
     setEmailVerified: (emailVerified: boolean) => Promise<any>;
     setSecurityStamp: (stamp: string) => Promise<any>;
     setForcePasswordReset: (forcePasswordReset: boolean) => Promise<any>;
-    setUsesKeyConnector: (usesKeyConnector: boolean) => Promise<void>;
     getUserId: () => Promise<string>;
     getEmail: () => Promise<string>;
     getSecurityStamp: () => Promise<string>;
@@ -23,7 +18,6 @@ export abstract class UserService {
     getKdfIterations: () => Promise<number>;
     getEmailVerified: () => Promise<boolean>;
     getForcePasswordReset: () => Promise<boolean>;
-    getUsesKeyConnector: () => Promise<boolean>;
     clear: () => Promise<any>;
     isAuthenticated: () => Promise<boolean>;
     canAccessPremium: () => Promise<boolean>;
@@ -36,5 +30,4 @@ export abstract class UserService {
     getAllProviders: () => Promise<Provider[]>;
     replaceProviders: (providers: { [id: string]: ProviderData; }) => Promise<any>;
     clearProviders: (userId: string) => Promise<any>;
-    mustConvertToKeyConnector: () => Promise<boolean>;
 }

--- a/common/src/abstractions/userVerification.service.ts
+++ b/common/src/abstractions/userVerification.service.ts
@@ -1,9 +1,9 @@
-import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
+import { SecretVerificationRequest } from '../models/request/secretVerificationRequest';
 
 import { Verification } from '../types/verification';
 
 export abstract class UserVerificationService {
-    buildRequest: <T extends PasswordVerificationRequest> (verification: Verification,
+    buildRequest: <T extends SecretVerificationRequest> (verification: Verification,
         requestClass?: new () => T, alreadyHashed?: boolean) => Promise<T>;
     verifyUser: (verification: Verification) => Promise<boolean>;
 }

--- a/common/src/abstractions/userVerification.service.ts
+++ b/common/src/abstractions/userVerification.service.ts
@@ -1,0 +1,8 @@
+import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
+
+import { Verification } from '../types/verification';
+
+export abstract class UserVerificationService {
+    buildRequest: <T extends PasswordVerificationRequest> (verification: Verification,
+        requestClass?: new () => T, alreadyEncrypted?: boolean) => Promise<T>;
+}

--- a/common/src/abstractions/userVerification.service.ts
+++ b/common/src/abstractions/userVerification.service.ts
@@ -4,6 +4,6 @@ import { Verification } from '../types/verification';
 
 export abstract class UserVerificationService {
     buildRequest: <T extends PasswordVerificationRequest> (verification: Verification,
-        requestClass?: new () => T, alreadyEncrypted?: boolean) => Promise<T>;
+        requestClass?: new () => T, alreadyHashed?: boolean) => Promise<T>;
     verifyUser: (verification: Verification) => Promise<boolean>;
 }

--- a/common/src/abstractions/userVerification.service.ts
+++ b/common/src/abstractions/userVerification.service.ts
@@ -5,4 +5,5 @@ import { Verification } from '../types/verification';
 export abstract class UserVerificationService {
     buildRequest: <T extends PasswordVerificationRequest> (verification: Verification,
         requestClass?: new () => T, alreadyEncrypted?: boolean) => Promise<T>;
+    verifyUser: (verification: Verification) => Promise<boolean>;
 }

--- a/common/src/enums/eventType.ts
+++ b/common/src/enums/eventType.ts
@@ -8,6 +8,7 @@ export enum EventType {
     User_FailedLogIn2fa = 1006,
     User_ClientExportedVault = 1007,
     User_UpdatedTempPassword = 1008,
+    User_MigratedKeyToKeyConnector = 1009,
 
     Cipher_Created = 1100,
     Cipher_Updated = 1101,

--- a/common/src/enums/eventType.ts
+++ b/common/src/enums/eventType.ts
@@ -46,7 +46,6 @@ export enum EventType {
     OrganizationUser_ResetPassword_Withdraw = 1507,
     OrganizationUser_AdminResetPassword = 1508,
     OrganizationUser_ResetSsoLink = 1509,
-    OrganizationUser_LinkedSso = 1510,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,

--- a/common/src/enums/eventType.ts
+++ b/common/src/enums/eventType.ts
@@ -46,11 +46,16 @@ export enum EventType {
     OrganizationUser_ResetPassword_Withdraw = 1507,
     OrganizationUser_AdminResetPassword = 1508,
     OrganizationUser_ResetSsoLink = 1509,
+    OrganizationUser_LinkedSso = 1510,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,
     // Organization_ClientExportedVault = 1602,
     Organization_VaultAccessed = 1603,
+    Organization_EnabledSso = 1604,
+    Organization_DisabledSso = 1605,
+    Organization_EnabledKeyConnector = 1606,
+    Organization_DisabledKeyConnector = 1607,
 
     Policy_Updated = 1700,
 

--- a/common/src/enums/verificationType.ts
+++ b/common/src/enums/verificationType.ts
@@ -1,0 +1,4 @@
+export enum VerificationType {
+    MasterPassword = 0,
+    OTP = 1,
+}

--- a/common/src/models/api/ssoConfigApi.ts
+++ b/common/src/models/api/ssoConfigApi.ts
@@ -37,8 +37,8 @@ enum Saml2SigningBehavior {
 export class SsoConfigApi extends BaseResponse {
     configType: SsoType;
 
-    useCryptoAgent: boolean;
-    cryptoAgentUrl: string;
+    useKeyConnector: boolean;
+    keyConnectorUrl: string;
 
     // OpenId
     authority: string;
@@ -81,8 +81,8 @@ export class SsoConfigApi extends BaseResponse {
 
         this.configType = this.getResponseProperty('ConfigType');
 
-        this.useCryptoAgent = this.getResponseProperty('UseCryptoAgent');
-        this.cryptoAgentUrl = this.getResponseProperty('CryptoAgentUrl');
+        this.useKeyConnector = this.getResponseProperty('UseKeyConnector');
+        this.keyConnectorUrl = this.getResponseProperty('KeyConnectorUrl');
 
         this.authority = this.getResponseProperty('Authority');
         this.clientId = this.getResponseProperty('ClientId');

--- a/common/src/models/data/organizationData.ts
+++ b/common/src/models/data/organizationData.ts
@@ -33,8 +33,8 @@ export class OrganizationData {
     providerId: string;
     providerName: string;
     isProviderUser: boolean;
-    usesCryptoAgent: boolean;
-    cryptoAgentUrl: string;
+    usesKeyConnector: boolean;
+    keyConnectorUrl: string;
 
     constructor(response: ProfileOrganizationResponse) {
         this.id = response.id;
@@ -64,7 +64,7 @@ export class OrganizationData {
         this.hasPublicAndPrivateKeys = response.hasPublicAndPrivateKeys;
         this.providerId = response.providerId;
         this.providerName = response.providerName;
-        this.usesCryptoAgent = response.usesCryptoAgent;
-        this.cryptoAgentUrl = response.cryptoAgentUrl;
+        this.usesKeyConnector = response.usesKeyConnector;
+        this.keyConnectorUrl = response.keyConnectorUrl;
     }
 }

--- a/common/src/models/data/organizationData.ts
+++ b/common/src/models/data/organizationData.ts
@@ -33,6 +33,7 @@ export class OrganizationData {
     providerId: string;
     providerName: string;
     isProviderUser: boolean;
+    cryptoAgentUrl: string;
 
     constructor(response: ProfileOrganizationResponse) {
         this.id = response.id;
@@ -62,5 +63,6 @@ export class OrganizationData {
         this.hasPublicAndPrivateKeys = response.hasPublicAndPrivateKeys;
         this.providerId = response.providerId;
         this.providerName = response.providerName;
+        this.cryptoAgentUrl = response.cryptoAgentUrl;
     }
 }

--- a/common/src/models/data/organizationData.ts
+++ b/common/src/models/data/organizationData.ts
@@ -33,6 +33,7 @@ export class OrganizationData {
     providerId: string;
     providerName: string;
     isProviderUser: boolean;
+    usesCryptoAgent: boolean;
     cryptoAgentUrl: string;
 
     constructor(response: ProfileOrganizationResponse) {
@@ -63,6 +64,7 @@ export class OrganizationData {
         this.hasPublicAndPrivateKeys = response.hasPublicAndPrivateKeys;
         this.providerId = response.providerId;
         this.providerName = response.providerName;
+        this.usesCryptoAgent = response.usesCryptoAgent;
         this.cryptoAgentUrl = response.cryptoAgentUrl;
     }
 }

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -34,8 +34,8 @@ export class Organization {
     providerId: string;
     providerName: string;
     isProviderUser: boolean;
-    usesCryptoAgent: boolean;
-    cryptoAgentUrl: string;
+    usesKeyConnector: boolean;
+    keyConnectorUrl: string;
 
     constructor(obj?: OrganizationData) {
         if (obj == null) {
@@ -70,8 +70,8 @@ export class Organization {
         this.providerId = obj.providerId;
         this.providerName = obj.providerName;
         this.isProviderUser = obj.isProviderUser;
-        this.usesCryptoAgent = obj.usesCryptoAgent;
-        this.cryptoAgentUrl = obj.cryptoAgentUrl;
+        this.usesKeyConnector = obj.usesKeyConnector;
+        this.keyConnectorUrl = obj.keyConnectorUrl;
     }
 
     get canAccess() {

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -70,7 +70,7 @@ export class Organization {
         this.providerId = obj.providerId;
         this.providerName = obj.providerName;
         this.isProviderUser = obj.isProviderUser;
-        this.usesCryptoAgent = obj.cryptoAgentUrl
+        this.usesCryptoAgent = obj.usesCryptoAgent
         this.cryptoAgentUrl = obj.cryptoAgentUrl;
     }
 

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -70,7 +70,7 @@ export class Organization {
         this.providerId = obj.providerId;
         this.providerName = obj.providerName;
         this.isProviderUser = obj.isProviderUser;
-        this.usesCryptoAgent = obj.usesCryptoAgent
+        this.usesCryptoAgent = obj.usesCryptoAgent;
         this.cryptoAgentUrl = obj.cryptoAgentUrl;
     }
 

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -34,6 +34,7 @@ export class Organization {
     providerId: string;
     providerName: string;
     isProviderUser: boolean;
+    usesCryptoAgent: boolean;
     cryptoAgentUrl: string;
 
     constructor(obj?: OrganizationData) {
@@ -69,6 +70,7 @@ export class Organization {
         this.providerId = obj.providerId;
         this.providerName = obj.providerName;
         this.isProviderUser = obj.isProviderUser;
+        this.usesCryptoAgent = obj.cryptoAgentUrl
         this.cryptoAgentUrl = obj.cryptoAgentUrl;
     }
 

--- a/common/src/models/domain/organization.ts
+++ b/common/src/models/domain/organization.ts
@@ -34,6 +34,7 @@ export class Organization {
     providerId: string;
     providerName: string;
     isProviderUser: boolean;
+    cryptoAgentUrl: string;
 
     constructor(obj?: OrganizationData) {
         if (obj == null) {
@@ -68,6 +69,7 @@ export class Organization {
         this.providerId = obj.providerId;
         this.providerName = obj.providerName;
         this.isProviderUser = obj.isProviderUser;
+        this.cryptoAgentUrl = obj.cryptoAgentUrl;
     }
 
     get canAccess() {

--- a/common/src/models/request/account/setKeyConnectorKeyRequest.ts
+++ b/common/src/models/request/account/setKeyConnectorKeyRequest.ts
@@ -2,7 +2,7 @@ import { KeysRequest } from '../keysRequest';
 
 import { KdfType } from '../../../enums/kdfType';
 
-export class SetCryptoAgentKeyRequest {
+export class SetKeyConnectorKeyRequest {
     key: string;
     keys: KeysRequest;
     kdf: KdfType;

--- a/common/src/models/request/account/verifyOTPRequest.ts
+++ b/common/src/models/request/account/verifyOTPRequest.ts
@@ -1,0 +1,7 @@
+export class VerifyOTPRequest {
+    OTP: string;
+
+    constructor(OTP: string) {
+        this.OTP = OTP;
+    }
+}

--- a/common/src/models/request/account/verifyOtpRequest.ts
+++ b/common/src/models/request/account/verifyOtpRequest.ts
@@ -1,0 +1,7 @@
+export class VerifyOtpRequest {
+    otp: string;
+
+    constructor(otp: string) {
+        this.otp = otp;
+    }
+}

--- a/common/src/models/request/account/verifyOtpRequest.ts
+++ b/common/src/models/request/account/verifyOtpRequest.ts
@@ -1,7 +1,0 @@
-export class VerifyOtpRequest {
-    otp: string;
-
-    constructor(otp: string) {
-        this.otp = otp;
-    }
-}

--- a/common/src/models/request/emailTokenRequest.ts
+++ b/common/src/models/request/emailTokenRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class EmailTokenRequest extends PasswordVerificationRequest {
+export class EmailTokenRequest extends SecretVerificationRequest {
     newEmail: string;
     masterPasswordHash: string;
 }

--- a/common/src/models/request/keyConnectorUserKeyRequest.ts
+++ b/common/src/models/request/keyConnectorUserKeyRequest.ts
@@ -1,4 +1,4 @@
-export class CryptoAgentUserKeyRequest {
+export class KeyConnectorUserKeyRequest {
     key: string;
 
     constructor(key: string) {

--- a/common/src/models/request/passwordRequest.ts
+++ b/common/src/models/request/passwordRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class PasswordRequest extends PasswordVerificationRequest {
+export class PasswordRequest extends SecretVerificationRequest {
     newMasterPasswordHash: string;
     key: string;
 }

--- a/common/src/models/request/passwordVerificationRequest.ts
+++ b/common/src/models/request/passwordVerificationRequest.ts
@@ -1,4 +1,19 @@
+import { VerificationType } from '../../enums/verificationType';
+
+export type Verification = {
+    type: VerificationType,
+    secret: string,
+};
+
 export class PasswordVerificationRequest {
     masterPasswordHash: string;
     otp: string;
+
+    constructor(verification: Verification) {
+        if (verification.type === VerificationType.MasterPassword) {
+            this.masterPasswordHash = verification.secret;
+        } else {
+            this.otp = verification.secret;
+        }
+    }
 }

--- a/common/src/models/request/passwordVerificationRequest.ts
+++ b/common/src/models/request/passwordVerificationRequest.ts
@@ -1,19 +1,4 @@
-import { VerificationType } from '../../enums/verificationType';
-
-export type Verification = {
-    type: VerificationType,
-    secret: string,
-};
-
 export class PasswordVerificationRequest {
     masterPasswordHash: string;
     otp: string;
-
-    constructor(verification: Verification) {
-        if (verification.type === VerificationType.MasterPassword) {
-            this.masterPasswordHash = verification.secret;
-        } else {
-            this.otp = verification.secret;
-        }
-    }
 }

--- a/common/src/models/request/passwordVerificationRequest.ts
+++ b/common/src/models/request/passwordVerificationRequest.ts
@@ -1,3 +1,4 @@
 export class PasswordVerificationRequest {
     masterPasswordHash: string;
+    otp: string;
 }

--- a/common/src/models/request/secretVerificationRequest.ts
+++ b/common/src/models/request/secretVerificationRequest.ts
@@ -1,4 +1,4 @@
-export class PasswordVerificationRequest {
+export class SecretVerificationRequest {
     masterPasswordHash: string;
     otp: string;
 }

--- a/common/src/models/request/tokenRequest.ts
+++ b/common/src/models/request/tokenRequest.ts
@@ -14,9 +14,11 @@ export class TokenRequest implements CaptchaProtectedRequest {
     clientId: string;
     clientSecret: string;
     device?: DeviceRequest;
+    orgIdentifier?: string;
 
     constructor(credentials: string[], codes: string[], clientIdClientSecret: string[], public provider: TwoFactorProviderType,
-        public token: string, public remember: boolean, public captchaResponse: string, device?: DeviceRequest) {
+        public token: string, public remember: boolean, public captchaResponse: string, device?: DeviceRequest,
+        orgIdentifier?: string) {
         if (credentials != null && credentials.length > 1) {
             this.email = credentials[0];
             this.masterPasswordHash = credentials[1];
@@ -27,6 +29,7 @@ export class TokenRequest implements CaptchaProtectedRequest {
         } else if (clientIdClientSecret != null && clientIdClientSecret.length > 1) {
             this.clientId = clientIdClientSecret[0];
             this.clientSecret = clientIdClientSecret[1];
+            this.orgIdentifier = orgIdentifier;
         }
         this.device = device != null ? device : null;
     }
@@ -41,6 +44,7 @@ export class TokenRequest implements CaptchaProtectedRequest {
             obj.scope = clientId.startsWith('organization') ? 'api.organization' : 'api';
             obj.grant_type = 'client_credentials';
             obj.client_secret = this.clientSecret;
+            obj.org_identifier = this.orgIdentifier;
         } else if (this.masterPasswordHash != null && this.email != null) {
             obj.grant_type = 'password';
             obj.username = this.email;

--- a/common/src/models/request/tokenRequest.ts
+++ b/common/src/models/request/tokenRequest.ts
@@ -14,11 +14,9 @@ export class TokenRequest implements CaptchaProtectedRequest {
     clientId: string;
     clientSecret: string;
     device?: DeviceRequest;
-    orgIdentifier?: string;
 
     constructor(credentials: string[], codes: string[], clientIdClientSecret: string[], public provider: TwoFactorProviderType,
-        public token: string, public remember: boolean, public captchaResponse: string, device?: DeviceRequest,
-        orgIdentifier?: string) {
+        public token: string, public remember: boolean, public captchaResponse: string, device?: DeviceRequest) {
         if (credentials != null && credentials.length > 1) {
             this.email = credentials[0];
             this.masterPasswordHash = credentials[1];
@@ -29,7 +27,6 @@ export class TokenRequest implements CaptchaProtectedRequest {
         } else if (clientIdClientSecret != null && clientIdClientSecret.length > 1) {
             this.clientId = clientIdClientSecret[0];
             this.clientSecret = clientIdClientSecret[1];
-            this.orgIdentifier = orgIdentifier;
         }
         this.device = device != null ? device : null;
     }
@@ -44,7 +41,6 @@ export class TokenRequest implements CaptchaProtectedRequest {
             obj.scope = clientId.startsWith('organization') ? 'api.organization' : 'api';
             obj.grant_type = 'client_credentials';
             obj.client_secret = this.clientSecret;
-            obj.org_identifier = this.orgIdentifier;
         } else if (this.masterPasswordHash != null && this.email != null) {
             obj.grant_type = 'password';
             obj.username = this.email;

--- a/common/src/models/request/twoFactorEmailRequest.ts
+++ b/common/src/models/request/twoFactorEmailRequest.ts
@@ -2,10 +2,4 @@ import { PasswordVerificationRequest } from './passwordVerificationRequest';
 
 export class TwoFactorEmailRequest extends PasswordVerificationRequest {
     email: string;
-
-    constructor(email: string, masterPasswordHash: string) {
-        super();
-        this.masterPasswordHash = masterPasswordHash;
-        this.email = email;
-    }
 }

--- a/common/src/models/request/twoFactorEmailRequest.ts
+++ b/common/src/models/request/twoFactorEmailRequest.ts
@@ -1,5 +1,5 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class TwoFactorEmailRequest extends PasswordVerificationRequest {
+export class TwoFactorEmailRequest extends SecretVerificationRequest {
     email: string;
 }

--- a/common/src/models/request/twoFactorProviderRequest.ts
+++ b/common/src/models/request/twoFactorProviderRequest.ts
@@ -1,7 +1,7 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
 import { TwoFactorProviderType } from '../../enums/twoFactorProviderType';
 
-export class TwoFactorProviderRequest extends PasswordVerificationRequest {
+export class TwoFactorProviderRequest extends SecretVerificationRequest {
     type: TwoFactorProviderType;
 }

--- a/common/src/models/request/twoFactorRecoveryRequest.ts
+++ b/common/src/models/request/twoFactorRecoveryRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class TwoFactorRecoveryRequest extends PasswordVerificationRequest {
+export class TwoFactorRecoveryRequest extends SecretVerificationRequest {
     recoveryCode: string;
     email: string;
 }

--- a/common/src/models/request/updateTwoFactorAuthenticatorRequest.ts
+++ b/common/src/models/request/updateTwoFactorAuthenticatorRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class UpdateTwoFactorAuthenticatorRequest extends PasswordVerificationRequest {
+export class UpdateTwoFactorAuthenticatorRequest extends SecretVerificationRequest {
     token: string;
     key: string;
 }

--- a/common/src/models/request/updateTwoFactorDuoRequest.ts
+++ b/common/src/models/request/updateTwoFactorDuoRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class UpdateTwoFactorDuoRequest extends PasswordVerificationRequest {
+export class UpdateTwoFactorDuoRequest extends SecretVerificationRequest {
     integrationKey: string;
     secretKey: string;
     host: string;

--- a/common/src/models/request/updateTwoFactorEmailRequest.ts
+++ b/common/src/models/request/updateTwoFactorEmailRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class UpdateTwoFactorEmailRequest extends PasswordVerificationRequest {
+export class UpdateTwoFactorEmailRequest extends SecretVerificationRequest {
     token: string;
     email: string;
 }

--- a/common/src/models/request/updateTwoFactorWebAuthnDeleteRequest.ts
+++ b/common/src/models/request/updateTwoFactorWebAuthnDeleteRequest.ts
@@ -1,5 +1,5 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class UpdateTwoFactorWebAuthnDeleteRequest extends PasswordVerificationRequest {
+export class UpdateTwoFactorWebAuthnDeleteRequest extends SecretVerificationRequest {
     id: number;
 }

--- a/common/src/models/request/updateTwoFactorWebAuthnRequest.ts
+++ b/common/src/models/request/updateTwoFactorWebAuthnRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class UpdateTwoFactorWebAuthnRequest extends PasswordVerificationRequest {
+export class UpdateTwoFactorWebAuthnRequest extends SecretVerificationRequest {
     deviceResponse: PublicKeyCredential;
     name: string;
     id: number;

--- a/common/src/models/request/updateTwoFactorYubioOtpRequest.ts
+++ b/common/src/models/request/updateTwoFactorYubioOtpRequest.ts
@@ -1,6 +1,6 @@
-import { PasswordVerificationRequest } from './passwordVerificationRequest';
+import { SecretVerificationRequest } from './secretVerificationRequest';
 
-export class UpdateTwoFactorYubioOtpRequest extends PasswordVerificationRequest {
+export class UpdateTwoFactorYubioOtpRequest extends SecretVerificationRequest {
     key1: string;
     key2: string;
     key3: string;

--- a/common/src/models/response/identityTokenResponse.ts
+++ b/common/src/models/response/identityTokenResponse.ts
@@ -15,7 +15,7 @@ export class IdentityTokenResponse extends BaseResponse {
     kdf: KdfType;
     kdfIterations: number;
     forcePasswordReset: boolean;
-    cryptoAgentUrl: string;
+    keyConnectorUrl: string;
 
     constructor(response: any) {
         super(response);
@@ -31,6 +31,6 @@ export class IdentityTokenResponse extends BaseResponse {
         this.kdf = this.getResponseProperty('Kdf');
         this.kdfIterations = this.getResponseProperty('KdfIterations');
         this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset');
-        this.cryptoAgentUrl = this.getResponseProperty('CryptoAgentUrl');
+        this.keyConnectorUrl = this.getResponseProperty('KeyConnectorUrl');
     }
 }

--- a/common/src/models/response/keyConnectorUserKeyResponse.ts
+++ b/common/src/models/response/keyConnectorUserKeyResponse.ts
@@ -1,6 +1,6 @@
 import { BaseResponse } from './baseResponse';
 
-export class CryptoAgentUserKeyResponse extends BaseResponse {
+export class KeyConnectorUserKeyResponse extends BaseResponse {
     key: string;
 
     constructor(response: any) {

--- a/common/src/models/response/profileOrganizationResponse.ts
+++ b/common/src/models/response/profileOrganizationResponse.ts
@@ -33,6 +33,8 @@ export class ProfileOrganizationResponse extends BaseResponse {
     userId: string;
     providerId: string;
     providerName: string;
+    usesCryptoAgent: boolean;
+    cryptoAgentUrl: string;
 
     constructor(response: any) {
         super(response);
@@ -64,5 +66,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
         this.userId = this.getResponseProperty('UserId');
         this.providerId = this.getResponseProperty('ProviderId');
         this.providerName = this.getResponseProperty('ProviderName');
+        this.usesCryptoAgent = this.getResponseProperty('UsesCryptoAgent') ?? false;
+        this.cryptoAgentUrl = this.getResponseProperty('CryptoAgentUrl');
     }
 }

--- a/common/src/models/response/profileOrganizationResponse.ts
+++ b/common/src/models/response/profileOrganizationResponse.ts
@@ -33,8 +33,8 @@ export class ProfileOrganizationResponse extends BaseResponse {
     userId: string;
     providerId: string;
     providerName: string;
-    usesCryptoAgent: boolean;
-    cryptoAgentUrl: string;
+    usesKeyConnector: boolean;
+    keyConnectorUrl: string;
 
     constructor(response: any) {
         super(response);
@@ -66,7 +66,7 @@ export class ProfileOrganizationResponse extends BaseResponse {
         this.userId = this.getResponseProperty('UserId');
         this.providerId = this.getResponseProperty('ProviderId');
         this.providerName = this.getResponseProperty('ProviderName');
-        this.usesCryptoAgent = this.getResponseProperty('UsesCryptoAgent') ?? false;
-        this.cryptoAgentUrl = this.getResponseProperty('CryptoAgentUrl');
+        this.usesKeyConnector = this.getResponseProperty('UsesKeyConnector') ?? false;
+        this.keyConnectorUrl = this.getResponseProperty('KeyConnectorUrl');
     }
 }

--- a/common/src/models/response/profileProviderOrganizationResponse.ts
+++ b/common/src/models/response/profileProviderOrganizationResponse.ts
@@ -3,6 +3,6 @@ import { ProfileOrganizationResponse } from './profileOrganizationResponse';
 export class ProfileProviderOrganizationResponse extends ProfileOrganizationResponse {
     constructor(response: any) {
         super(response);
-        this.usesCryptoAgent = false;
+        this.usesKeyConnector = false;
     }
 }

--- a/common/src/models/response/profileProviderOrganizationResponse.ts
+++ b/common/src/models/response/profileProviderOrganizationResponse.ts
@@ -1,68 +1,8 @@
-import { BaseResponse } from './baseResponse';
+import { ProfileOrganizationResponse } from './profileOrganizationResponse';
 
-import { OrganizationUserStatusType } from '../../enums/organizationUserStatusType';
-import { OrganizationUserType } from '../../enums/organizationUserType';
-import { PermissionsApi } from '../api/permissionsApi';
-
-export class ProfileProviderOrganizationResponse extends BaseResponse {
-    id: string;
-    name: string;
-    usePolicies: boolean;
-    useGroups: boolean;
-    useDirectory: boolean;
-    useEvents: boolean;
-    useTotp: boolean;
-    use2fa: boolean;
-    useApi: boolean;
-    useSso: boolean;
-    useResetPassword: boolean;
-    selfHost: boolean;
-    usersGetPremium: boolean;
-    seats: number;
-    maxCollections: number;
-    maxStorageGb?: number;
-    key: string;
-    hasPublicAndPrivateKeys: boolean;
-    status: OrganizationUserStatusType;
-    type: OrganizationUserType;
-    enabled: boolean;
-    ssoBound: boolean;
-    identifier: string;
-    permissions: PermissionsApi;
-    resetPasswordEnrolled: boolean;
-    userId: string;
-    providerId: string;
-    providerName: string;
-
+export class ProfileProviderOrganizationResponse extends ProfileOrganizationResponse {
     constructor(response: any) {
         super(response);
-        this.id = this.getResponseProperty('Id');
-        this.name = this.getResponseProperty('Name');
-        this.usePolicies = this.getResponseProperty('UsePolicies');
-        this.useGroups = this.getResponseProperty('UseGroups');
-        this.useDirectory = this.getResponseProperty('UseDirectory');
-        this.useEvents = this.getResponseProperty('UseEvents');
-        this.useTotp = this.getResponseProperty('UseTotp');
-        this.use2fa = this.getResponseProperty('Use2fa');
-        this.useApi = this.getResponseProperty('UseApi');
-        this.useSso = this.getResponseProperty('UseSso');
-        this.useResetPassword = this.getResponseProperty('UseResetPassword');
-        this.selfHost = this.getResponseProperty('SelfHost');
-        this.usersGetPremium = this.getResponseProperty('UsersGetPremium');
-        this.seats = this.getResponseProperty('Seats');
-        this.maxCollections = this.getResponseProperty('MaxCollections');
-        this.maxStorageGb = this.getResponseProperty('MaxStorageGb');
-        this.key = this.getResponseProperty('Key');
-        this.hasPublicAndPrivateKeys = this.getResponseProperty('HasPublicAndPrivateKeys');
-        this.status = this.getResponseProperty('Status');
-        this.type = this.getResponseProperty('Type');
-        this.enabled = this.getResponseProperty('Enabled');
-        this.ssoBound = this.getResponseProperty('SsoBound');
-        this.identifier = this.getResponseProperty('Identifier');
-        this.permissions = new PermissionsApi(this.getResponseProperty('permissions'));
-        this.resetPasswordEnrolled = this.getResponseProperty('ResetPasswordEnrolled');
-        this.userId = this.getResponseProperty('UserId');
-        this.providerId = this.getResponseProperty('ProviderId');
-        this.providerName = this.getResponseProperty('ProviderName');
+        this.usesCryptoAgent = false;
     }
 }

--- a/common/src/models/response/profileResponse.ts
+++ b/common/src/models/response/profileResponse.ts
@@ -16,7 +16,7 @@ export class ProfileResponse extends BaseResponse {
     privateKey: string;
     securityStamp: string;
     forcePasswordReset: boolean;
-    usesCryptoAgent: boolean;
+    usesKeyConnector: boolean;
     organizations: ProfileOrganizationResponse[] = [];
     providers: ProfileProviderResponse[] = [];
     providerOrganizations: ProfileProviderOrganizationResponse[] = [];
@@ -35,7 +35,7 @@ export class ProfileResponse extends BaseResponse {
         this.privateKey = this.getResponseProperty('PrivateKey');
         this.securityStamp = this.getResponseProperty('SecurityStamp');
         this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset') ?? false;
-        this.usesCryptoAgent = this.getResponseProperty('UsesCryptoAgent') ?? false;
+        this.usesKeyConnector = this.getResponseProperty('UsesKeyConnector') ?? false;
 
         const organizations = this.getResponseProperty('Organizations');
         if (organizations != null) {

--- a/common/src/models/response/profileResponse.ts
+++ b/common/src/models/response/profileResponse.ts
@@ -16,6 +16,7 @@ export class ProfileResponse extends BaseResponse {
     privateKey: string;
     securityStamp: string;
     forcePasswordReset: boolean;
+    usesCryptoAgent: boolean;
     organizations: ProfileOrganizationResponse[] = [];
     providers: ProfileProviderResponse[] = [];
     providerOrganizations: ProfileProviderOrganizationResponse[] = [];
@@ -34,6 +35,7 @@ export class ProfileResponse extends BaseResponse {
         this.privateKey = this.getResponseProperty('PrivateKey');
         this.securityStamp = this.getResponseProperty('SecurityStamp');
         this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset') ?? false;
+        this.usesCryptoAgent = this.getResponseProperty('UsesCryptoAgent') ?? false;
 
         const organizations = this.getResponseProperty('Organizations');
         if (organizations != null) {

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -170,6 +170,7 @@ import { SetCryptoAgentKeyRequest } from '../models/request/account/setCryptoAge
 import { CryptoAgentUserKeyRequest } from '../models/request/cryptoAgentUserKeyRequest';
 import { CryptoAgentUserKeyResponse } from '../models/response/cryptoAgentUserKeyResponse';
 import { SendAccessView } from '../models/view/sendAccessView';
+import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
 
 export class ApiService implements ApiServiceAbstraction {
     protected apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>;
@@ -403,6 +404,10 @@ export class ApiService implements ApiServiceAbstraction {
 
     postAccountRequestOtp(): Promise<void> {
         return this.send('POST', '/accounts/request-otp', null, true, false);
+    }
+
+    postAccountVerifyOtp(request: VerifyOtpRequest): Promise<void> {
+        return this.send('POST', '/accounts/verify-otp', request, true, false);
     }
 
     // Folder APIs

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -167,10 +167,10 @@ import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyRes
 import { UserKeyResponse } from '../models/response/userKeyResponse';
 
 import { SetCryptoAgentKeyRequest } from '../models/request/account/setCryptoAgentKeyRequest';
+import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
 import { CryptoAgentUserKeyRequest } from '../models/request/cryptoAgentUserKeyRequest';
 import { CryptoAgentUserKeyResponse } from '../models/response/cryptoAgentUserKeyResponse';
 import { SendAccessView } from '../models/view/sendAccessView';
-import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
 
 export class ApiService implements ApiServiceAbstraction {
     protected apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>;

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -173,7 +173,7 @@ import { KeyConnectorUserKeyResponse } from '../models/response/keyConnectorUser
 import { SendAccessView } from '../models/view/sendAccessView';
 
 export class ApiService implements ApiServiceAbstraction {
-    protected apiKeyRefresh: (clientId: string, clientSecret: string, orgIdentifier?: string) => Promise<any>;
+    protected apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>;
     private device: DeviceType;
     private deviceType: string;
     private isWebClient = false;
@@ -1561,13 +1561,11 @@ export class ApiService implements ApiServiceAbstraction {
     protected async doApiTokenRefresh(): Promise<void> {
         const clientId = await this.tokenService.getClientId();
         const clientSecret = await this.tokenService.getClientSecret();
-        const orgIdentifier = await this.tokenService.getClientSecret();
         if (Utils.isNullOrWhitespace(clientId) || Utils.isNullOrWhitespace(clientSecret) || this.apiKeyRefresh == null) {
             throw new Error();
         }
 
-        // TODO retrieve this properly
-        await this.apiKeyRefresh(clientId, clientSecret, 'entorg');
+        await this.apiKeyRefresh(clientId, clientSecret);
     }
 
     protected async doRefreshToken(): Promise<void> {

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -166,10 +166,10 @@ import { ChallengeResponse } from '../models/response/twoFactorWebAuthnResponse'
 import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyResponse';
 import { UserKeyResponse } from '../models/response/userKeyResponse';
 
-import { SetCryptoAgentKeyRequest } from '../models/request/account/setCryptoAgentKeyRequest';
+import { SetKeyConnectorKeyRequest } from '../models/request/account/setKeyConnectorKeyRequest';
 import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
-import { CryptoAgentUserKeyRequest } from '../models/request/cryptoAgentUserKeyRequest';
-import { CryptoAgentUserKeyResponse } from '../models/response/cryptoAgentUserKeyResponse';
+import { KeyConnectorUserKeyRequest } from '../models/request/keyConnectorUserKeyRequest';
+import { KeyConnectorUserKeyResponse } from '../models/response/keyConnectorUserKeyResponse';
 import { SendAccessView } from '../models/view/sendAccessView';
 
 export class ApiService implements ApiServiceAbstraction {
@@ -293,8 +293,8 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/accounts/set-password', request, true, false);
     }
 
-    postSetCryptoAgentKey(request: SetCryptoAgentKeyRequest): Promise<any> {
-        return this.send('POST', '/accounts/set-crypto-agent-key', request, true, false);
+    postSetKeyConnectorKey(request: SetKeyConnectorKeyRequest): Promise<any> {
+        return this.send('POST', '/accounts/set-key-connector-key', request, true, false);
     }
 
     postSecurityStamp(request: PasswordVerificationRequest): Promise<any> {
@@ -410,8 +410,8 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/accounts/verify-otp', request, true, false);
     }
 
-    postConvertToCryptoAgent(): Promise<void> {
-        return this.send('POST', '/accounts/convert-to-crypto-agent', null, true, false);
+    postConvertToKeyConnector(): Promise<void> {
+        return this.send('POST', '/accounts/convert-to-key-connector', null, true, false);
     }
 
     // Folder APIs
@@ -1449,12 +1449,12 @@ export class ApiService implements ApiServiceAbstraction {
         return r as string;
     }
 
-    // Crypto Agent
+    // Key Connector
 
-    async getUserKeyFromCryptoAgent(cryptoAgentUrl: string): Promise<CryptoAgentUserKeyResponse> {
+    async getUserKeyFromKeyConnector(keyConnectorUrl: string): Promise<KeyConnectorUserKeyResponse> {
         const authHeader = await this.getActiveBearerToken();
 
-        const response = await this.fetch(new Request(cryptoAgentUrl + '/user-keys', {
+        const response = await this.fetch(new Request(keyConnectorUrl + '/user-keys', {
             cache: 'no-store',
             method: 'GET',
             headers: new Headers({
@@ -1468,13 +1468,13 @@ export class ApiService implements ApiServiceAbstraction {
             return Promise.reject(error);
         }
 
-        return new CryptoAgentUserKeyResponse(await response.json());
+        return new KeyConnectorUserKeyResponse(await response.json());
     }
 
-    async postUserKeyToCryptoAgent(cryptoAgentUrl: string, request: CryptoAgentUserKeyRequest): Promise<void> {
+    async postUserKeyToKeyConnector(keyConnectorUrl: string, request: KeyConnectorUserKeyRequest): Promise<void> {
         const authHeader = await this.getActiveBearerToken();
 
-        const response = await this.fetch(new Request(cryptoAgentUrl + '/user-keys', {
+        const response = await this.fetch(new Request(keyConnectorUrl + '/user-keys', {
             cache: 'no-store',
             method: 'POST',
             headers: new Headers({

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -173,7 +173,7 @@ import { CryptoAgentUserKeyResponse } from '../models/response/cryptoAgentUserKe
 import { SendAccessView } from '../models/view/sendAccessView';
 
 export class ApiService implements ApiServiceAbstraction {
-    protected apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>;
+    protected apiKeyRefresh: (clientId: string, clientSecret: string, orgIdentifier?: string) => Promise<any>;
     private device: DeviceType;
     private deviceType: string;
     private isWebClient = false;
@@ -1561,11 +1561,13 @@ export class ApiService implements ApiServiceAbstraction {
     protected async doApiTokenRefresh(): Promise<void> {
         const clientId = await this.tokenService.getClientId();
         const clientSecret = await this.tokenService.getClientSecret();
+        const orgIdentifier = await this.tokenService.getClientSecret();
         if (Utils.isNullOrWhitespace(clientId) || Utils.isNullOrWhitespace(clientSecret) || this.apiKeyRefresh == null) {
             throw new Error();
         }
 
-        await this.apiKeyRefresh(clientId, clientSecret);
+        // TODO retrieve this properly
+        await this.apiKeyRefresh(clientId, clientSecret, 'entorg');
     }
 
     protected async doRefreshToken(): Promise<void> {

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -167,7 +167,7 @@ import { TwoFactorYubiKeyResponse } from '../models/response/twoFactorYubiKeyRes
 import { UserKeyResponse } from '../models/response/userKeyResponse';
 
 import { SetKeyConnectorKeyRequest } from '../models/request/account/setKeyConnectorKeyRequest';
-import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
+import { VerifyOTPRequest } from '../models/request/account/verifyOTPRequest';
 import { KeyConnectorUserKeyRequest } from '../models/request/keyConnectorUserKeyRequest';
 import { KeyConnectorUserKeyResponse } from '../models/response/keyConnectorUserKeyResponse';
 import { SendAccessView } from '../models/view/sendAccessView';
@@ -402,11 +402,11 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('PUT', '/accounts/update-temp-password', request, true, false);
     }
 
-    postAccountRequestOtp(): Promise<void> {
+    postAccountRequestOTP(): Promise<void> {
         return this.send('POST', '/accounts/request-otp', null, true, false);
     }
 
-    postAccountVerifyOtp(request: VerifyOtpRequest): Promise<void> {
+    postAccountVerifyOTP(request: VerifyOTPRequest): Promise<void> {
         return this.send('POST', '/accounts/verify-otp', request, true, false);
     }
 

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -52,7 +52,6 @@ import { OrganizationUserUpdateGroupsRequest } from '../models/request/organizat
 import { OrganizationUserUpdateRequest } from '../models/request/organizationUserUpdateRequest';
 import { PasswordHintRequest } from '../models/request/passwordHintRequest';
 import { PasswordRequest } from '../models/request/passwordRequest';
-import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
 import { PaymentRequest } from '../models/request/paymentRequest';
 import { PolicyRequest } from '../models/request/policyRequest';
 import { PreloginRequest } from '../models/request/preloginRequest';
@@ -68,6 +67,7 @@ import { ProviderUserInviteRequest } from '../models/request/provider/providerUs
 import { ProviderUserUpdateRequest } from '../models/request/provider/providerUserUpdateRequest';
 import { RegisterRequest } from '../models/request/registerRequest';
 import { SeatRequest } from '../models/request/seatRequest';
+import { SecretVerificationRequest } from '../models/request/secretVerificationRequest';
 import { SelectionReadOnlyRequest } from '../models/request/selectionReadOnlyRequest';
 import { SendAccessRequest } from '../models/request/sendAccessRequest';
 import { SendRequest } from '../models/request/sendRequest';
@@ -297,11 +297,11 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/accounts/set-key-connector-key', request, true, false);
     }
 
-    postSecurityStamp(request: PasswordVerificationRequest): Promise<any> {
+    postSecurityStamp(request: SecretVerificationRequest): Promise<any> {
         return this.send('POST', '/accounts/security-stamp', request, true, false);
     }
 
-    deleteAccount(request: PasswordVerificationRequest): Promise<any> {
+    deleteAccount(request: SecretVerificationRequest): Promise<any> {
         return this.send('DELETE', '/accounts', request, true, false);
     }
 
@@ -364,7 +364,7 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/accounts/verify-email-token', request, false, false);
     }
 
-    postAccountVerifyPassword(request: PasswordVerificationRequest): Promise<any> {
+    postAccountVerifyPassword(request: SecretVerificationRequest): Promise<any> {
         return this.send('POST', '/accounts/verify-password', request, true, false);
     }
 
@@ -388,12 +388,12 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('GET', '/accounts/sso/user-identifier', null, true, true);
     }
 
-    async postUserApiKey(id: string, request: PasswordVerificationRequest): Promise<ApiKeyResponse> {
+    async postUserApiKey(id: string, request: SecretVerificationRequest): Promise<ApiKeyResponse> {
         const r = await this.send('POST', '/accounts/api-key', request, true, true);
         return new ApiKeyResponse(r);
     }
 
-    async postUserRotateApiKey(id: string, request: PasswordVerificationRequest): Promise<ApiKeyResponse> {
+    async postUserRotateApiKey(id: string, request: SecretVerificationRequest): Promise<ApiKeyResponse> {
         const r = await this.send('POST', '/accounts/rotate-api-key', request, true, true);
         return new ApiKeyResponse(r);
     }
@@ -586,7 +586,7 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('PUT', '/ciphers/' + id + '/collections-admin', request, true, false);
     }
 
-    postPurgeCiphers(request: PasswordVerificationRequest, organizationId: string = null): Promise<any> {
+    postPurgeCiphers(request: SecretVerificationRequest, organizationId: string = null): Promise<any> {
         let path = '/ciphers/purge';
         if (organizationId != null) {
             path += '?organizationId=' + organizationId;
@@ -952,44 +952,44 @@ export class ApiService implements ApiServiceAbstraction {
         return new ListResponse(r, TwoFactorProviderResponse);
     }
 
-    async getTwoFactorAuthenticator(request: PasswordVerificationRequest): Promise<TwoFactorAuthenticatorResponse> {
+    async getTwoFactorAuthenticator(request: SecretVerificationRequest): Promise<TwoFactorAuthenticatorResponse> {
         const r = await this.send('POST', '/two-factor/get-authenticator', request, true, true);
         return new TwoFactorAuthenticatorResponse(r);
     }
 
-    async getTwoFactorEmail(request: PasswordVerificationRequest): Promise<TwoFactorEmailResponse> {
+    async getTwoFactorEmail(request: SecretVerificationRequest): Promise<TwoFactorEmailResponse> {
         const r = await this.send('POST', '/two-factor/get-email', request, true, true);
         return new TwoFactorEmailResponse(r);
     }
 
-    async getTwoFactorDuo(request: PasswordVerificationRequest): Promise<TwoFactorDuoResponse> {
+    async getTwoFactorDuo(request: SecretVerificationRequest): Promise<TwoFactorDuoResponse> {
         const r = await this.send('POST', '/two-factor/get-duo', request, true, true);
         return new TwoFactorDuoResponse(r);
     }
 
     async getTwoFactorOrganizationDuo(organizationId: string,
-        request: PasswordVerificationRequest): Promise<TwoFactorDuoResponse> {
+        request: SecretVerificationRequest): Promise<TwoFactorDuoResponse> {
         const r = await this.send('POST', '/organizations/' + organizationId + '/two-factor/get-duo',
             request, true, true);
         return new TwoFactorDuoResponse(r);
     }
 
-    async getTwoFactorYubiKey(request: PasswordVerificationRequest): Promise<TwoFactorYubiKeyResponse> {
+    async getTwoFactorYubiKey(request: SecretVerificationRequest): Promise<TwoFactorYubiKeyResponse> {
         const r = await this.send('POST', '/two-factor/get-yubikey', request, true, true);
         return new TwoFactorYubiKeyResponse(r);
     }
 
-    async getTwoFactorWebAuthn(request: PasswordVerificationRequest): Promise<TwoFactorWebAuthnResponse> {
+    async getTwoFactorWebAuthn(request: SecretVerificationRequest): Promise<TwoFactorWebAuthnResponse> {
         const r = await this.send('POST', '/two-factor/get-webauthn', request, true, true);
         return new TwoFactorWebAuthnResponse(r);
     }
 
-    async getTwoFactorWebAuthnChallenge(request: PasswordVerificationRequest): Promise<ChallengeResponse> {
+    async getTwoFactorWebAuthnChallenge(request: SecretVerificationRequest): Promise<ChallengeResponse> {
         const r = await this.send('POST', '/two-factor/get-webauthn-challenge', request, true, true);
         return new ChallengeResponse(r);
     }
 
-    async getTwoFactorRecover(request: PasswordVerificationRequest): Promise<TwoFactorRecoverResponse> {
+    async getTwoFactorRecover(request: SecretVerificationRequest): Promise<TwoFactorRecoverResponse> {
         const r = await this.send('POST', '/two-factor/get-recover', request, true, true);
         return new TwoFactorRecoverResponse(r);
     }
@@ -1200,12 +1200,12 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/organizations/' + id + '/license', data, true, false);
     }
 
-    async postOrganizationApiKey(id: string, request: PasswordVerificationRequest): Promise<ApiKeyResponse> {
+    async postOrganizationApiKey(id: string, request: SecretVerificationRequest): Promise<ApiKeyResponse> {
         const r = await this.send('POST', '/organizations/' + id + '/api-key', request, true, true);
         return new ApiKeyResponse(r);
     }
 
-    async postOrganizationRotateApiKey(id: string, request: PasswordVerificationRequest): Promise<ApiKeyResponse> {
+    async postOrganizationRotateApiKey(id: string, request: SecretVerificationRequest): Promise<ApiKeyResponse> {
         const r = await this.send('POST', '/organizations/' + id + '/rotate-api-key', request, true, true);
         return new ApiKeyResponse(r);
     }
@@ -1250,7 +1250,7 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/organizations/' + id + '/reinstate', null, true, false);
     }
 
-    deleteOrganization(id: string, request: PasswordVerificationRequest): Promise<any> {
+    deleteOrganization(id: string, request: SecretVerificationRequest): Promise<any> {
         return this.send('DELETE', '/organizations/' + id, request, true, false);
     }
 

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -410,6 +410,10 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('POST', '/accounts/verify-otp', request, true, false);
     }
 
+    postConvertToCryptoAgent(): Promise<void> {
+        return this.send('POST', '/accounts/convert-to-crypto-agent', null, true, false);
+    }
+
     // Folder APIs
 
     async getFolder(id: string): Promise<FolderResponse> {

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -401,6 +401,10 @@ export class ApiService implements ApiServiceAbstraction {
         return this.send('PUT', '/accounts/update-temp-password', request, true, false);
     }
 
+    postAccountRequestOtp(): Promise<void> {
+        return this.send('POST', '/accounts/request-otp', null, true, false);
+    }
+
     // Folder APIs
 
     async getFolder(id: string): Promise<FolderResponse> {

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -142,10 +142,10 @@ export class AuthService implements AuthServiceAbstraction {
             null, null, null, null, null, orgId);
     }
 
-    async logInApiKey(clientId: string, clientSecret: string, orgIdentifier?: string): Promise<AuthResult> {
+    async logInApiKey(clientId: string, clientSecret: string): Promise<AuthResult> {
         this.selectedTwoFactorProviderType = null;
         return await this.logInHelper(null, null, null, null, null, null, clientId, clientSecret,
-            null, null, null, null, null, orgIdentifier);
+            null, null, null, null, null, null);
     }
 
     async logInTwoFactor(twoFactorProvider: TwoFactorProviderType, twoFactorToken: string,
@@ -307,13 +307,13 @@ export class AuthService implements AuthServiceAbstraction {
         let request: TokenRequest;
         if (twoFactorToken != null && twoFactorProvider != null) {
             request = new TokenRequest(emailPassword, codeCodeVerifier, clientIdClientSecret, twoFactorProvider,
-                twoFactorToken, remember, captchaToken, deviceRequest, orgId);
+                twoFactorToken, remember, captchaToken, deviceRequest);
         } else if (storedTwoFactorToken != null) {
             request = new TokenRequest(emailPassword, codeCodeVerifier, clientIdClientSecret,
-                TwoFactorProviderType.Remember, storedTwoFactorToken, false, captchaToken, deviceRequest, orgId);
+                TwoFactorProviderType.Remember, storedTwoFactorToken, false, captchaToken, deviceRequest);
         } else {
             request = new TokenRequest(emailPassword, codeCodeVerifier, clientIdClientSecret, null,
-                null, false, captchaToken, deviceRequest, orgId);
+                null, false, captchaToken, deviceRequest);
         }
 
         const response = await this.apiService.postIdentityToken(request);

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -5,9 +5,9 @@ import { TwoFactorProviderType } from '../enums/twoFactorProviderType';
 import { AuthResult } from '../models/domain/authResult';
 import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
 
-import { SetCryptoAgentKeyRequest } from '../models/request/account/setCryptoAgentKeyRequest';
-import { CryptoAgentUserKeyRequest } from '../models/request/cryptoAgentUserKeyRequest';
+import { SetKeyConnectorKeyRequest } from '../models/request/account/setKeyConnectorKeyRequest';
 import { DeviceRequest } from '../models/request/deviceRequest';
+import { KeyConnectorUserKeyRequest } from '../models/request/keyConnectorUserKeyRequest';
 import { KeysRequest } from '../models/request/keysRequest';
 import { PreloginRequest } from '../models/request/preloginRequest';
 import { TokenRequest } from '../models/request/tokenRequest';
@@ -365,15 +365,15 @@ export class AuthService implements AuthServiceAbstraction {
             // Skip this step during SSO new user flow. No key is returned from server.
             if (code == null || tokenResponse.key != null) {
 
-                if (tokenResponse.cryptoAgentUrl != null) {
+                if (tokenResponse.keyConnectorUrl != null) {
                     try {
-                        const userKeyResponse = await this.apiService.getUserKeyFromCryptoAgent(tokenResponse.cryptoAgentUrl);
+                        const userKeyResponse = await this.apiService.getUserKeyFromKeyConnector(tokenResponse.keyConnectorUrl);
                         const keyArr = Utils.fromB64ToArray(userKeyResponse.key);
                         const k = new SymmetricCryptoKey(keyArr);
                         await this.cryptoService.setKey(k);
                     } catch (e) {
                         this.logService.error(e);
-                        throw new Error('Unable to reach crypto agent');
+                        throw new Error('Unable to reach key connector');
                     }
                 }
 
@@ -391,11 +391,11 @@ export class AuthService implements AuthServiceAbstraction {
                 }
 
                 await this.cryptoService.setEncPrivateKey(tokenResponse.privateKey);
-            } else if (tokenResponse.cryptoAgentUrl != null) {
+            } else if (tokenResponse.keyConnectorUrl != null) {
                 const password = await this.cryptoFunctionService.randomBytes(64);
 
                 const k = await this.cryptoService.makeKey(Utils.fromBufferToB64(password), this.tokenService.getEmail(), tokenResponse.kdf, tokenResponse.kdfIterations);
-                const cryptoAgentRequest = new CryptoAgentUserKeyRequest(k.encKeyB64);
+                const keyConnectorRequest = new KeyConnectorUserKeyRequest(k.encKeyB64);
                 await this.cryptoService.setKey(k);
 
                 const encKey = await this.cryptoService.makeEncKey(k);
@@ -404,16 +404,16 @@ export class AuthService implements AuthServiceAbstraction {
                 const [pubKey, privKey] = await this.cryptoService.makeKeyPair();
 
                 try {
-                    await this.apiService.postUserKeyToCryptoAgent(tokenResponse.cryptoAgentUrl, cryptoAgentRequest);
+                    await this.apiService.postUserKeyToKeyConnector(tokenResponse.keyConnectorUrl, keyConnectorRequest);
                 } catch (e) {
-                    throw new Error('Unable to reach crypto agent');
+                    throw new Error('Unable to reach key connector');
                 }
 
                 const keys = new KeysRequest(pubKey, privKey.encryptedString);
-                const setPasswordRequest = new SetCryptoAgentKeyRequest(
+                const setPasswordRequest = new SetKeyConnectorKeyRequest(
                     encKey[1].encryptedString, tokenResponse.kdf, tokenResponse.kdfIterations, orgId, keys
                 );
-                await this.apiService.postSetCryptoAgentKey(setPasswordRequest);
+                await this.apiService.postSetKeyConnectorKey(setPasswordRequest);
             }
         }
 

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -142,10 +142,10 @@ export class AuthService implements AuthServiceAbstraction {
             null, null, null, null, null, orgId);
     }
 
-    async logInApiKey(clientId: string, clientSecret: string): Promise<AuthResult> {
+    async logInApiKey(clientId: string, clientSecret: string, orgIdentifier?: string): Promise<AuthResult> {
         this.selectedTwoFactorProviderType = null;
         return await this.logInHelper(null, null, null, null, null, null, clientId, clientSecret,
-            null, null, null, null, null, null);
+            null, null, null, null, null, orgIdentifier);
     }
 
     async logInTwoFactor(twoFactorProvider: TwoFactorProviderType, twoFactorToken: string,
@@ -307,13 +307,13 @@ export class AuthService implements AuthServiceAbstraction {
         let request: TokenRequest;
         if (twoFactorToken != null && twoFactorProvider != null) {
             request = new TokenRequest(emailPassword, codeCodeVerifier, clientIdClientSecret, twoFactorProvider,
-                twoFactorToken, remember, captchaToken, deviceRequest);
+                twoFactorToken, remember, captchaToken, deviceRequest, orgId);
         } else if (storedTwoFactorToken != null) {
             request = new TokenRequest(emailPassword, codeCodeVerifier, clientIdClientSecret,
-                TwoFactorProviderType.Remember, storedTwoFactorToken, false, captchaToken, deviceRequest);
+                TwoFactorProviderType.Remember, storedTwoFactorToken, false, captchaToken, deviceRequest, orgId);
         } else {
             request = new TokenRequest(emailPassword, codeCodeVerifier, clientIdClientSecret, null,
-                null, false, captchaToken, deviceRequest);
+                null, false, captchaToken, deviceRequest, orgId);
         }
 
         const response = await this.apiService.postIdentityToken(request);

--- a/common/src/services/constants.service.ts
+++ b/common/src/services/constants.service.ts
@@ -32,7 +32,6 @@ export class ConstantsService {
     static readonly biometricText: string = 'biometricText';
     static readonly biometricAwaitingAcceptance: string = 'biometricAwaitingAcceptance';
     static readonly biometricFingerprintValidated: string = 'biometricFingerprintValidated';
-    static readonly convertAccountToKeyConnector: string = 'convertAccountToKeyConnector';
 
     readonly environmentUrlsKey: string = ConstantsService.environmentUrlsKey;
     readonly disableGaKey: string = ConstantsService.disableGaKey;
@@ -66,5 +65,4 @@ export class ConstantsService {
     readonly biometricText: string = ConstantsService.biometricText;
     readonly biometricAwaitingAcceptance: string = ConstantsService.biometricAwaitingAcceptance;
     readonly biometricFingerprintValidated: string = ConstantsService.biometricFingerprintValidated;
-    readonly convertAccountToKeyConnector: string = ConstantsService.convertAccountToKeyConnector;
 }

--- a/common/src/services/constants.service.ts
+++ b/common/src/services/constants.service.ts
@@ -32,6 +32,7 @@ export class ConstantsService {
     static readonly biometricText: string = 'biometricText';
     static readonly biometricAwaitingAcceptance: string = 'biometricAwaitingAcceptance';
     static readonly biometricFingerprintValidated: string = 'biometricFingerprintValidated';
+    static readonly convertAccountToKeyConnector: string = 'convertAccountToKeyConnector';
 
     readonly environmentUrlsKey: string = ConstantsService.environmentUrlsKey;
     readonly disableGaKey: string = ConstantsService.disableGaKey;
@@ -65,4 +66,5 @@ export class ConstantsService {
     readonly biometricText: string = ConstantsService.biometricText;
     readonly biometricAwaitingAcceptance: string = ConstantsService.biometricAwaitingAcceptance;
     readonly biometricFingerprintValidated: string = ConstantsService.biometricFingerprintValidated;
+    readonly convertAccountToKeyConnector: string = ConstantsService.convertAccountToKeyConnector;
 }

--- a/common/src/services/environment.service.ts
+++ b/common/src/services/environment.service.ts
@@ -19,6 +19,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     private iconsUrl: string;
     private notificationsUrl: string;
     private eventsUrl: string;
+    private keyConnectorUrl: string;
 
     constructor(private storageService: StorageService) {}
 
@@ -103,6 +104,10 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
         return 'https://events.bitwarden.com';
     }
 
+    getKeyConnectorUrl() {
+        return this.keyConnectorUrl;
+    }
+
     async setUrlsFromStorage(): Promise<void> {
         const urlsObj: any = await this.storageService.get(ConstantsService.environmentUrlsKey);
         const urls = urlsObj || {
@@ -113,6 +118,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
             notifications: null,
             events: null,
             webVault: null,
+            keyConnector: null,
         };
 
         const envUrls = new EnvironmentUrls();
@@ -128,6 +134,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
         this.iconsUrl = urls.icons;
         this.notificationsUrl = urls.notifications;
         this.eventsUrl = envUrls.events = urls.events;
+        this.keyConnectorUrl = urls.keyConnector;
     }
 
     async setUrls(urls: Urls, saveSettings: boolean = true): Promise<any> {
@@ -138,6 +145,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
         urls.icons = this.formatUrl(urls.icons);
         urls.notifications = this.formatUrl(urls.notifications);
         urls.events = this.formatUrl(urls.events);
+        urls.keyConnector = this.formatUrl(urls.keyConnector);
 
         if (saveSettings) {
             await this.storageService.save(ConstantsService.environmentUrlsKey, {
@@ -148,6 +156,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
                 icons: urls.icons,
                 notifications: urls.notifications,
                 events: urls.events,
+                keyConnector: urls.keyConnector,
             });
         }
 
@@ -158,6 +167,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
         this.iconsUrl = urls.icons;
         this.notificationsUrl = urls.notifications;
         this.eventsUrl = urls.events;
+        this.keyConnectorUrl = urls.keyConnector;
 
         this.urlsSubject.next(urls);
 
@@ -173,6 +183,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
             icons: this.iconsUrl,
             notifications: this.notificationsUrl,
             events: this.eventsUrl,
+            keyConnector: this.keyConnectorUrl,
         };
     }
 

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -1,0 +1,84 @@
+import { ApiService } from '../abstractions/api.service';
+import { CryptoService } from '../abstractions/crypto.service';
+import { EnvironmentService } from '../abstractions/environment.service';
+import { KeyConnectorService as KeyConnectorServiceAbstraction } from '../abstractions/keyConnector.service';
+import { LogService } from '../abstractions/log.service';
+import { StorageService } from '../abstractions/storage.service';
+import { UserService } from '../abstractions/user.service';
+
+import { OrganizationUserType } from '../enums/organizationUserType';
+
+import { Utils } from '../misc/utils';
+
+import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
+
+import { KeyConnectorUserKeyRequest } from '../models/request/keyConnectorUserKeyRequest';
+
+const Keys = {
+    usesKeyConnector: 'usesKeyConnector',
+};
+
+export class KeyConnectorService implements KeyConnectorServiceAbstraction {
+    private usesKeyConnector: boolean = false;
+
+    constructor(private storageService: StorageService, private userService: UserService,
+        private cryptoService: CryptoService, private apiService: ApiService,
+        private environmentService: EnvironmentService, private logService: LogService) { }
+
+    setUsesKeyConnector(usesKeyConnector: boolean) {
+        this.usesKeyConnector = usesKeyConnector;
+        return this.storageService.save(Keys.usesKeyConnector, usesKeyConnector);
+    }
+
+    async getUsesKeyConnector(): Promise<boolean> {
+        return this.usesKeyConnector ??= await this.storageService.get<boolean>(Keys.usesKeyConnector);
+    }
+
+    async userNeedsMigration() {
+        const managingOrganization = await this.getManagingOrganization();
+        const userIsNotExempt = managingOrganization?.type !== OrganizationUserType.Owner
+            && managingOrganization?.type !== OrganizationUserType.Admin;
+        const userIsNotUsingKeyConnector = !await this.getUsesKeyConnector();
+
+        return userIsNotExempt && userIsNotUsingKeyConnector;
+    }
+
+    async migrateUser() {
+        const organization = await this.getManagingOrganization();
+        const key = await this.cryptoService.getKey();
+
+        try {
+            const keyConnectorRequest = new KeyConnectorUserKeyRequest(key.encKeyB64);
+            await this.apiService.postUserKeyToKeyConnector(organization.keyConnectorUrl, keyConnectorRequest);
+        } catch (e) {
+            throw new Error('Unable to reach key connector');
+        }
+
+        await this.apiService.postConvertToKeyConnector();
+    }
+
+    async getAndSetKey(url?: string) {
+        if (url == null) {
+            url = this.environmentService.getKeyConnectorUrl();
+        }
+
+        if (url == null) {
+            throw new Error('No Key Connector URL found.');
+        }
+
+        try {
+            const userKeyResponse = await this.apiService.getUserKeyFromKeyConnector(url);
+            const keyArr = Utils.fromB64ToArray(userKeyResponse.key);
+            const k = new SymmetricCryptoKey(keyArr);
+            await this.cryptoService.setKey(k);
+        } catch (e) {
+            this.logService.error(e);
+            throw new Error('Unable to reach key connector');
+        }
+    }
+
+    async getManagingOrganization() {
+        const orgs = await this.userService.getAllOrganizations();
+        return orgs.find(o => o.usesKeyConnector);
+    }
+}

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -4,6 +4,7 @@ import { EnvironmentService } from '../abstractions/environment.service';
 import { KeyConnectorService as KeyConnectorServiceAbstraction } from '../abstractions/keyConnector.service';
 import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
+import { TokenService } from '../abstractions/token.service';
 import { UserService } from '../abstractions/user.service';
 
 import { OrganizationUserType } from '../enums/organizationUserType';
@@ -23,7 +24,8 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
 
     constructor(private storageService: StorageService, private userService: UserService,
         private cryptoService: CryptoService, private apiService: ApiService,
-        private environmentService: EnvironmentService, private logService: LogService) { }
+        private environmentService: EnvironmentService, private tokenService: TokenService,
+        private logService: LogService) { }
 
     setUsesKeyConnector(usesKeyConnector: boolean) {
         this.usesKeyConnector = usesKeyConnector;
@@ -35,10 +37,11 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     }
 
     async userNeedsMigration() {
+        const loggedInUsingSso = this.tokenService.getIsExternal();
         const requiredByOrganization = await this.getManagingOrganization() != null;
         const userIsNotUsingKeyConnector = !await this.getUsesKeyConnector();
 
-        return requiredByOrganization && userIsNotUsingKeyConnector;
+        return loggedInUsingSso && requiredByOrganization && userIsNotUsingKeyConnector;
     }
 
     async migrateUser() {

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -21,7 +21,7 @@ const Keys = {
 };
 
 export class KeyConnectorService implements KeyConnectorServiceAbstraction {
-    private usesKeyConnector: boolean = false;
+    private usesKeyConnector?: boolean = null;
 
     constructor(private storageService: StorageService, private userService: UserService,
         private cryptoService: CryptoService, private apiService: ApiService,

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -35,12 +35,10 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     }
 
     async userNeedsMigration() {
-        const managingOrganization = await this.getManagingOrganization();
-        const userIsNotExempt = managingOrganization?.type !== OrganizationUserType.Owner
-            && managingOrganization?.type !== OrganizationUserType.Admin;
+        const requiredByOrganization = await this.getManagingOrganization() != null;
         const userIsNotUsingKeyConnector = !await this.getUsesKeyConnector();
 
-        return userIsNotExempt && userIsNotUsingKeyConnector;
+        return requiredByOrganization && userIsNotUsingKeyConnector;
     }
 
     async migrateUser() {
@@ -79,6 +77,10 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
 
     async getManagingOrganization() {
         const orgs = await this.userService.getAllOrganizations();
-        return orgs.find(o => o.usesKeyConnector);
+        return orgs.find(o =>
+            o.usesKeyConnector &&
+            o.type !== OrganizationUserType.Admin &&
+            o.type !== OrganizationUserType.Owner &&
+            !o.isProviderUser);
     }
 }

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -17,6 +17,7 @@ import { KeyConnectorUserKeyRequest } from '../models/request/keyConnectorUserKe
 
 const Keys = {
     usesKeyConnector: 'usesKeyConnector',
+    convertAccountToKeyConnector: 'convertAccountToKeyConnector',
 };
 
 export class KeyConnectorService implements KeyConnectorServiceAbstraction {
@@ -85,5 +86,21 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
             o.type !== OrganizationUserType.Admin &&
             o.type !== OrganizationUserType.Owner &&
             !o.isProviderUser);
+    }
+
+    async setConvertAccountRequired(status: boolean) {
+        await this.storageService.save(Keys.convertAccountToKeyConnector, status);
+    }
+
+    async getConvertAccountRequired(): Promise<boolean> {
+        return await this.storageService.get(Keys.convertAccountToKeyConnector);
+    }
+
+    async removeConvertAccountRequired() {
+        await this.storageService.remove(Keys.convertAccountToKeyConnector);
+    }
+
+    async clear() {
+        await this.removeConvertAccountRequired();
     }
 }

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -323,6 +323,8 @@ export class SyncService implements SyncServiceAbstraction {
 
         if (await this.keyConnectorService.userNeedsMigration()) {
             this.messagingService.send('convertAccountToKeyConnector');
+        } else {
+            this.keyConnectorService.removeConvertAccountRequired();
         }
 
         return Promise.all([

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -298,7 +298,7 @@ export class SyncService implements SyncServiceAbstraction {
         await this.cryptoService.setEncPrivateKey(response.privateKey);
         await this.cryptoService.setProviderKeys(response.providers);
         await this.cryptoService.setOrgKeys(response.organizations, response.providerOrganizations);
-        await this.userService.setUsesCryptoAgent(response.usesCryptoAgent);
+        await this.userService.setUsesKeyConnector(response.usesKeyConnector);
         await this.userService.setSecurityStamp(response.securityStamp);
         await this.userService.setEmailVerified(response.emailVerified);
         await this.userService.setForcePasswordReset(response.forcePasswordReset);
@@ -320,10 +320,10 @@ export class SyncService implements SyncServiceAbstraction {
             }
         });
 
-        const orgUsesCryptoAgent = response.organizations.some(o => o.usesCryptoAgent);
-        const userIsNotUsingCryptoAgent = !response.usesCryptoAgent;
-        if (this.tokenService.getIsExternal() && orgUsesCryptoAgent && userIsNotUsingCryptoAgent) {
-            this.messagingService.send('convertAccountToCryptoAgent');
+        const orgUsesKeyConnector = response.organizations.some(o => o.usesKeyConnector);
+        const userIsNotUsingKeyConnector = !response.usesKeyConnector;
+        if (this.tokenService.getIsExternal() && orgUsesKeyConnector && userIsNotUsingKeyConnector) {
+            this.messagingService.send('convertAccountToKeyConnector');
         }
 
         return Promise.all([

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -296,6 +296,7 @@ export class SyncService implements SyncServiceAbstraction {
         await this.cryptoService.setEncPrivateKey(response.privateKey);
         await this.cryptoService.setProviderKeys(response.providers);
         await this.cryptoService.setOrgKeys(response.organizations, response.providerOrganizations);
+        await this.userService.setUsesCryptoAgent(response.usesCryptoAgent);
         await this.userService.setSecurityStamp(response.securityStamp);
         await this.userService.setEmailVerified(response.emailVerified);
         await this.userService.setForcePasswordReset(response.forcePasswordReset);

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -321,7 +321,7 @@ export class SyncService implements SyncServiceAbstraction {
             }
         });
 
-        if (this.tokenService.getIsExternal() && await this.keyConnectorService.userNeedsMigration()) {
+        if (await this.keyConnectorService.userNeedsMigration()) {
             this.messagingService.send('convertAccountToKeyConnector');
         }
 

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -322,7 +322,7 @@ export class SyncService implements SyncServiceAbstraction {
         });
 
         const orgWithCryptoAgent = response.organizations.find(o => o.usesKeyConnector);
-        const orgUsesKeyConnector = orgWithCryptoAgent?.type != OrganizationUserType.Owner && orgWithCryptoAgent?.type != OrganizationUserType.Admin;
+        const orgUsesKeyConnector = orgWithCryptoAgent?.type !== OrganizationUserType.Owner && orgWithCryptoAgent?.type !== OrganizationUserType.Admin;
         const userIsNotUsingKeyConnector = !response.usesKeyConnector;
         if (this.tokenService.getIsExternal() && orgUsesKeyConnector && userIsNotUsingKeyConnector) {
             this.messagingService.send('convertAccountToKeyConnector');

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -12,6 +12,7 @@ import { StorageService } from '../abstractions/storage.service';
 import { SyncService as SyncServiceAbstraction } from '../abstractions/sync.service';
 import { TokenService } from '../abstractions/token.service';
 import { UserService } from '../abstractions/user.service';
+import { OrganizationUserType } from '../enums/organizationUserType';
 
 import { CipherData } from '../models/data/cipherData';
 import { CollectionData } from '../models/data/collectionData';
@@ -320,7 +321,8 @@ export class SyncService implements SyncServiceAbstraction {
             }
         });
 
-        const orgUsesKeyConnector = response.organizations.some(o => o.usesKeyConnector);
+        const orgWithCryptoAgent = response.organizations.find(o => o.usesKeyConnector);
+        const orgUsesKeyConnector = orgWithCryptoAgent?.type != OrganizationUserType.Owner && orgWithCryptoAgent?.type != OrganizationUserType.Admin;
         const userIsNotUsingKeyConnector = !response.usesKeyConnector;
         if (this.tokenService.getIsExternal() && orgUsesKeyConnector && userIsNotUsingKeyConnector) {
             this.messagingService.send('convertAccountToKeyConnector');

--- a/common/src/services/token.service.ts
+++ b/common/src/services/token.service.ts
@@ -243,6 +243,15 @@ export class TokenService implements TokenServiceAbstraction {
         return decoded.iss as string;
     }
 
+    getIsExternal(): boolean {
+        const decoded = this.decodeToken();
+        if (!Array.isArray(decoded.amr)) {
+            throw new Error('No amr found');
+        }
+
+        return decoded.amr.includes('external');
+    }
+
     private async storeTokenValue(key: string, value: string) {
         if (await this.skipTokenStorage()) {
             // if we have a vault timeout and the action is log out, don't store token

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -10,6 +10,8 @@ import { KdfType } from '../enums/kdfType';
 import { ProviderData } from '../models/data/providerData';
 import { Provider } from '../models/domain/provider';
 
+import { OrganizationUserType } from '../enums/organizationUserType';
+
 const Keys = {
     userId: 'userId',
     userEmail: 'userEmail',
@@ -240,5 +242,15 @@ export class UserService implements UserServiceAbstraction {
 
     async clearProviders(userId: string): Promise<any> {
         await this.storageService.remove(Keys.providersPrefix + userId);
+    }
+
+    async mustConvertToKeyConnector(): Promise<boolean> {
+        const orgs = await this.getAllOrganizations();
+        const orgWithCryptoAgent = orgs.find(o => o.usesKeyConnector);
+        const orgUsesKeyConnector = orgWithCryptoAgent?.type !== OrganizationUserType.Owner
+            && orgWithCryptoAgent?.type !== OrganizationUserType.Admin;
+        const userIsNotUsingKeyConnector = !await this.getUsesKeyConnector();
+
+        return orgUsesKeyConnector && userIsNotUsingKeyConnector;
     }
 }

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -20,7 +20,7 @@ const Keys = {
     providersPrefix: 'providers_',
     emailVerified: 'emailVerified',
     forcePasswordReset: 'forcePasswordReset',
-    usesCryptoAgent: 'usesCryptoAgent',
+    usesKeyConnector: 'usesKeyConnector',
 };
 
 export class UserService implements UserServiceAbstraction {
@@ -31,7 +31,7 @@ export class UserService implements UserServiceAbstraction {
     private kdfIterations: number;
     private emailVerified: boolean;
     private forcePasswordReset: boolean;
-    private usesCryptoAgent: boolean = false;
+    private usesKeyConnector: boolean = false;
 
     constructor(private tokenService: TokenService, private storageService: StorageService) { }
 
@@ -62,9 +62,9 @@ export class UserService implements UserServiceAbstraction {
         return this.storageService.save(Keys.forcePasswordReset, forcePasswordReset);
     }
 
-    setUsesCryptoAgent(usesCryptoAgent: boolean) {
-        this.usesCryptoAgent = usesCryptoAgent;
-        return this.storageService.save(Keys.usesCryptoAgent, usesCryptoAgent);
+    setUsesKeyConnector(usesKeyConnector: boolean) {
+        this.usesKeyConnector = usesKeyConnector;
+        return this.storageService.save(Keys.usesKeyConnector, usesKeyConnector);
     }
 
     async getUserId(): Promise<string> {
@@ -116,8 +116,8 @@ export class UserService implements UserServiceAbstraction {
         return this.forcePasswordReset;
     }
 
-    async getUsesCryptoAgent(): Promise<boolean> {
-        return this.usesCryptoAgent ??= await this.storageService.get<boolean>(Keys.usesCryptoAgent);
+    async getUsesKeyConnector(): Promise<boolean> {
+        return this.usesKeyConnector ??= await this.storageService.get<boolean>(Keys.usesKeyConnector);
     }
 
     async clear(): Promise<any> {

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -1,5 +1,3 @@
-import { CryptoService } from '../abstractions/crypto.service';
-import { I18nService } from '../abstractions/i18n.service';
 import { StorageService } from '../abstractions/storage.service';
 import { TokenService } from '../abstractions/token.service';
 import { UserService as UserServiceAbstraction } from '../abstractions/user.service';
@@ -8,14 +6,9 @@ import { OrganizationData } from '../models/data/organizationData';
 import { Organization } from '../models/domain/organization';
 
 import { KdfType } from '../enums/kdfType';
-import { VerificationType } from '../enums/verificationType';
 
 import { ProviderData } from '../models/data/providerData';
 import { Provider } from '../models/domain/provider';
-
-import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
-
-import { Verification } from '../types/verification';
 
 const Keys = {
     userId: 'userId',
@@ -40,8 +33,7 @@ export class UserService implements UserServiceAbstraction {
     private forcePasswordReset: boolean;
     private usesCryptoAgent: boolean;
 
-    constructor(private tokenService: TokenService, private storageService: StorageService,
-        private cryptoService: CryptoService, private i18nService: I18nService) { }
+    constructor(private tokenService: TokenService, private storageService: StorageService) { }
 
     async setInformation(userId: string, email: string, kdf: KdfType, kdfIterations: number): Promise<any> {
         this.email = email;

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -249,29 +249,4 @@ export class UserService implements UserServiceAbstraction {
     async clearProviders(userId: string): Promise<any> {
         await this.storageService.remove(Keys.providersPrefix + userId);
     }
-
-    async buildVerificationRequest<T extends PasswordVerificationRequest>
-        (verification: Verification, requestClass?: new () => T, alreadyEncrypted?: boolean) {
-
-        if (verification?.secret == null || verification.secret === '') {
-            const error = verification?.type === VerificationType.OTP
-                ? 'verificationCodeRequired'
-                : 'masterPassRequired';
-            throw new Error(this.i18nService.t(error));
-        }
-
-        const request = requestClass != null
-            ? new requestClass()
-            : new PasswordVerificationRequest() as T;
-
-        if (verification.type === VerificationType.OTP) {
-            request.otp = verification.secret;
-        } else {
-            request.masterPasswordHash = alreadyEncrypted
-                ? verification.secret
-                : await this.cryptoService.hashPassword(verification.secret, null);
-        }
-
-        return request;
-    }
 }

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -31,7 +31,7 @@ export class UserService implements UserServiceAbstraction {
     private kdfIterations: number;
     private emailVerified: boolean;
     private forcePasswordReset: boolean;
-    private usesCryptoAgent: boolean;
+    private usesCryptoAgent: boolean = false;
 
     constructor(private tokenService: TokenService, private storageService: StorageService) { }
 

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -19,6 +19,7 @@ const Keys = {
     providersPrefix: 'providers_',
     emailVerified: 'emailVerified',
     forcePasswordReset: 'forcePasswordReset',
+    usesCryptoAgent: 'usesCryptoAgent',
 };
 
 export class UserService implements UserServiceAbstraction {
@@ -29,6 +30,7 @@ export class UserService implements UserServiceAbstraction {
     private kdfIterations: number;
     private emailVerified: boolean;
     private forcePasswordReset: boolean;
+    private usesCryptoAgent: boolean;
 
     constructor(private tokenService: TokenService, private storageService: StorageService) { }
 
@@ -57,6 +59,11 @@ export class UserService implements UserServiceAbstraction {
     setForcePasswordReset(forcePasswordReset: boolean) {
         this.forcePasswordReset = forcePasswordReset;
         return this.storageService.save(Keys.forcePasswordReset, forcePasswordReset);
+    }
+
+    setUsesCryptoAgent(usesCryptoAgent: boolean) {
+        this.usesCryptoAgent = usesCryptoAgent;
+        return this.storageService.save(Keys.usesCryptoAgent, usesCryptoAgent);
     }
 
     async getUserId(): Promise<string> {
@@ -106,6 +113,10 @@ export class UserService implements UserServiceAbstraction {
             this.forcePasswordReset = await this.storageService.get<boolean>(Keys.forcePasswordReset);
         }
         return this.forcePasswordReset;
+    }
+
+    async getUsesCryptoAgent(): Promise<boolean> {
+        return this.usesCryptoAgent ??= await this.storageService.get<boolean>(Keys.usesCryptoAgent);
     }
 
     async clear(): Promise<any> {

--- a/common/src/services/user.service.ts
+++ b/common/src/services/user.service.ts
@@ -256,7 +256,7 @@ export class UserService implements UserServiceAbstraction {
         if (verification?.secret == null || verification.secret === '') {
             const error = verification?.type === VerificationType.OTP
                 ? 'verificationCodeRequired'
-                : 'masterPassRequired'
+                : 'masterPassRequired';
             throw new Error(this.i18nService.t(error));
         }
 

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -1,3 +1,5 @@
+import { Injectable } from '@angular/core';
+
 import { UserVerificationService as UserVerificationServiceAbstraction } from '../abstractions/userVerification.service';
 
 import { ApiService } from '../abstractions/api.service';
@@ -12,6 +14,7 @@ import { PasswordVerificationRequest } from '../models/request/passwordVerificat
 
 import { Verification } from '../types/verification';
 
+@Injectable()
 export class UserVerificationService implements UserVerificationServiceAbstraction {
     constructor(private cryptoService: CryptoService, private i18nService: I18nService,
         private platformUtilsService: PlatformUtilsService, private apiService: ApiService) { }
@@ -46,7 +49,8 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
             const request = new VerifyOtpRequest(verification.secret);
             try {
                 await this.apiService.postAccountVerifyOtp(request);
-            } catch {
+            } catch (e) {
+                console.log(e);
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                     this.i18nService.t('invalidVerificationCode'));
                 return false;

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -50,7 +50,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
         if (verification.type === VerificationType.OTP) {
             const request = new VerifyOTPRequest(verification.secret);
             try {
-                await this.apiService.postAccountVerifyOtp(request);
+                await this.apiService.postAccountVerifyOTP(request);
             } catch (e) {
                 this.logService.error(e);
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -11,7 +11,7 @@ import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { VerificationType } from '../enums/verificationType';
 
 import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
-import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
+import { SecretVerificationRequest } from '../models/request/secretVerificationRequest';
 
 import { Verification } from '../types/verification';
 
@@ -21,7 +21,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
         private platformUtilsService: PlatformUtilsService, private apiService: ApiService,
         private logService: LogService) { }
 
-    async buildRequest<T extends PasswordVerificationRequest>(verification: Verification,
+    async buildRequest<T extends SecretVerificationRequest>(verification: Verification,
         requestClass?: new () => T, alreadyHashed?: boolean) {
         if (verification?.secret == null || verification.secret === '') {
             throw new Error('No secret provided for verification.');
@@ -29,7 +29,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
 
         const request = requestClass != null
             ? new requestClass()
-            : new PasswordVerificationRequest() as T;
+            : new SecretVerificationRequest() as T;
 
         if (verification.type === VerificationType.OTP) {
             request.otp = verification.secret;

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -5,6 +5,7 @@ import { UserVerificationService as UserVerificationServiceAbstraction } from '.
 import { ApiService } from '../abstractions/api.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { I18nService } from '../abstractions/i18n.service';
+import { LogService } from '../abstractions/log.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 
 import { VerificationType } from '../enums/verificationType';
@@ -17,7 +18,8 @@ import { Verification } from '../types/verification';
 @Injectable()
 export class UserVerificationService implements UserVerificationServiceAbstraction {
     constructor(private cryptoService: CryptoService, private i18nService: I18nService,
-        private platformUtilsService: PlatformUtilsService, private apiService: ApiService) { }
+        private platformUtilsService: PlatformUtilsService, private apiService: ApiService,
+        private logService: LogService) { }
 
     async buildRequest<T extends PasswordVerificationRequest>(verification: Verification,
         requestClass?: new () => T, alreadyEncrypted?: boolean) {
@@ -50,7 +52,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
             try {
                 await this.apiService.postAccountVerifyOtp(request);
             } catch (e) {
-                console.log(e);
+                this.logService.error(e);
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                     this.i18nService.t('invalidVerificationCode'));
                 return false;

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -1,0 +1,35 @@
+import { CryptoService } from '../abstractions/crypto.service';
+import { I18nService } from '../abstractions/i18n.service';
+import { UserVerificationService as UserVerificationServiceAbstraction } from '../abstractions/userVerification.service';
+
+import { VerificationType } from '../enums/verificationType';
+
+import { PasswordVerificationRequest } from '../models/request/passwordVerificationRequest';
+
+import { Verification } from '../types/verification';
+
+export class UserVerificationService implements UserVerificationServiceAbstraction {
+    constructor(private cryptoService: CryptoService) { }
+
+    async buildRequest<T extends PasswordVerificationRequest>
+        (verification: Verification, requestClass?: new () => T, alreadyEncrypted?: boolean) {
+
+        if (verification?.secret == null || verification.secret === '') {
+            throw new Error('No secret provided for verification.');
+        }
+
+        const request = requestClass != null
+            ? new requestClass()
+            : new PasswordVerificationRequest() as T;
+
+        if (verification.type === VerificationType.OTP) {
+            request.otp = verification.secret;
+        } else {
+            request.masterPasswordHash = alreadyEncrypted
+                ? verification.secret
+                : await this.cryptoService.hashPassword(verification.secret, null);
+        }
+
+        return request;
+    }
+}

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -10,7 +10,7 @@ import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 
 import { VerificationType } from '../enums/verificationType';
 
-import { VerifyOtpRequest } from '../models/request/account/verifyOtpRequest';
+import { VerifyOTPRequest } from '../models/request/account/verifyOTPRequest';
 import { SecretVerificationRequest } from '../models/request/secretVerificationRequest';
 
 import { Verification } from '../types/verification';
@@ -48,7 +48,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
         }
 
         if (verification.type === VerificationType.OTP) {
-            const request = new VerifyOtpRequest(verification.secret);
+            const request = new VerifyOTPRequest(verification.secret);
             try {
                 await this.apiService.postAccountVerifyOtp(request);
             } catch (e) {

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -22,7 +22,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
         private logService: LogService) { }
 
     async buildRequest<T extends PasswordVerificationRequest>(verification: Verification,
-        requestClass?: new () => T, alreadyEncrypted?: boolean) {
+        requestClass?: new () => T, alreadyHashed?: boolean) {
         if (verification?.secret == null || verification.secret === '') {
             throw new Error('No secret provided for verification.');
         }
@@ -34,7 +34,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
         if (verification.type === VerificationType.OTP) {
             request.otp = verification.secret;
         } else {
-            request.masterPasswordHash = alreadyEncrypted
+            request.masterPasswordHash = alreadyHashed
                 ? verification.secret
                 : await this.cryptoService.hashPassword(verification.secret, null);
         }

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -4,6 +4,7 @@ import { CipherService } from '../abstractions/cipher.service';
 import { CollectionService } from '../abstractions/collection.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { FolderService } from '../abstractions/folder.service';
+import { KeyConnectorService } from '../abstractions/keyConnector.service';
 import { MessagingService } from '../abstractions/messaging.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 import { PolicyService } from '../abstractions/policy.service';
@@ -28,6 +29,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         protected platformUtilsService: PlatformUtilsService, private storageService: StorageService,
         private messagingService: MessagingService, private searchService: SearchService,
         private userService: UserService, private tokenService: TokenService, private policyService: PolicyService,
+        private keyConnectorService: KeyConnectorService,
         private lockedCallback: () => Promise<void> = null, private loggedOutCallback: () => Promise<void> = null) {
     }
 
@@ -98,7 +100,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
             return;
         }
 
-        if (await this.userService.getUsesKeyConnector()) {
+        if (await this.keyConnectorService.getUsesKeyConnector()) {
             const pinSet = await this.isPinLockSet();
             const pinLock = (pinSet[0] && this.pinProtectedKey != null) || pinSet[1];
 

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -98,6 +98,15 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
             return;
         }
 
+        if (await this.userService.getUsesCryptoAgent()) {
+            const pinSet = await this.isPinLockSet();
+            const pinLock = (pinSet[0] && this.pinProtectedKey != null) || pinSet[1];
+
+            if (!pinLock && !await this.isBiometricLockSet()) {
+                await this.logOut();
+            }
+        }
+
         this.biometricLocked = true;
         this.everBeenUnlocked = true;
         await this.cryptoService.clearKey(false);

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -98,7 +98,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
             return;
         }
 
-        if (await this.userService.getUsesCryptoAgent()) {
+        if (await this.userService.getUsesKeyConnector()) {
             const pinSet = await this.isPinLockSet();
             const pinLock = (pinSet[0] && this.pinProtectedKey != null) || pinSet[1];
 

--- a/common/src/types/verification.ts
+++ b/common/src/types/verification.ts
@@ -1,0 +1,6 @@
+import { VerificationType } from '../enums/verificationType';
+
+export type Verification = {
+    type: VerificationType,
+    secret: string,
+};

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -66,7 +66,6 @@ export class LoginCommand {
             const apiIdentifiers = await this.apiIdentifiers();
             clientId = apiIdentifiers.clientId;
             clientSecret = apiIdentifiers.clientSecret;
-            orgIdentifier = apiIdentifiers.orgIdentifier;
         } else if (options.sso != null && this.canInteract) {
             const passwordOptions: any = {
                 type: 'password',
@@ -153,7 +152,7 @@ export class LoginCommand {
                 }
             } else {
                 if (clientId != null && clientSecret != null) {
-                    response = await this.authService.logInApiKey(clientId, clientSecret, orgIdentifier);
+                    response = await this.authService.logInApiKey(clientId, clientSecret);
                 } else if (ssoCode != null && ssoCodeVerifier != null) {
                     response = await this.authService.logInSso(ssoCode, ssoCodeVerifier, this.ssoRedirectUri,
                         orgIdentifier);
@@ -431,33 +430,10 @@ export class LoginCommand {
         return clientSecret;
     }
 
-    private async apiOrgIdentifier(): Promise<string> {
-        let orgIdentifier: string = null;
-
-        const storedOrgIdentifier: string = process.env.BW_ORGIDENTIFIER;
-        if (storedOrgIdentifier == null) {
-            if (this.canInteract) {
-                const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
-                    type: 'input',
-                    name: 'orgIdentifier',
-                    message: 'Organization identifier',
-                });
-                orgIdentifier = answer.orgIdentifier;
-            } else {
-                orgIdentifier = null;
-            }
-        } else {
-            orgIdentifier = storedOrgIdentifier;
-        }
-
-        return orgIdentifier;
-    }
-
-    private async apiIdentifiers(): Promise<{ clientId: string, clientSecret: string, orgIdentifier?: string; }> {
+    private async apiIdentifiers(): Promise<{ clientId: string, clientSecret: string; }> {
         return {
             clientId: await this.apiClientId(),
             clientSecret: await this.apiClientSecret(),
-            orgIdentifier: await this.apiOrgIdentifier(),
         };
     }
 

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -437,6 +437,11 @@ export class LoginCommand {
             }
 
             await this.apiService.postConvertToKeyConnector();
+
+            const urls = this.environmentService.getUrls();
+            urls.keyConnector = organization.keyConnectorUrl;
+            await this.environmentService.setUrls(urls, true);
+
             return await this.handleSuccessResponse();
         } else if (answer.convert === 'leave') {
             await this.apiService.postLeaveOrganization(organization.id);

--- a/node/src/services/nodeApi.service.ts
+++ b/node/src/services/nodeApi.service.ts
@@ -17,7 +17,8 @@ import { TokenService } from 'jslib-common/abstractions/token.service';
 export class NodeApiService extends ApiService {
     constructor(tokenService: TokenService, platformUtilsService: PlatformUtilsService,
         environmentService: EnvironmentService, logoutCallback: (expired: boolean) => Promise<void>,
-        customUserAgent: string = null, apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>) {
+        customUserAgent: string = null, apiKeyRefresh: (clientId: string, clientSecret: string,
+        orgIdentifier?: string) => Promise<any>) {
         super(tokenService, platformUtilsService, environmentService, logoutCallback, customUserAgent);
         this.apiKeyRefresh = apiKeyRefresh;
     }

--- a/node/src/services/nodeApi.service.ts
+++ b/node/src/services/nodeApi.service.ts
@@ -17,8 +17,7 @@ import { TokenService } from 'jslib-common/abstractions/token.service';
 export class NodeApiService extends ApiService {
     constructor(tokenService: TokenService, platformUtilsService: PlatformUtilsService,
         environmentService: EnvironmentService, logoutCallback: (expired: boolean) => Promise<void>,
-        customUserAgent: string = null, apiKeyRefresh: (clientId: string, clientSecret: string,
-        orgIdentifier?: string) => Promise<any>) {
+        customUserAgent: string = null, apiKeyRefresh: (clientId: string, clientSecret: string) => Promise<any>) {
         super(tokenService, platformUtilsService, environmentService, logoutCallback, customUserAgent);
         this.apiKeyRefresh = apiKeyRefresh;
     }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Adds the missing functionality for using the Key Connector.
 * Password verification is handled using an email based OTP instead.
 * New component for removing the password of an account.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **angular/src/components/add-edit.component.ts**: Disable reprompt checkbox.
* **angular/src/components/export.component.ts**: Changes the export form to use reactive forms since it simplified the template work a bit. Uses the new `UserVerificationService` to verify.
* **angular/src/components/lock.component.ts**: Changed lock component to log you out if you use the key connector without biometric or pin.
* **angular/src/components/sso.component.ts**: Update crypto agent references to key connector. Also fixed a spelling error in a method.
* **angular/src/components/verify-master-password.component.ts**: Added new component for verifying using either master password or OTP.
* **angular/src/services/passwordReprompt.service.ts**: Disable password reprompt when using key connector.
* **common/src/enums/eventType.ts**: Add new events for enabling/disabling sso/key connector.
* **common/src/enums/verificationType.ts**: Add new enum for identifying which operation is used to verify.
* **common/src/models/api/ssoConfigApi.ts**: Rename crypto agent to key connector.
* **common/src/models/request/account/verifyOtpRequest.ts**: New request for verifying OTP.
* **common/src/models/request/passwordVerificationRequest.ts**: Add otp as alternative verification method.
* **common/src/models/request/tokenRequest.ts**: Include orgIdentifier in TokenRequest. Used to determine users org when using api key.
* **common/src/models/response/identityTokenResponse.ts**: Rename crypto agent references.
* **common/src/models/response/profileOrganizationResponse.ts**: Include organization key connector info in sync.
* **common/src/models/response/profileProviderOrganizationResponse.ts**: Explicitly extend ProfileOrganizationResponse since that's the behavior services expects.
* **common/src/models/response/profileResponse.ts**: Include details if the user uses key connector.
* **common/src/services/api.service.ts**: Add new endpoints related to converting existing accounts to key connector, OTP and more.
* **common/src/services/auth.service.ts**: Update auth service to send along org identifier in `logInApiKey`, rename crypto agent to key connector.
* **common/src/services/sync.service.ts**: Add logic for redirecting to "Remove password" page when the account should be migrated to key connector.
* **common/src/services/token.service.ts**: Add helper for determining if the user logged in using SSO.
* **common/src/services/user.service.ts**: Set whether the user uses key connector or not.
* **common/src/services/userVerification.service.ts**: New service for handling user verification using either password or OTP.
* **common/src/services/vaultTimeout.service.ts**: Log out user if using key connector and no biometric/pin is set.
* **node/src/cli/commands/login.command.ts** - (see the CLI PR for more context)
  * moved the full sync here (from the child component) because it's required before we can check if the user needs to migrate to Key Connector.
  * add migration flow - see the `migrateToKeyConnector` method
  * in the SSO flow (using the `--sso` option), get the Organization Identifier back from the browser popup so that we can feed it through to `auth.service`.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
