### PR TITLE
Use MP policies when registering a new user through SSO

### DIFF
--- a/angular/src/components/change-password.component.ts
+++ b/angular/src/components/change-password.component.ts
@@ -40,7 +40,7 @@ export class ChangePasswordComponent implements OnInit {
 
   async ngOnInit() {
     this.email = await this.stateService.getEmail();
-    this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions();
+    this.enforcedPolicyOptions ??= await this.policyService.getMasterPasswordPolicyOptions();
   }
 
   async submit() {

--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -79,6 +79,7 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
         const response = await this.apiService.getOrganizationAutoEnrollStatus(this.identifier);
         this.orgId = response.id;
         this.resetPasswordAutoEnroll = response.resetPasswordEnabled;
+        this.enforcedPolicyOptions =  await this.policyService.getMasterPasswordPoliciesForInvitedUsers(this.orgId);
       } catch {
         this.platformUtilsService.showToast("error", null, this.i18nService.t("errorOccurred"));
       }

--- a/angular/src/components/set-password.component.ts
+++ b/angular/src/components/set-password.component.ts
@@ -79,7 +79,8 @@ export class SetPasswordComponent extends BaseChangePasswordComponent {
         const response = await this.apiService.getOrganizationAutoEnrollStatus(this.identifier);
         this.orgId = response.id;
         this.resetPasswordAutoEnroll = response.resetPasswordEnabled;
-        this.enforcedPolicyOptions =  await this.policyService.getMasterPasswordPoliciesForInvitedUsers(this.orgId);
+        this.enforcedPolicyOptions =
+          await this.policyService.getMasterPasswordPoliciesForInvitedUsers(this.orgId);
       } catch {
         this.platformUtilsService.showToast("error", null, this.i18nService.t("errorOccurred"));
       }

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -355,6 +355,10 @@ export abstract class ApiService {
     email: string,
     organizationUserId: string
   ) => Promise<ListResponse<PolicyResponse>>;
+  getPoliciesByInvitedUser: (
+    organizationId: string,
+    userId: string
+  ) => Promise<ListResponse<PolicyResponse>>;
   putPolicy: (
     organizationId: string,
     type: PolicyType,

--- a/common/src/abstractions/policy.service.ts
+++ b/common/src/abstractions/policy.service.ts
@@ -15,6 +15,7 @@ export abstract class PolicyService {
   getPolicyForOrganization: (policyType: PolicyType, organizationId: string) => Promise<Policy>;
   replace: (policies: { [id: string]: PolicyData }) => Promise<any>;
   clear: (userId?: string) => Promise<any>;
+  getMasterPasswordPoliciesForInvitedUsers: (orgId: string) => Promise<MasterPasswordPolicyOptions>;
   getMasterPasswordPolicyOptions: (policies?: Policy[]) => Promise<MasterPasswordPolicyOptions>;
   evaluateMasterPassword: (
     passwordStrength: number,

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -1047,6 +1047,24 @@ export class ApiService implements ApiServiceAbstraction {
     return new ListResponse(r, PolicyResponse);
   }
 
+  async getPoliciesByInvitedUser(
+      organizationId: string,
+      userId: string
+    ): Promise<ListResponse<PolicyResponse>> {
+    const r = await this.send(
+        "GET",
+        "/organizations/" +
+        organizationId +
+        "/policies/invited-user?" +
+        "userId=" +
+        userId, 
+        null,
+        false,
+        true
+    );
+    return new ListResponse(r, PolicyResponse);
+  }
+
   async putPolicy(
     organizationId: string,
     type: PolicyType,

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -1048,19 +1048,15 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   async getPoliciesByInvitedUser(
-      organizationId: string,
-      userId: string
-    ): Promise<ListResponse<PolicyResponse>> {
+    organizationId: string,
+    userId: string
+  ): Promise<ListResponse<PolicyResponse>> {
     const r = await this.send(
-        "GET",
-        "/organizations/" +
-        organizationId +
-        "/policies/invited-user?" +
-        "userId=" +
-        userId, 
-        null,
-        false,
-        true
+      "GET",
+      "/organizations/" + organizationId + "/policies/invited-user?" + "userId=" + userId,
+      null,
+      false,
+      true
     );
     return new ListResponse(r, PolicyResponse);
   }

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -78,11 +78,13 @@ export class PolicyService implements PolicyServiceAbstraction {
     await this.stateService.setEncryptedPolicies(null, { userId: userId });
   }
 
-  async getMasterPasswordPoliciesForInvitedUsers(orgId: string): Promise<MasterPasswordPolicyOptions> {
+  async getMasterPasswordPoliciesForInvitedUsers(
+    orgId: string
+  ): Promise<MasterPasswordPolicyOptions> {
     const userId = await this.stateService.getUserId();
-    var response =  await this.apiService.getPoliciesByInvitedUser(orgId, userId);
-    var policies = await this.mapPoliciesFromToken(response);
-    return this.getMasterPasswordPolicyOptions(policies)
+    const response = await this.apiService.getPoliciesByInvitedUser(orgId, userId);
+    const policies = await this.mapPoliciesFromToken(response);
+    return this.getMasterPasswordPolicyOptions(policies);
   }
 
   async getMasterPasswordPolicyOptions(policies?: Policy[]): Promise<MasterPasswordPolicyOptions> {

--- a/common/src/services/policy.service.ts
+++ b/common/src/services/policy.service.ts
@@ -78,6 +78,13 @@ export class PolicyService implements PolicyServiceAbstraction {
     await this.stateService.setEncryptedPolicies(null, { userId: userId });
   }
 
+  async getMasterPasswordPoliciesForInvitedUsers(orgId: string): Promise<MasterPasswordPolicyOptions> {
+    const userId = await this.stateService.getUserId();
+    var response =  await this.apiService.getPoliciesByInvitedUser(orgId, userId);
+    var policies = await this.mapPoliciesFromToken(response);
+    return this.getMasterPasswordPolicyOptions(policies)
+  }
+
   async getMasterPasswordPolicyOptions(policies?: Policy[]): Promise<MasterPasswordPolicyOptions> {
     let enforcedOptions: MasterPasswordPolicyOptions = null;
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Asana Task: https://app.asana.com/0/1169444489336079/1201499725597872/f
Dependency: https://github.com/bitwarden/server/pull/1779
Users currently don't have their master password checked against the organization policy while registering via SSO. This fix checks if the user is registering a new account, and if so pulls org policies from the endpoint created in the server dependency.

**Will be cherry picked to rc**

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **angular/src/components/change-password.component.ts:** Fill policies if user is not registering for first time
- **angular/src/components/set-password.component.ts:** If identifier is set (registering), fill policies using userId and orgId
- **common/src/services/policy.service.ts:** Add method for finding policies if userId is an invited user to organization
- **common/src/services/api.service.ts:** Call to get policies for invited users

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Test all registration methods for MP policies
    - sso
        - invitation
        - no invitation
    - non-sso
        - invitation

**Note: Existing accounts using an invitation will still not work and out of scope for this task**
See: https://app.asana.com/0/1169444489336079/1200003629652775/f

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
