### PR TITLE
[bug] Add several state value defaults

### DIFF
--- a/common/src/enums/stateVersion.ts
+++ b/common/src/enums/stateVersion.ts
@@ -1,0 +1,5 @@
+export enum StateVersion {
+  One = 1, // Original flat key/value pair store
+  Two = 2, // Move to a typed State object
+  Latest = Two,
+}

--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -139,7 +139,7 @@ export class AccountSettings {
   protectedPin?: string;
   settings?: any; // TODO: Merge whatever is going on here into the AccountSettings model properly
   vaultTimeout?: number;
-  vaultTimeoutAction?: string;
+  vaultTimeoutAction?: string = "lock";
 }
 
 export class AccountTokens {

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -2,14 +2,14 @@ export class GlobalState {
   enableAlwaysOnTop?: boolean;
   installedVersion?: string;
   lastActive?: number;
-  locale?: string;
+  locale?: string = "en";
   openAtLogin?: boolean;
   organizationInvitation?: any;
   ssoCodeVerifier?: string;
   ssoOrganizationIdentifier?: string;
   ssoState?: string;
   rememberedEmail?: string;
-  theme?: string;
+  theme?: string = "light";
   window?: Map<string, any> = new Map<string, any>();
   twoFactorToken?: string;
   disableFavicon?: boolean;
@@ -23,7 +23,7 @@ export class GlobalState {
   biometricText?: string;
   noAutoPromptBiometrics?: boolean;
   noAutoPromptBiometricsText?: string;
-  stateVersion: number;
+  stateVersion: number = 2;
   environmentUrls?: any = {
     server: "bitwarden.com",
   };

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -25,7 +25,7 @@ export class GlobalState {
   biometricText?: string;
   noAutoPromptBiometrics?: boolean;
   noAutoPromptBiometricsText?: string;
-  stateVersion: number = StateVersion.Latest;
+  stateVersion: StateVersion = StateVersion.Latest;
   environmentUrls?: any = {
     server: "bitwarden.com",
   };

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -1,3 +1,5 @@
+import { StateVersion } from "../../enums/stateVersion";
+
 export class GlobalState {
   enableAlwaysOnTop?: boolean;
   installedVersion?: string;
@@ -23,7 +25,7 @@ export class GlobalState {
   biometricText?: string;
   noAutoPromptBiometrics?: boolean;
   noAutoPromptBiometricsText?: string;
-  stateVersion: number = 2;
+  stateVersion: number = StateVersion.Latest;
   environmentUrls?: any = {
     server: "bitwarden.com",
   };

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -74,7 +74,6 @@ export class StateService<TAccount extends Account = Account>
       );
       this.state = diskState;
       await this.pruneInMemoryAccounts();
-      await this.saveStateToStorage(this.state, await this.defaultOnDiskMemoryOptions());
       await this.pushAccounts();
     }
   }

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -17,6 +17,7 @@ import { SendData } from "../models/data/sendData";
 
 import { HtmlStorageLocation } from "../enums/htmlStorageLocation";
 import { KdfType } from "../enums/kdfType";
+import { StateVersion } from "../enums/stateVersion";
 
 // Originally (before January 2022) storage was handled as a flat key/value pair store.
 // With the move to a typed object for state storage these keys should no longer be in use anywhere outside of this migration.
@@ -125,12 +126,13 @@ export class StateMigrationService {
         htmlStorageLocation: HtmlStorageLocation.Local,
       })
     )?.globals?.stateVersion;
-    return currentStateVersion == null || currentStateVersion < this.latestVersion;
+    return currentStateVersion == null || currentStateVersion < StateVersion.Latest;
   }
 
   async migrate(): Promise<void> {
     let currentStateVersion =
-      (await this.storageService.get<State<Account>>("state"))?.globals?.stateVersion ?? 1;
+      (await this.storageService.get<State<Account>>("state"))?.globals?.stateVersion ??
+      StateVersion.One;
     while (currentStateVersion < this.latestVersion) {
       switch (currentStateVersion) {
         case 1:
@@ -208,7 +210,7 @@ export class StateMigrationService {
                 v1Keys.rememberedEmail,
                 options
               ),
-              stateVersion: 2,
+              stateVersion: StateVersion.Two,
               theme: await this.storageService.get<string>(v1Keys.theme, options),
               twoFactorToken: await this.storageService.get<string>(
                 v1KeyPrefixes.twoFactorToken + userId,

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -113,8 +113,6 @@ const v1KeyPrefixes = {
 };
 
 export class StateMigrationService {
-  readonly latestVersion: number = 2;
-
   constructor(
     protected storageService: StorageService,
     protected secureStorageService: StorageService
@@ -133,9 +131,9 @@ export class StateMigrationService {
     let currentStateVersion =
       (await this.storageService.get<State<Account>>("state"))?.globals?.stateVersion ??
       StateVersion.One;
-    while (currentStateVersion < this.latestVersion) {
+    while (currentStateVersion < StateVersion.Latest) {
       switch (currentStateVersion) {
-        case 1:
+        case StateVersion.One:
           await this.migrateStateFrom1To2();
           break;
       }

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -2,6 +2,7 @@ import { StorageService } from "../abstractions/storage.service";
 
 import { Account } from "../models/domain/account";
 import { GeneratedPasswordHistory } from "../models/domain/generatedPasswordHistory";
+import { GlobalState } from "../models/domain/globalState";
 import { State } from "../models/domain/state";
 import { StorageOptions } from "../models/domain/storageOptions";
 
@@ -147,9 +148,7 @@ export class StateMigrationService {
     const initialState: State<Account> =
       userId == null
         ? {
-            globals: {
-              stateVersion: 2,
-            },
+            globals: new GlobalState(),
             accounts: {},
             activeUserId: null,
           }


### PR DESCRIPTION
## Related Work
- [Asana Task](https://app.asana.com/0/inbox/1183359552741416/1201592404236978/1201607436480545)
- https://github.com/bitwarden/web/pull/1365

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The storage engine refactor created a bug where dropdown setting values are not defaulting appropriately, most noticeable on web where a vault timeout of "never" should only be allowed for dev, but instead was being applied as a default for all environments. This is addressed in two parts: a jslib PR that sets defaults for locale, theme, and timeout action (as those are the same on each client) and a web PR that extends the account model and sets an appropriate default for vault timeout duration based on environment. 

I fixed one other thing while in the area: simply removing a call to set InMemory state while loading state from disk. This simply isn't needed and was added as a misunderstanding - the OnDiskInMemory options are a web specific location for secure storage, and likely needs to be removed completely. 

## Code changes
* Added defaults for theme, locale, timeout action, and state version
* Adjusted the migrator to use an initialized GlobalState instead of a hardcoded partial 
* Removed the call to save disk loaded state to the HtmlStorageServices's memory store

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
