### PR TITLE
[bug] Use Account constructor when calling addAccount

### DIFF
--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -545,7 +545,7 @@ export class AuthService implements AuthServiceAbstraction {
 
     const accountInformation = await this.tokenService.decodeToken(tokenResponse.accessToken);
     await this.stateService.addAccount(
-      new Account({
+      new Account(new Account({
         profile: {
           ...new AccountProfile(),
           ...{
@@ -570,7 +570,7 @@ export class AuthService implements AuthServiceAbstraction {
             refreshToken: tokenResponse.refreshToken,
           },
         },
-      })
+      }))
     );
 
     if (tokenResponse.twoFactorToken != null) {

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -545,32 +545,34 @@ export class AuthService implements AuthServiceAbstraction {
 
     const accountInformation = await this.tokenService.decodeToken(tokenResponse.accessToken);
     await this.stateService.addAccount(
-      new Account(new Account({
-        profile: {
-          ...new AccountProfile(),
-          ...{
-            userId: accountInformation.sub,
-            email: accountInformation.email,
-            apiKeyClientId: clientId,
-            hasPremiumPersonally: accountInformation.premium,
-            kdfIterations: tokenResponse.kdfIterations,
-            kdfType: tokenResponse.kdf,
+      new Account(
+        new Account({
+          profile: {
+            ...new AccountProfile(),
+            ...{
+              userId: accountInformation.sub,
+              email: accountInformation.email,
+              apiKeyClientId: clientId,
+              hasPremiumPersonally: accountInformation.premium,
+              kdfIterations: tokenResponse.kdfIterations,
+              kdfType: tokenResponse.kdf,
+            },
           },
-        },
-        keys: {
-          ...new AccountKeys(),
-          ...{
-            apiKeyClientSecret: clientSecret,
+          keys: {
+            ...new AccountKeys(),
+            ...{
+              apiKeyClientSecret: clientSecret,
+            },
           },
-        },
-        tokens: {
-          ...new AccountTokens(),
-          ...{
-            accessToken: tokenResponse.accessToken,
-            refreshToken: tokenResponse.refreshToken,
+          tokens: {
+            ...new AccountTokens(),
+            ...{
+              accessToken: tokenResponse.accessToken,
+              refreshToken: tokenResponse.refreshToken,
+            },
           },
-        },
-      }))
+        })
+      )
     );
 
     if (tokenResponse.twoFactorToken != null) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
In order to ensure accounts are fully initialized when added we need to call the Account constructor when signing in instead of passing in just a partial object.

## Code changes
* Use the Account constructor when calling addAccount from the AuthService

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
