### PR TITLE
Update Safari importer to be Safari and macOS importer

### DIFF
--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -85,13 +85,13 @@ export class ImportService implements ImportServiceAbstraction {
     featuredImportOptions = [
         { id: 'bitwardenjson', name: 'Bitwarden (json)' },
         { id: 'bitwardencsv', name: 'Bitwarden (csv)' },
-        { id: 'lastpasscsv', name: 'LastPass (csv)' },
         { id: 'chromecsv', name: 'Chrome (csv)' },
-        { id: 'firefoxcsv', name: 'Firefox (csv)' },
-        { id: 'safaricsv', name: 'Safari and macOS (csv)' },
-        { id: 'keepass2xml', name: 'KeePass 2 (xml)' },
-        { id: '1password1pif', name: '1Password (1pif)' },
         { id: 'dashlanejson', name: 'Dashlane (json)' },
+        { id: 'firefoxcsv', name: 'Firefox (csv)' },
+        { id: 'keepass2xml', name: 'KeePass 2 (xml)' },
+        { id: 'lastpasscsv', name: 'LastPass (csv)' },
+        { id: 'safaricsv', name: 'Safari and macOS (csv)' },
+        { id: '1password1pif', name: '1Password (1pif)' },
     ];
 
     regularImportOptions: ImportOption[] = [

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -88,7 +88,7 @@ export class ImportService implements ImportServiceAbstraction {
         { id: 'lastpasscsv', name: 'LastPass (csv)' },
         { id: 'chromecsv', name: 'Chrome (csv)' },
         { id: 'firefoxcsv', name: 'Firefox (csv)' },
-        { id: 'safaricsv', name: 'Safari (csv)' },
+        { id: 'safaricsv', name: 'Safari and macOS (csv)' },
         { id: 'keepass2xml', name: 'KeePass 2 (xml)' },
         { id: '1password1pif', name: '1Password (1pif)' },
         { id: 'dashlanejson', name: 'Dashlane (json)' },


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

macOS Monterey added an export option from System Preferences > Passwords, which uses the same format as exporting from Safari (which we already support). I've updated the name of the importer from "Safari" to "Safari and macOS", so that users know it supports both.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **common/src/services/import.service.ts** - 
  * update name as described above
  * put the featured importers (at the top of the dropdown) in alphabetical order. The exception to this is 1Password, that should be at the top (numbers come before letters), but I assume we want Bitwarden as the first option, so I've left it at the bottom. I still think it looks more orderly than before.

Web will need to update jslib after this is merged.

## Testing requirements
QA can test to confirm that the importer also works for macOS exports. Otherwise this is just a change to the UI label.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
