### PR TITLE
[Linked fields] Reset linkedIds if cipher type changes

### DIFF
--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -102,5 +102,9 @@ export class AddEditCustomFieldsComponent implements OnChanges {
         this.cipher.linkedFieldOptions.forEach((linkedFieldOption, id) =>
             options.push({ name: this.i18nService.t(linkedFieldOption.i18nKey), value: id }));
         this.linkedFieldOptions = options.sort(Utils.getSortFunction(this.i18nService, 'name'));
+
+        this.cipher.fields
+            .filter(f => f.type = FieldType.Linked)
+            .forEach(f => f.linkedId = this.linkedFieldOptions[0].value);
     }
 }

--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -103,8 +103,10 @@ export class AddEditCustomFieldsComponent implements OnChanges {
             options.push({ name: this.i18nService.t(linkedFieldOption.i18nKey), value: id }));
         this.linkedFieldOptions = options.sort(Utils.getSortFunction(this.i18nService, 'name'));
 
-        this.cipher.fields
-            .filter(f => f.type = FieldType.Linked)
-            .forEach(f => f.linkedId = this.linkedFieldOptions[0].value);
+        if (!this.editMode) {
+            this.cipher.fields
+                .filter(f => f.type = FieldType.Linked)
+                .forEach(f => f.linkedId = this.linkedFieldOptions[0].value);
+        }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When creating a new cipher, if you add a linked field and then change the cipher type, it will update the dropdown options but not the `Field.linkedId` value. This can leave you with a `linkedId` that belongs to a different cipher type.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **angular/src/components/add-edit-custom-fields.component.ts**: if we're adding a new cipher, and the cipher type changes, reset all `linkedId` values to make sure they align with the new cipher type. (This will also fire once on page load, but if we're adding a new cipher then there won't be any existing fields to overwrite.)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

NA, will be tested as part of linked custom fields.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
