### PR TITLE
[Key Connector] QA fixes for CLI and Desktop

### DIFF
--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -10,6 +10,7 @@ import {
 
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
+import { UserVerificationService } from 'jslib-common/abstractions/userVerification.service';
 
 import { VerificationType } from 'jslib-common/enums/verificationType';
 
@@ -34,7 +35,8 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
 
     private onChange: (value: Verification) => void;
 
-    constructor(private keyConnectorService: KeyConnectorService, private apiService: ApiService) { }
+    constructor(private keyConnectorService: KeyConnectorService,
+        private userVerificationService: UserVerificationService) { }
 
     async ngOnInit() {
         this.usesKeyConnector = await this.keyConnectorService.getUsesKeyConnector();
@@ -54,7 +56,7 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
     async requestOTP() {
         if (this.usesKeyConnector) {
             this.disableRequestOTP = true;
-            await this.apiService.postAccountRequestOTP();
+            await this.userVerificationService.requestOTP();
         }
     }
 

--- a/common/src/abstractions/userVerification.service.ts
+++ b/common/src/abstractions/userVerification.service.ts
@@ -6,4 +6,5 @@ export abstract class UserVerificationService {
     buildRequest: <T extends SecretVerificationRequest> (verification: Verification,
         requestClass?: new () => T, alreadyHashed?: boolean) => Promise<T>;
     verifyUser: (verification: Verification) => Promise<boolean>;
+    requestOTP: () => Promise<void>;
 }

--- a/common/src/models/response/identityTokenResponse.ts
+++ b/common/src/models/response/identityTokenResponse.ts
@@ -15,6 +15,7 @@ export class IdentityTokenResponse extends BaseResponse {
     kdf: KdfType;
     kdfIterations: number;
     forcePasswordReset: boolean;
+    apiUseKeyConnector: boolean;
     keyConnectorUrl: string;
 
     constructor(response: any) {
@@ -31,6 +32,7 @@ export class IdentityTokenResponse extends BaseResponse {
         this.kdf = this.getResponseProperty('Kdf');
         this.kdfIterations = this.getResponseProperty('KdfIterations');
         this.forcePasswordReset = this.getResponseProperty('ForcePasswordReset');
+        this.apiUseKeyConnector = this.getResponseProperty('ApiUseKeyConnector');
         this.keyConnectorUrl = this.getResponseProperty('KeyConnectorUrl');
     }
 }

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -370,8 +370,9 @@ export class AuthService implements AuthServiceAbstraction {
 
                 if (tokenResponse.keyConnectorUrl != null) {
                     await this.keyConnectorService.getAndSetKey(tokenResponse.keyConnectorUrl);
-                } else if (this.environmentService.getKeyConnectorUrl() != null) {
-                    await this.keyConnectorService.getAndSetKey();
+                } else if (tokenResponse.apiUseKeyConnector) {
+                    const keyConnectorUrl = this.environmentService.getKeyConnectorUrl();
+                    await this.keyConnectorService.getAndSetKey(keyConnectorUrl);
                 }
 
                 await this.cryptoService.setEncKey(tokenResponse.key);

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -1,6 +1,5 @@
 import { ApiService } from '../abstractions/api.service';
 import { CryptoService } from '../abstractions/crypto.service';
-import { EnvironmentService } from '../abstractions/environment.service';
 import { KeyConnectorService as KeyConnectorServiceAbstraction } from '../abstractions/keyConnector.service';
 import { LogService } from '../abstractions/log.service';
 import { StorageService } from '../abstractions/storage.service';
@@ -25,8 +24,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
 
     constructor(private storageService: StorageService, private userService: UserService,
         private cryptoService: CryptoService, private apiService: ApiService,
-        private environmentService: EnvironmentService, private tokenService: TokenService,
-        private logService: LogService) { }
+        private tokenService: TokenService, private logService: LogService) { }
 
     setUsesKeyConnector(usesKeyConnector: boolean) {
         this.usesKeyConnector = usesKeyConnector;
@@ -59,15 +57,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
         await this.apiService.postConvertToKeyConnector();
     }
 
-    async getAndSetKey(url?: string) {
-        if (url == null) {
-            url = this.environmentService.getKeyConnectorUrl();
-        }
-
-        if (url == null) {
-            throw new Error('No Key Connector URL found.');
-        }
-
+    async getAndSetKey(url: string) {
         try {
             const userKeyResponse = await this.apiService.getUserKeyFromKeyConnector(url);
             const keyArr = Utils.fromB64ToArray(userKeyResponse.key);

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -22,7 +22,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
             if (verification.type === VerificationType.OTP) {
                 this.handleError(this.i18nService.t('verificationCodeRequired'));
             } else {
-                this.handleError(this.i18nService.t('masterPasswordRequired'));
+                this.handleError(this.i18nService.t('masterPassRequired'));
             }
             return null;
         }
@@ -47,7 +47,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
             if (verification.type === VerificationType.OTP) {
                 this.handleError(this.i18nService.t('verificationCodeRequired'));
             } else {
-                this.handleError(this.i18nService.t('masterPasswordRequired'));
+                this.handleError(this.i18nService.t('masterPassRequired'));
             }
             return false;
         }

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -1,11 +1,8 @@
-import { Injectable } from '@angular/core';
-
 import { UserVerificationService as UserVerificationServiceAbstraction } from '../abstractions/userVerification.service';
 
 import { ApiService } from '../abstractions/api.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { I18nService } from '../abstractions/i18n.service';
-import { LogService } from '../abstractions/log.service';
 import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 
 import { VerificationType } from '../enums/verificationType';
@@ -15,11 +12,9 @@ import { SecretVerificationRequest } from '../models/request/secretVerificationR
 
 import { Verification } from '../types/verification';
 
-@Injectable()
 export class UserVerificationService implements UserVerificationServiceAbstraction {
     constructor(private cryptoService: CryptoService, private i18nService: I18nService,
-        private platformUtilsService: PlatformUtilsService, private apiService: ApiService,
-        private logService: LogService) { }
+        private platformUtilsService: PlatformUtilsService, private apiService: ApiService) { }
 
     async buildRequest<T extends SecretVerificationRequest>(verification: Verification,
         requestClass?: new () => T, alreadyHashed?: boolean) {
@@ -44,7 +39,11 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
 
     async verifyUser(verification: Verification): Promise<boolean> {
         if (verification?.secret == null || verification.secret === '') {
-            throw new Error('No secret provided for verification.');
+            if (verification.type === VerificationType.OTP) {
+                this.showError(this.i18nService.t('verificationCodeRequired'));
+            } else {
+                this.showError(this.i18nService.t('masterPasswordRequired'));
+            }
         }
 
         if (verification.type === VerificationType.OTP) {
@@ -52,19 +51,24 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
             try {
                 await this.apiService.postAccountVerifyOTP(request);
             } catch (e) {
-                this.logService.error(e);
-                this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-                    this.i18nService.t('invalidVerificationCode'));
+                this.showError(this.i18nService.t('invalidVerificationCode'));
                 return false;
             }
         } else {
             const passwordValid = await this.cryptoService.compareAndUpdateKeyHash(verification.secret, null);
             if (!passwordValid) {
-                this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-                    this.i18nService.t('invalidMasterPassword'));
+                this.showError(this.i18nService.t('invalidMasterPassword'));
                 return false;
             }
         }
         return true;
+    }
+
+    async requestOTP() {
+        await this.apiService.postAccountRequestOTP();
+    }
+
+    protected showError(message: string) {
+        this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), message);
     }
 }

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -3,7 +3,6 @@ import { UserVerificationService as UserVerificationServiceAbstraction } from '.
 import { ApiService } from '../abstractions/api.service';
 import { CryptoService } from '../abstractions/crypto.service';
 import { I18nService } from '../abstractions/i18n.service';
-import { PlatformUtilsService } from '../abstractions/platformUtils.service';
 
 import { VerificationType } from '../enums/verificationType';
 
@@ -14,7 +13,7 @@ import { Verification } from '../types/verification';
 
 export class UserVerificationService implements UserVerificationServiceAbstraction {
     constructor(private cryptoService: CryptoService, private i18nService: I18nService,
-        private platformUtilsService: PlatformUtilsService, private apiService: ApiService) { }
+        private apiService: ApiService) { }
 
     async buildRequest<T extends SecretVerificationRequest>(verification: Verification,
         requestClass?: new () => T, alreadyHashed?: boolean) {

--- a/common/src/services/userVerification.service.ts
+++ b/common/src/services/userVerification.service.ts
@@ -60,7 +60,7 @@ export class UserVerificationService implements UserVerificationServiceAbstracti
     private validateInput(verification: Verification) {
         if (verification?.secret == null || verification.secret === '') {
             if (verification.type === VerificationType.OTP) {
-                throw new Error(this.i18nService.t('verificationCodeRequired'))
+                throw new Error(this.i18nService.t('verificationCodeRequired'));
             } else {
                 throw new Error(this.i18nService.t('masterPassRequired'));
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix QA feedback on Key Connector:

* Fix no error in desktop when OTP/MP is blank: https://app.asana.com/0/0/1201361837847153/f
* Support CLI changes: https://github.com/bitwarden/cli/pull/410

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **common/src/services/userVerification.service.ts** - 
  * add wrapper for requesting OTP code, it just made sense to have it in this service as the main interface
  * provide CLI support, which I forgot the first time round:
    * break out error handling into its own `protected` method. This lets us override it in CLI, which doesn't use toasts.
    * remove `@Injectable` Angular decorator, which doesn't belong in `jslib-common`. Angular clients will need their `services.module.ts` updated.
  * add proper error handling if the secret is null or an empty string (tell the user, don't just throw an error)
  * remove `logService`, I don't think it's necessary where we're surfacing the error to the user
* **common/src/services/keyConnector.service.ts** - don't ask `environmentService.getKeyConnectorUrl()` for the url as default behaviour. This is only used in one very specific use case (using apikey in CLI), so it didn't make sense to have it as a fallback. I also removed the null check because the try/catch block below will catch a null or empty value.
* **common/src/models/response/identityTokenResponse.ts** - add support for `apiUseKeyConnector` flag, which tells CLI to check for the saved key connector URL. See CLI PR for more context.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
