### PR TITLE
FSescure-Importer: Add support for style = global

### DIFF
--- a/common/src/importers/fsecureFskImporter.ts
+++ b/common/src/importers/fsecureFskImporter.ts
@@ -26,7 +26,7 @@ export class FSecureFskImporter extends BaseImporter implements Importer {
             cipher.name = this.getValueOrDefault(value.service);
             cipher.notes = this.getValueOrDefault(value.notes);
 
-            if (value.style === 'website') {
+            if (value.style === 'website' || value.style === 'globe') {
                 cipher.login.username = this.getValueOrDefault(value.username);
                 cipher.login.password = this.getValueOrDefault(value.password);
                 cipher.login.uris = this.makeUriArray(value.url);

--- a/spec/common/importers/fsecureFskImporter.spec.ts
+++ b/spec/common/importers/fsecureFskImporter.spec.ts
@@ -3,53 +3,51 @@ import { FSecureFskImporter as Importer } from 'jslib-common/importers/fsecureFs
 const TestDataWithStyleSetToWebsite: string =
     JSON.stringify({
         data: {
-            "8d58b5cf252dd06fbd98f5289e918ab1":
-            {
-                color: "#00baff",
+            '8d58b5cf252dd06fbd98f5289e918ab1': {
+                color: '#00baff',
                 reatedDate: 1609302913,
-                creditCvv: "",
-                creditExpiry: "",
-                creditNumber: "",
+                creditCvv: '',
+                creditExpiry: '',
+                creditNumber: '',
                 favorite: 0,
                 modifiedDate: 1609302913,
-                notes: "note",
-                password: "word",
+                notes: 'note',
+                password: 'word',
                 passwordList: [],
                 passwordModifiedDate: 1609302913,
                 rev: 1,
-                service: "My first pass",
-                style: "website",
+                service: 'My first pass',
+                style: 'website',
                 type: 1,
-                url: "https://bitwarden.com",
-                username: "pass"
-            }
-        }
+                url: 'https://bitwarden.com',
+                username: 'pass',
+            },
+        },
     });
 
 const TestDataWithStyleSetToGlobe: string =
     JSON.stringify({
         data: {
-            "8d58b5cf252dd06fbd98f5289e918ab1":
-            {
-                color: "#00baff",
+            '8d58b5cf252dd06fbd98f5289e918ab1': {
+                color: '#00baff',
                 reatedDate: 1609302913,
-                creditCvv: "",
-                creditExpiry: "",
-                creditNumber: "",
+                creditCvv: '',
+                creditExpiry: '',
+                creditNumber: '',
                 favorite: 0,
                 modifiedDate: 1609302913,
-                notes: "note",
-                password: "word",
+                notes: 'note',
+                password: 'word',
                 passwordList: [],
                 passwordModifiedDate: 1609302913,
                 rev: 1,
-                service: "My first pass",
-                style: "globe",
+                service: 'My first pass',
+                style: 'globe',
                 type: 1,
-                url: "https://bitwarden.com",
-                username: "pass"
-            }
-        }
+                url: 'https://bitwarden.com',
+                username: 'pass',
+            },
+        },
     });
 
 

--- a/spec/common/importers/fsecureFskImporter.spec.ts
+++ b/spec/common/importers/fsecureFskImporter.spec.ts
@@ -1,0 +1,82 @@
+import { FSecureFskImporter as Importer } from 'jslib-common/importers/fsecureFskImporter';
+
+const TestDataWithStyleSetToWebsite: string =
+    JSON.stringify({
+        data: {
+            "8d58b5cf252dd06fbd98f5289e918ab1":
+            {
+                color: "#00baff",
+                reatedDate: 1609302913,
+                creditCvv: "",
+                creditExpiry: "",
+                creditNumber: "",
+                favorite: 0,
+                modifiedDate: 1609302913,
+                notes: "note",
+                password: "word",
+                passwordList: [],
+                passwordModifiedDate: 1609302913,
+                rev: 1,
+                service: "My first pass",
+                style: "website",
+                type: 1,
+                url: "https://bitwarden.com",
+                username: "pass"
+            }
+        }
+    });
+
+const TestDataWithStyleSetToGlobe: string =
+    JSON.stringify({
+        data: {
+            "8d58b5cf252dd06fbd98f5289e918ab1":
+            {
+                color: "#00baff",
+                reatedDate: 1609302913,
+                creditCvv: "",
+                creditExpiry: "",
+                creditNumber: "",
+                favorite: 0,
+                modifiedDate: 1609302913,
+                notes: "note",
+                password: "word",
+                passwordList: [],
+                passwordModifiedDate: 1609302913,
+                rev: 1,
+                service: "My first pass",
+                style: "globe",
+                type: 1,
+                url: "https://bitwarden.com",
+                username: "pass"
+            }
+        }
+    });
+
+
+describe('FSecure FSK Importer', () => {
+    it('should parse data with style set to website', async () => {
+        const importer = new Importer();
+        const result = await importer.parse(TestDataWithStyleSetToWebsite);
+        expect(result != null).toBe(true);
+
+        const cipher = result.ciphers.shift();
+        expect(cipher.login.username).toEqual('pass');
+        expect(cipher.login.password).toEqual('word');
+        expect(cipher.login.uris.length).toEqual(1);
+        const uriView = cipher.login.uris.shift();
+        expect(uriView.uri).toEqual('https://bitwarden.com');
+    });
+
+    it('should parse data with style set to globe', async () => {
+        const importer = new Importer();
+        const result = await importer.parse(TestDataWithStyleSetToGlobe);
+        expect(result != null).toBe(true);
+
+        const cipher = result.ciphers.shift();
+        expect(cipher.login.username).toEqual('pass');
+        expect(cipher.login.password).toEqual('word');
+        expect(cipher.login.uris.length).toEqual(1);
+        const uriView = cipher.login.uris.shift();
+        expect(uriView.uri).toEqual('https://bitwarden.com');
+    });
+});


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Originally created this PR https://github.com/bitwarden/jslib/pull/303 but the structure of jslib has changed since then. Seemed easier to just create a new PR for it.

Closes bitwarden/web#756

Checks the style-property of a fsk-file and now supports 'website' and 'globe'

Asana task: https://app.asana.com/0/1169444489336079/1199370041222794/f

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **common\src\importers\fsecureFskImporter.ts:** Added support for parsing entries with the style set to global.
* **spec\common\importers\fsecureFskImporter.spec.ts:** Unit tests for parsing entries with style set to `website` and `global`

## Testing requirements
Should be able to import a FSecure file with the styles (website and global)

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
