### PR TITLE
[Linked fields] Fix change detection on cipherType

### DIFF
--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -49,6 +49,10 @@ export class AddEditCustomFieldsComponent implements OnChanges {
     ngOnChanges(changes: SimpleChanges) {
         if (changes.thisCipherType != null) {
             this.setLinkedFieldOptions();
+
+            if (!changes.thisCipherType.firstChange) {
+                this.resetCipherLinkedFields();
+            }
         }
     }
 
@@ -92,9 +96,7 @@ export class AddEditCustomFieldsComponent implements OnChanges {
     }
 
     private setLinkedFieldOptions() {
-        // Delete any Linked custom fields if the item type does not support them
         if (this.cipher.linkedFieldOptions == null) {
-            this.cipher.fields = this.cipher.fields.filter(f => f.type !== FieldType.Linked);
             return;
         }
 
@@ -102,11 +104,17 @@ export class AddEditCustomFieldsComponent implements OnChanges {
         this.cipher.linkedFieldOptions.forEach((linkedFieldOption, id) =>
             options.push({ name: this.i18nService.t(linkedFieldOption.i18nKey), value: id }));
         this.linkedFieldOptions = options.sort(Utils.getSortFunction(this.i18nService, 'name'));
+    }
 
-        if (!this.editMode) {
-            this.cipher.fields
-                .filter(f => f.type = FieldType.Linked)
-                .forEach(f => f.linkedId = this.linkedFieldOptions[0].value);
+    private resetCipherLinkedFields() {
+        // Delete any Linked custom fields if the item type does not support them
+        if (this.cipher.linkedFieldOptions == null) {
+            this.cipher.fields = this.cipher.fields.filter(f => f.type !== FieldType.Linked);
+            return;
         }
+
+        this.cipher.fields
+            .filter(f => f.type = FieldType.Linked)
+            .forEach(f => f.linkedId = this.linkedFieldOptions[0].value);
     }
 }

--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -48,11 +48,9 @@ export class AddEditCustomFieldsComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.thisCipherType != null) {
-            console.log('setLinkedField');
             this.setLinkedFieldOptions();
 
             if (!changes.thisCipherType.firstChange) {
-                console.log('resetCipherLinkedFields');
                 this.resetCipherLinkedFields();
             }
         }

--- a/angular/src/components/add-edit-custom-fields.component.ts
+++ b/angular/src/components/add-edit-custom-fields.component.ts
@@ -48,9 +48,11 @@ export class AddEditCustomFieldsComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.thisCipherType != null) {
+            console.log('setLinkedField');
             this.setLinkedFieldOptions();
 
             if (!changes.thisCipherType.firstChange) {
+                console.log('resetCipherLinkedFields');
                 this.resetCipherLinkedFields();
             }
         }
@@ -107,6 +109,10 @@ export class AddEditCustomFieldsComponent implements OnChanges {
     }
 
     private resetCipherLinkedFields() {
+        if (this.cipher.fields == null || this.cipher.fields.length === 0) {
+            return;
+        }
+
         // Delete any Linked custom fields if the item type does not support them
         if (this.cipher.linkedFieldOptions == null) {
             this.cipher.fields = this.cipher.fields.filter(f => f.type !== FieldType.Linked);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Bug fix for #431. When editing a cipher in the web vault, any linked field values would be reset to whatever the first dropdown option is.

We do want to reset these values if the user is adding a new cipher and they change the cipher type. However, the test for "adding a new cipher" was `(!editMode)`, which is passed in from the parent component. `editMode` is briefly `undefined` before the real value is received, which meant it always met this condition. I also realised that `editMode` defaults to `false` in the parent before it correctly sets the value, which could also be a problem.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **angular/src/components/add-edit-custom-fields.component.ts**:
  * separate out (1) resetting the `linkedFieldOptions` dropdown list and (2) resetting the cipher's linked field values.
  * only reset the cipher's linked field values if `ngOnChanges` fires and it's _not_ the first change. Note that `ngOnChanges` always fires at least once as part of the change detection cycle, so this will ignore that initial change - which is also when it receives its value from the parent. Any further changes after that point will represent a "real" change in the cipher type. (I didn't think it was necessary to check `!editMode` anymore because the cipher type can only ever (properly) change when adding a new cipher.)

This will require jslib updates on web, browser and desktop (but no other changes to those clients).

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

To be tested as part of the parent ticket.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
