### PR TITLE
Add role="alert" to callouts only when enforceAlert is passed

### DIFF
--- a/angular/src/components/callout.component.html
+++ b/angular/src/components/callout.component.html
@@ -1,5 +1,5 @@
 <div #callout class="callout callout-{{calloutStyle}}" [ngClass]="{'clickable': clickable}"
-    [attr.role]="enforceAlert ? 'alert' : null">
+    [attr.role]="useAlertRole ? 'alert' : null">
     <h3 class="callout-heading" *ngIf="title">
         <i class="fa {{icon}}" *ngIf="icon" aria-hidden="true"></i>
         {{title}}

--- a/angular/src/components/callout.component.ts
+++ b/angular/src/components/callout.component.ts
@@ -19,7 +19,7 @@ export class CalloutComponent implements OnInit {
     @Input() clickable: boolean;
     @Input() enforcedPolicyOptions: MasterPasswordPolicyOptions;
     @Input() enforcedPolicyMessage: string;
-    @Input() enforceAlert = false;
+    @Input() useAlertRole = false;
 
     calloutStyle: string;
 


### PR DESCRIPTION
This is a an accessibility fix. All callouts where assigned  “role=alert” which was causing them to be read on page load by screen readers regardless of their position in the page.

This fix makes it so that we can dynamically make callouts do this, such as when "Check Exposed Passwords" is clicked in Tools > Exposed Passwords Report in web.

PR in Web: https://github.com/bitwarden/web/pull/1254
More context: https://app.asana.com/0/1153292148278596/1201246232113633/f