### PR TITLE
[Key Connector] Resolve desktop not prompting to remove password

### DIFF
--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -321,16 +321,16 @@ export class SyncService implements SyncServiceAbstraction {
             }
         });
 
+        await Promise.all([
+            this.userService.replaceOrganizations(organizations),
+            this.userService.replaceProviders(providers),
+        ]);
+
         if (await this.keyConnectorService.userNeedsMigration()) {
             this.messagingService.send('convertAccountToKeyConnector');
         } else {
             this.keyConnectorService.removeConvertAccountRequired();
         }
-
-        return Promise.all([
-            this.userService.replaceOrganizations(organizations),
-            this.userService.replaceProviders(providers),
-        ]);
     }
 
     private async syncFolders(userId: string, response: FolderResponse[]) {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolves an issue where the desktop application didn't correctly prompt to remove password after first unlock with key connector.

The issue was caused by the check running before the organizations were replaced which meant the `requiredByOrganization` check in `userNeedsMigration` always returned false until the next sync. On other clients this operation is a race condition that to my knowledge always runs correctly.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
