### PR TITLE
Update base export component for userVerificationService changes

### DIFF
--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -69,7 +69,10 @@ export class ExportComponent implements OnInit {
         }
 
         const secret = this.exportForm.get('secret').value;
-        if (!await this.userVerificationService.verifyUser(secret)) {
+        try {
+            await this.userVerificationService.verifyUser(secret);
+        } catch (e) {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), e.message);
             return;
         }
 

--- a/angular/src/components/verify-master-password.component.ts
+++ b/angular/src/components/verify-master-password.component.ts
@@ -8,7 +8,6 @@ import {
     NG_VALUE_ACCESSOR,
 } from '@angular/forms';
 
-import { ApiService } from 'jslib-common/abstractions/api.service';
 import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 import { UserVerificationService } from 'jslib-common/abstractions/userVerification.service';
 
@@ -40,17 +39,9 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
 
     async ngOnInit() {
         this.usesKeyConnector = await this.keyConnectorService.getUsesKeyConnector();
+        this.processChanges(this.secret.value);
 
-        this.secret.valueChanges.subscribe(secret => {
-            if (this.onChange == null) {
-                return;
-            }
-
-            this.onChange({
-                type: this.usesKeyConnector ? VerificationType.OTP : VerificationType.MasterPassword,
-                secret: secret,
-            });
-        });
+        this.secret.valueChanges.subscribe(secret => this.processChanges(secret));
     }
 
     async requestOTP() {
@@ -79,5 +70,16 @@ export class VerifyMasterPasswordComponent implements ControlValueAccessor, OnIn
         } else {
             this.secret.enable();
         }
+    }
+
+    private processChanges(secret: string) {
+        if (this.onChange == null) {
+            return;
+        }
+
+        this.onChange({
+            type: this.usesKeyConnector ? VerificationType.OTP : VerificationType.MasterPassword,
+            secret: secret,
+        });
     }
 }

--- a/common/src/enums/eventType.ts
+++ b/common/src/enums/eventType.ts
@@ -47,6 +47,7 @@ export enum EventType {
     OrganizationUser_ResetPassword_Withdraw = 1507,
     OrganizationUser_AdminResetPassword = 1508,
     OrganizationUser_ResetSsoLink = 1509,
+    OrganizationUser_SsoFirstUse = 1510,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,

--- a/common/src/enums/eventType.ts
+++ b/common/src/enums/eventType.ts
@@ -47,7 +47,6 @@ export enum EventType {
     OrganizationUser_ResetPassword_Withdraw = 1507,
     OrganizationUser_AdminResetPassword = 1508,
     OrganizationUser_ResetSsoLink = 1509,
-    OrganizationUser_SsoFirstUse = 1510,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Follow up to https://github.com/bitwarden/jslib/pull/544, where we decided to throw errors from `UserVerificationService` and catch them in the components if required. We need to update the base `export.component.ts` to use this new pattern.

In the course of testing, I also noticed the following error, which this PR fixes:
* use Key Connector
* submit a form that contains `VerifyMasterPasswordComponent` but leave the OTP blank
* expected: "Verification code required" error message
* actual: "Master Password required" error message

## Code changes

* **angular/src/components/export.component.ts** - add try/catch block
* **angular/src/components/verify-master-password.component.ts** - call `onChanges` with an initial value when the component loads. This is so that `verification.type` is correctly set and the right error message can be displayed, even if the user never interacts with the form control.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
