### PR TITLE
don't allow @ character in uriString prefixing

### DIFF
--- a/common/src/misc/utils.ts
+++ b/common/src/misc/utils.ts
@@ -219,7 +219,8 @@ export class Utils {
         }
 
         let httpUrl = uriString.startsWith('http://') || uriString.startsWith('https://');
-        if (!httpUrl && uriString.indexOf('://') < 0 && Utils.tldEndingRegex.test(uriString)) {
+        if (!httpUrl && uriString.indexOf('://') < 0 && Utils.tldEndingRegex.test(uriString) &&
+            uriString.indexOf('@') < 0) {
             uriString = 'http://' + uriString;
             httpUrl = true;
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The WebExtensions password storage logic is fully relying on the top URL currently loaded. To ensure that the domain is correctly parsed, as it is used to retrieve the stored credentials, certain checks are deployed. It was discovered that currently a block list approach is implemented for protocols, which only contains the data: protocol handler. This could introduce security issues eg. via the about:blank page or similar pseudo protocols added to browsers.

As an example, the Safari web browsers allows to add arbitrary characters to the about:blank URL. In the end this behavior was not exploitable as this page origin can not be accessed by another page and therefore no iframe can be injected, which would have allowed to leak the credentials of any stored domain.

## Code changes
Added logic to prevent prefixing the URL with  `http://` if and `@` character is discovered anywhere in the URL.

## Testing requirements
Ensure that URL parsing is still working as expected for autofill and the display of URLs on item "view" pages.

For example, store an item with URL `google.com` (without https://) and make sure autofill still works as expected for logging into Google service.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
