### PR TITLE
Add autotype basic support

### DIFF
--- a/angular/src/components/view.component.ts
+++ b/angular/src/components/view.component.ts
@@ -6,14 +6,8 @@ import {
     NgZone,
     OnDestroy,
     OnInit,
-    Output,
+    Output
 } from '@angular/core';
-
-import { CipherRepromptType } from 'jslib-common/enums/cipherRepromptType';
-import { CipherType } from 'jslib-common/enums/cipherType';
-import { EventType } from 'jslib-common/enums/eventType';
-import { FieldType } from 'jslib-common/enums/fieldType';
-
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuditService } from 'jslib-common/abstractions/audit.service';
 import { BroadcasterService } from 'jslib-common/abstractions/broadcaster.service';
@@ -27,12 +21,18 @@ import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.se
 import { TokenService } from 'jslib-common/abstractions/token.service';
 import { TotpService } from 'jslib-common/abstractions/totp.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
-
+import { CipherRepromptType } from 'jslib-common/enums/cipherRepromptType';
+import { CipherType } from 'jslib-common/enums/cipherType';
+import { DeviceType } from 'jslib-common/enums/deviceType';
+import { EventType } from 'jslib-common/enums/eventType';
+import { FieldType } from 'jslib-common/enums/fieldType';
 import { ErrorResponse } from 'jslib-common/models/response/errorResponse';
-
 import { AttachmentView } from 'jslib-common/models/view/attachmentView';
 import { CipherView } from 'jslib-common/models/view/cipherView';
 import { LoginUriView } from 'jslib-common/models/view/loginUriView';
+
+
+
 
 const BroadcasterSubscriptionId = 'ViewComponent';
 
@@ -61,6 +61,7 @@ export class ViewComponent implements OnDestroy, OnInit {
     private totpInterval: any;
     private previousCipherId: string;
     private passwordReprompted: boolean = false;
+    private autoTypeLib: any;
 
     constructor(protected cipherService: CipherService, protected totpService: TotpService,
         protected tokenService: TokenService, protected i18nService: I18nService,
@@ -122,6 +123,21 @@ export class ViewComponent implements OnDestroy, OnInit {
         }
 
         return false;
+    }
+
+    async autoType() {
+        if (await this.promptPassword() && await this.autoTypeAvailable()) {
+            console.log("autotype on view component")
+            await this.platformUtilsService.autoType(this.cipher.login.username, this.cipher.login.password)
+            return true;
+        }
+
+        return false;
+    }
+
+    async autoTypeAvailable() {
+        //PoC only done for macOS
+        return this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop
     }
 
     async clone() {

--- a/common/src/abstractions/platformUtils.service.ts
+++ b/common/src/abstractions/platformUtils.service.ts
@@ -23,6 +23,7 @@ export abstract class PlatformUtilsService {
         options?: any) => void;
     showDialog: (body: string, title?: string, confirmText?: string, cancelText?: string,
         type?: string, bodyIsHtml?: boolean) => Promise<boolean>;
+    autoType: (username: string, password: string) => void;
     isDev: () => boolean;
     isSelfHost: () => boolean;
     copyToClipboard: (text: string, options?: any) => void | boolean;

--- a/electron/src/services/electronPlatformUtils.service.ts
+++ b/electron/src/services/electronPlatformUtils.service.ts
@@ -1,25 +1,25 @@
 import {
     clipboard,
     ipcRenderer,
-    shell,
+    shell
 } from 'electron';
-
-import {
-    isDev,
-    isMacAppStore,
-} from '../utils';
-
-import { DeviceType } from 'jslib-common/enums/deviceType';
-import { ThemeType } from 'jslib-common/enums/themeType';
-
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { MessagingService } from 'jslib-common/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { StorageService } from 'jslib-common/abstractions/storage.service';
-
+import { DeviceType } from 'jslib-common/enums/deviceType';
+import { ThemeType } from 'jslib-common/enums/themeType';
 import { ConstantsService } from 'jslib-common/services/constants.service';
-
 import { ElectronConstants } from '../electronConstants';
+import {
+    isDev,
+    isMacAppStore
+} from '../utils';
+
+
+
+
+
 
 export class ElectronPlatformUtilsService implements PlatformUtilsService {
     identityClientId: string;
@@ -148,6 +148,10 @@ export class ElectronPlatformUtilsService implements PlatformUtilsService {
         });
 
         return Promise.resolve(result.response === 0);
+    }
+
+    async autoType(username: string, password: string): Promise<boolean> {
+        return ipcRenderer.invoke('autoType', username, password);
     }
 
     isDev(): boolean {

--- a/node/src/cli/services/cliPlatformUtils.service.ts
+++ b/node/src/cli/services/cliPlatformUtils.service.ts
@@ -1,9 +1,9 @@
 import * as child_process from 'child_process';
-
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { DeviceType } from 'jslib-common/enums/deviceType';
 import { ThemeType } from 'jslib-common/enums/themeType';
 
-import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+
 
 // tslint:disable-next-line
 const open = require('open');
@@ -111,6 +111,11 @@ export class CliPlatformUtilsService implements PlatformUtilsService {
     }
 
     showDialog(text: string, title?: string, confirmText?: string, cancelText?: string, type?: string):
+        Promise<boolean> {
+        throw new Error('Not implemented.');
+    }
+
+    autoTYpe(username: string, password: string):
         Promise<boolean> {
         throw new Error('Not implemented.');
     }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Add basic autotype support (macos only for now)

Please check [Desktop PR 1182](https://github.com/bitwarden/desktop/pull/1182) as its needed as well

## Code changes
* Added a method to check if autotype is available, since for now is only for macos (autoTypeAvailable)
* Added method autoType in view.component
* Added electron handle to call node addon to perform autotype

## Testing requirements
Testing the build and bundle process (specially in other platforms to make sure nothing is broken)



## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
