### PR TITLE
[Key Connector] Hide "Master Pass On Restart" prompt when setting pin

### DIFF
--- a/angular/src/components/set-pin.component.ts
+++ b/angular/src/components/set-pin.component.ts
@@ -1,6 +1,7 @@
-import { Directive } from '@angular/core';
+import { Directive, OnInit } from '@angular/core';
 
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';
 import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
 import { VaultTimeoutService } from 'jslib-common/abstractions/vaultTimeout.service';
@@ -12,14 +13,20 @@ import { Utils } from 'jslib-common/misc/utils';
 import { ModalRef } from './modal/modal.ref';
 
 @Directive()
-export class SetPinComponent {
+export class SetPinComponent implements OnInit {
 
     pin = '';
     showPin = false;
     masterPassOnRestart = true;
+    showMasterPassOnRestart = true;
 
     constructor(private modalRef: ModalRef, private cryptoService: CryptoService, private userService: UserService,
-        private storageService: StorageService, private vaultTimeoutService: VaultTimeoutService) { }
+        private storageService: StorageService, private vaultTimeoutService: VaultTimeoutService,
+        private keyConnectorService: KeyConnectorService) { }
+
+    async ngOnInit() {
+        this.showMasterPassOnRestart = this.masterPassOnRestart = !await this.keyConnectorService.getUsesKeyConnector();
+    }
 
     toggleVisibility() {
         this.showPin = !this.showPin;

--- a/angular/src/components/set-pin.component.ts
+++ b/angular/src/components/set-pin.component.ts
@@ -1,4 +1,7 @@
-import { Directive, OnInit } from '@angular/core';
+import {
+    Directive,
+    OnInit
+} from '@angular/core';
 
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { KeyConnectorService } from 'jslib-common/abstractions/keyConnector.service';


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

If the user is using Key Connector and sets an unlock pin, do not ask them whether they want to "require unlocking with master password when the application is restarted". Instead, hide this checkbox and default it to false because they do not have a master password.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
