### PR TITLE
Pass in null for sso organziation for now.

### DIFF
--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -151,7 +151,7 @@ export class LoginCommand {
                 if (clientId != null && clientSecret != null) {
                     response = await this.authService.logInApiKey(clientId, clientSecret);
                 } else if (ssoCode != null && ssoCodeVerifier != null) {
-                    response = await this.authService.logInSso(ssoCode, ssoCodeVerifier, this.ssoRedirectUri);
+                    response = await this.authService.logInSso(ssoCode, ssoCodeVerifier, this.ssoRedirectUri, null);
                 } else {
                     response = await this.authService.logIn(email, password);
                 }


### PR DESCRIPTION
This will bypass cryptoagent

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes overlooked `login.command` during work to include crypto agent in jslib for web (#520). For now, this just bypasses crypto agent, we'll do a more thorough job to support it later in the week.

## Code changes
* **login.command**: bypass cryptoAgent by passing a null organization into the `loginSSO` helper.

## Testing requirements
None

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
