### PR TITLE
validate path for directory traversal

### DIFF
--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -1609,6 +1609,13 @@ export class ApiService implements ApiServiceAbstraction {
         authed: boolean, hasResponse: boolean, apiUrl?: string,
         alterHeaders?: (headers: Headers) => void): Promise<any> {
         apiUrl = Utils.isNullOrWhitespace(apiUrl) ? this.environmentService.getApiUrl() : apiUrl;
+
+        const requestUrl = apiUrl + path;
+        // Prevent directory traversal from malicious paths
+        if (new URL(requestUrl).href !== requestUrl) {
+            return Promise.reject('Invalid request url path.');
+        }
+
         const headers = new Headers({
             'Device-Type': this.deviceType,
         });

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -1654,7 +1654,7 @@ export class ApiService implements ApiServiceAbstraction {
         }
 
         requestInit.headers = headers;
-        const response = await this.fetch(new Request(apiUrl + path, requestInit));
+        const response = await this.fetch(new Request(requestUrl, requestInit));
 
         if (hasResponse && response.status === 200) {
             const responseJson = await response.json();


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It was discovered that user controlled path variables are not validated before they are utilized to construct a HTTP URL. By traversing the path up, it is possible to reach arbitrary API endpoints.

The impact of this issue was reduced as most paths immediately display the vault's lock page and it was not possible to abuse this behavior further.


## Code changes
Added a check in the generically used `send()` function to ensure paths have not been manipulated. We can do this by constructing a `new URL()` and comparing the `href` property to what was originally expected.


## Testing requirements
General regression to ensure no API calls are broken.

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
