### PR TITLE
[bug] Correct storage location of organizations

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1081,13 +1081,13 @@ export class StateService implements StateServiceAbstraction {
     }
 
     async getOrganizations(options?: StorageOptions): Promise<{ [id: string]: OrganizationData; }> {
-        return (await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions)))?.data?.organizations;
+        return (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))?.data?.organizations;
     }
 
     async setOrganizations(value: { [id: string]: OrganizationData; }, options?: StorageOptions): Promise<void> {
-        const account = await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions));
+        const account = await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()));
         account.data.organizations = value;
-        await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
+        await this.saveAccount(account, this.reconcileOptions(options, await this.defaultOnDiskOptions()));
     }
 
     async getPasswordGenerationOptions(options?: StorageOptions): Promise<any> {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Organizations are being stored in memory but we need that information to persist in session

## Code changes
* Changed the storage location of organizations

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
