### PR TITLE
Desktop displays duplicate ownership attributes 

### DIFF
--- a/angular/src/components/add-edit.component.ts
+++ b/angular/src/components/add-edit.component.ts
@@ -154,6 +154,9 @@ export class AddEditComponent implements OnInit {
     }
 
     async init() {
+        if (this.ownershipOptions.length) {
+            this.ownershipOptions = [];
+        }
         if (await this.policyService.policyAppliesToUser(PolicyType.PersonalOwnership)) {
             this.allowPersonal = false;
         } else {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
While editing or having a vault item open, if you clicked on a filter item in the navigation pane on the left the ownership options of your open item would duplicate.

This was happening because `ngOnChanges` was called when you selected a filter item, which made a call to `super.init()`.

This change resets the `ownershipOptions` array on every init in jslib.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **angular/src/components/add-edit.component.ts:** Reset `ownershipOptions` on init

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Test add/edit item while clicking on filter items
- Light testing around add/edit item functionality, specifically ownership options


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
