### PR TITLE
clean api url paths from directory traversal

### DIFF
--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -1616,6 +1616,9 @@ export class ApiService implements ApiServiceAbstraction {
             headers.set('User-Agent', this.customUserAgent);
         }
 
+        // Clean path from directory traversal
+        path = path.split('../').join('');
+
         const requestInit: RequestInit = {
             cache: 'no-store',
             credentials: this.getCredentials(),


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It was discovered that user controlled path variables are not validated before they are utilized to construct a HTTP URL. By traversing the path up, it is possible to reach arbitrary API endpoints.

The impact of this issue was reduced as most paths immediately display the vault's lock page and it was not possible to abuse this behavior further.

## Code changes
Updated the `send()` function in the API service to clean the request path from any directory traversal strings (`../`) before constructing the final url to call.

## Testing requirements
General regression to ensure no API calls are broken.


## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
