### PR TITLE
Bump electron to 16

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -14,7 +14,7 @@
         "electron": "16.0.2",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
-        "electron-updater": "4.3.9",
+        "electron-updater": "4.6.1",
         "forcefocus": "^1.1.0",
         "keytar": "7.7.0"
       },
@@ -290,9 +290,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builder-util-runtime": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.5.tgz",
-      "integrity": "sha512-fgUFHKtMNjdvH6PDRFntdIGUPgwZ69sXsAqEulCtoiqgWes5agrMq/Ud274zjJRTbckYh2PHh8/1CpFc6dpsbQ==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
+      "integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
       "dependencies": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -580,15 +580,15 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.9.tgz",
-      "integrity": "sha512-LCNfedSwZfS4Hza+pDyPR05LqHtGorCStaBgVpRnfKxOlZcvpYEX0AbMeH5XUtbtGRoH2V8osbbf2qKPNb7AsA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.6.1.tgz",
+      "integrity": "sha512-YsU1mHqXLrXXmBMsxhxy24PrbaB8rnpZDPmFa2gOkTYk/Ch13+R0fjsRSpPYvqtskVVY0ux8fu+HnUkVkqc7og==",
       "dependencies": {
-        "@types/semver": "^7.3.5",
-        "builder-util-runtime": "8.7.5",
+        "@types/semver": "^7.3.6",
+        "builder-util-runtime": "8.9.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
-        "lazy-val": "^1.0.4",
+        "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.5"
@@ -2084,9 +2084,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "builder-util-runtime": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.5.tgz",
-      "integrity": "sha512-fgUFHKtMNjdvH6PDRFntdIGUPgwZ69sXsAqEulCtoiqgWes5agrMq/Ud274zjJRTbckYh2PHh8/1CpFc6dpsbQ==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
+      "integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
       "requires": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -2307,15 +2307,15 @@
       }
     },
     "electron-updater": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.9.tgz",
-      "integrity": "sha512-LCNfedSwZfS4Hza+pDyPR05LqHtGorCStaBgVpRnfKxOlZcvpYEX0AbMeH5XUtbtGRoH2V8osbbf2qKPNb7AsA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.6.1.tgz",
+      "integrity": "sha512-YsU1mHqXLrXXmBMsxhxy24PrbaB8rnpZDPmFa2gOkTYk/Ch13+R0fjsRSpPYvqtskVVY0ux8fu+HnUkVkqc7og==",
       "requires": {
-        "@types/semver": "^7.3.5",
-        "builder-util-runtime": "8.7.5",
+        "@types/semver": "^7.3.6",
+        "builder-util-runtime": "8.9.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
-        "lazy-val": "^1.0.4",
+        "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.5"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-        "electron": "14.2.0",
+        "electron": "16.0.2",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.3.9",
@@ -546,12 +546,12 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "node_modules/electron": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.0.tgz",
-      "integrity": "sha512-6CmAv1P0xcwK3FQOSA27fHI36/wctSFVgj46VODn56srXXQWeolkK1VzeAFNE613iAuuH9jJdHvE3gz+c7XkNA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
+      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.0.1",
+        "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },
@@ -2276,11 +2276,11 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "electron": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.0.tgz",
-      "integrity": "sha512-6CmAv1P0xcwK3FQOSA27fHI36/wctSFVgj46VODn56srXXQWeolkK1VzeAFNE613iAuuH9jJdHvE3gz+c7XkNA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
+      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
       "requires": {
-        "@electron/get": "^1.0.1",
+        "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },

--- a/electron/package.json
+++ b/electron/package.json
@@ -30,7 +30,7 @@
     "electron": "16.0.2",
     "electron-log": "4.4.1",
     "electron-store": "8.0.1",
-    "electron-updater": "4.3.9",
+    "electron-updater": "4.6.1",
     "forcefocus": "^1.1.0",
     "keytar": "7.7.0"
   }

--- a/electron/package.json
+++ b/electron/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@bitwarden/jslib-common": "file:../common",
     "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-    "electron": "14.2.0",
+    "electron": "16.0.2",
     "electron-log": "4.4.1",
     "electron-store": "8.0.1",
     "electron-updater": "4.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
       "dependencies": {
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-        "electron": "14.2.0",
+        "electron": "16.0.2",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.3.9",
@@ -2721,12 +2721,12 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.0.tgz",
-      "integrity": "sha512-6CmAv1P0xcwK3FQOSA27fHI36/wctSFVgj46VODn56srXXQWeolkK1VzeAFNE613iAuuH9jJdHvE3gz+c7XkNA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
+      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.0.1",
+        "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },
@@ -9727,7 +9727,7 @@
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
         "@types/node": "^16.11.12",
-        "electron": "14.2.0",
+        "electron": "16.0.2",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.3.9",
@@ -11703,11 +11703,11 @@
       "dev": true
     },
     "electron": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.0.tgz",
-      "integrity": "sha512-6CmAv1P0xcwK3FQOSA27fHI36/wctSFVgj46VODn56srXXQWeolkK1VzeAFNE613iAuuH9jJdHvE3gz+c7XkNA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
+      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
       "requires": {
-        "@electron/get": "^1.0.1",
+        "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "electron": "16.0.2",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
-        "electron-updater": "4.3.9",
+        "electron-updater": "4.6.1",
         "forcefocus": "^1.1.0",
         "keytar": "7.7.0"
       },
@@ -1642,9 +1642,9 @@
       "dev": true
     },
     "node_modules/builder-util-runtime": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.5.tgz",
-      "integrity": "sha512-fgUFHKtMNjdvH6PDRFntdIGUPgwZ69sXsAqEulCtoiqgWes5agrMq/Ud274zjJRTbckYh2PHh8/1CpFc6dpsbQ==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
+      "integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
       "dependencies": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -2755,15 +2755,15 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.9.tgz",
-      "integrity": "sha512-LCNfedSwZfS4Hza+pDyPR05LqHtGorCStaBgVpRnfKxOlZcvpYEX0AbMeH5XUtbtGRoH2V8osbbf2qKPNb7AsA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.6.1.tgz",
+      "integrity": "sha512-YsU1mHqXLrXXmBMsxhxy24PrbaB8rnpZDPmFa2gOkTYk/Ch13+R0fjsRSpPYvqtskVVY0ux8fu+HnUkVkqc7og==",
       "dependencies": {
-        "@types/semver": "^7.3.5",
-        "builder-util-runtime": "8.7.5",
+        "@types/semver": "^7.3.6",
+        "builder-util-runtime": "8.9.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
-        "lazy-val": "^1.0.4",
+        "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.5"
@@ -9730,7 +9730,7 @@
         "electron": "16.0.2",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
-        "electron-updater": "4.3.9",
+        "electron-updater": "4.6.1",
         "forcefocus": "^1.1.0",
         "keytar": "7.7.0",
         "rimraf": "^3.0.2",
@@ -10826,9 +10826,9 @@
       "dev": true
     },
     "builder-util-runtime": {
-      "version": "8.7.5",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.5.tgz",
-      "integrity": "sha512-fgUFHKtMNjdvH6PDRFntdIGUPgwZ69sXsAqEulCtoiqgWes5agrMq/Ud274zjJRTbckYh2PHh8/1CpFc6dpsbQ==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
+      "integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
       "requires": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -11734,15 +11734,15 @@
       }
     },
     "electron-updater": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.3.9.tgz",
-      "integrity": "sha512-LCNfedSwZfS4Hza+pDyPR05LqHtGorCStaBgVpRnfKxOlZcvpYEX0AbMeH5XUtbtGRoH2V8osbbf2qKPNb7AsA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.6.1.tgz",
+      "integrity": "sha512-YsU1mHqXLrXXmBMsxhxy24PrbaB8rnpZDPmFa2gOkTYk/Ch13+R0fjsRSpPYvqtskVVY0ux8fu+HnUkVkqc7og==",
       "requires": {
-        "@types/semver": "^7.3.5",
-        "builder-util-runtime": "8.7.5",
+        "@types/semver": "^7.3.6",
+        "builder-util-runtime": "8.9.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
-        "lazy-val": "^1.0.4",
+        "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.5"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
To stay up-to-date with electron release schedule, bumping electron dependencies
Asana-task: https://app.asana.com/0/1200804338582616/1201506018477649/f

## Code changes
* **electron/package.json:** Updated `electron` to `16.0.2` and `electron-updater` to `4.6.1`
* **electron/package-lock.json:** Changes after running `npm i` in /electron/
* **package-lock.json:** Changes after running `npm i` in /

## Testing requirements
No testing necessary, testing will be done in the desktop client and directory-connector

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
