### PR TITLE
Bump node to 16 and npm 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Intall node-gyp
+      - name: Install node-gyp
         run: |
           npm install -g node-gyp
           node-gyp install $(node -v)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Update NPM
         run: |
-          npm install -g npm@8
           npm install -g node-gyp
           node-gyp install $(node -v)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
           npm install -g node-gyp
           node-gyp install $(node -v)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Update NPM
+      - name: Intall node-gyp
         run: |
           npm install -g node-gyp
           node-gyp install $(node -v)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Common code referenced across Bitwarden JavaScript projects.
 
 ## Requirements
-* [Node.js](https://nodejs.org) v14.17 or greater
-* NPM v7
+* [Node.js](https://nodejs.org) v16.13.1 or greater
+* NPM v8
 * Git
 * node-gyp
 

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -59,9 +59,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "node_modules/@types/node-forge": {
@@ -547,9 +547,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "@types/node-forge": {

--- a/common/package.json
+++ b/common/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/lunr": "^2.3.3",
-    "@types/node": "^14.17.1",
+    "@types/node": "^16.11.12",
     "@types/node-forge": "^0.9.7",
     "@types/papaparse": "^5.2.5",
     "@types/tldjs": "^2.3.0",

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -19,12 +19,13 @@
         "keytar": "7.7.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
       }
     },
     "../common": {
+      "name": "@bitwarden/jslib-common",
       "version": "0.0.0",
       "license": "GPL-3.0",
       "dependencies": {
@@ -41,7 +42,7 @@
       },
       "devDependencies": {
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -104,9 +105,10 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.9",
@@ -637,6 +639,11 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1887,7 +1894,7 @@
         "@microsoft/signalr": "5.0.10",
         "@microsoft/signalr-protocol-msgpack": "5.0.10",
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -1942,9 +1949,10 @@
       }
     },
     "@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.3.9",
@@ -2275,6 +2283,13 @@
         "@electron/get": "^1.0.1",
         "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+          "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+        }
       }
     },
     "electron-log": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "tslint 'src/**/*.ts' 'spec/**/*.ts' --fix"
   },
   "devDependencies": {
-    "@types/node": "^14.17.1",
+    "@types/node": "^16.11.12",
     "rimraf": "^3.0.2",
     "typescript": "4.3.5"
   },

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/inquirer": "^7.3.1",
         "@types/lowdb": "^1.0.10",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-fetch": "^2.5.10",
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
@@ -45,7 +45,7 @@
       },
       "devDependencies": {
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -81,8 +81,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.17.27",
-      "integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -693,7 +694,7 @@
         "@microsoft/signalr": "5.0.10",
         "@microsoft/signalr-protocol-msgpack": "5.0.10",
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -733,8 +734,9 @@
       }
     },
     "@types/node": {
-      "version": "14.17.27",
-      "integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/inquirer": "^7.3.1",
     "@types/lowdb": "^1.0.10",
-    "@types/node": "^14.17.1",
+    "@types/node": "^16.11.12",
     "@types/node-fetch": "^2.5.10",
     "rimraf": "^3.0.2",
     "typescript": "4.3.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@fluffy-spoon/substitute": "^1.202.0",
         "@types/jasmine": "^3.7.6",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "concurrently": "^6.1.0",
         "form-data": "4.0.0",
         "jasmine": "^3.7.0",
@@ -93,7 +93,7 @@
       },
       "devDependencies": {
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -117,7 +117,7 @@
         "keytar": "7.7.0"
       },
       "devDependencies": {
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
       }
@@ -139,7 +139,7 @@
       "devDependencies": {
         "@types/inquirer": "^7.3.1",
         "@types/lowdb": "^1.0.10",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-fetch": "^2.5.10",
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
@@ -624,9 +624,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz",
-      "integrity": "sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg=="
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -2829,6 +2830,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -9698,7 +9704,7 @@
         "@microsoft/signalr": "5.0.10",
         "@microsoft/signalr-protocol-msgpack": "5.0.10",
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -9720,7 +9726,7 @@
       "requires": {
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "electron": "14.2.0",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
@@ -9737,7 +9743,7 @@
         "@bitwarden/jslib-common": "file:../common",
         "@types/inquirer": "^7.3.1",
         "@types/lowdb": "^1.0.10",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-fetch": "^2.5.10",
         "chalk": "^4.1.1",
         "commander": "7.2.0",
@@ -9944,9 +9950,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz",
-      "integrity": "sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg=="
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -11703,6 +11710,13 @@
         "@electron/get": "^1.0.1",
         "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+          "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+        }
       }
     },
     "electron-log": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,8 @@
         "webpack": "^4.46.0"
       },
       "engines": {
-        "node": "~14",
-        "npm": "~7"
+        "node": "~16",
+        "npm": "~8"
       }
     },
     "angular": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@fluffy-spoon/substitute": "^1.202.0",
     "@types/jasmine": "^3.7.6",
-    "@types/node": "^14.17.1",
+    "@types/node": "^16.11.12",
     "concurrently": "^6.1.0",
     "form-data": "4.0.0",
     "jasmine": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@bitwarden/jslib-node": "file:node"
   },
   "engines": {
-    "node": "~14",
-    "npm": "~7"
+    "node": "~16",
+    "npm": "~8"
   }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With our plan to bump electron soon, we need to upgrade Node to v16 (LTS) as newer version of electron require it. Also not a bad idea to move to the newest LTS.

## Code changes
* **package.json:** Updated engine requirements and bumped @types/node to 16.11.12
* **common/package.json:** Bump @types/node to 16.11.12
* **electron/package.json:** Bump @types/node to 16.11.12
* **node/package.json:** Bump @types/node to 16.11.12
* **build.yml:** Setting the build to require node v16 and npm v8
* **README.md:** Updated requirements
* **Various package-lock.json:** Updates after running `npm i`

## Testing requirements
All unit test still green.
Regression testing will be needed on the clients once those are updated

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
