### PR TITLE
Rename all occurrences of fb to formBuilder

### DIFF
--- a/angular/src/components/export.component.ts
+++ b/angular/src/components/export.component.ts
@@ -20,7 +20,7 @@ export class ExportComponent implements OnInit {
   formPromise: Promise<string>;
   disabledByPolicy: boolean = false;
 
-  exportForm = this.fb.group({
+  exportForm = this.formBuilder.group({
     format: ["json"],
     secret: [""],
   });
@@ -41,7 +41,7 @@ export class ExportComponent implements OnInit {
     protected win: Window,
     private logService: LogService,
     private userVerificationService: UserVerificationService,
-    private fb: FormBuilder
+    private formBuilder: FormBuilder
   ) {}
 
   async ngOnInit() {

--- a/angular/src/components/settings/vault-timeout-input.component.ts
+++ b/angular/src/components/settings/vault-timeout-input.component.ts
@@ -21,9 +21,9 @@ export class VaultTimeoutInputComponent implements ControlValueAccessor, Validat
 
   static CUSTOM_VALUE = -100;
 
-  form = this.fb.group({
+  form = this.formBuilder.group({
     vaultTimeout: [null],
-    custom: this.fb.group({
+    custom: this.formBuilder.group({
       hours: [null],
       minutes: [null],
     }),
@@ -38,7 +38,7 @@ export class VaultTimeoutInputComponent implements ControlValueAccessor, Validat
   private validatorChange: () => void;
 
   constructor(
-    private fb: FormBuilder,
+    private formBuilder: FormBuilder,
     private policyService: PolicyService,
     private i18nService: I18nService
   ) {}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Rename all occurrences of fb to formBuilder as it can be confusing.

## Code changes

There were a lot less files to fix than I thought. The only two were:
- **angular/src/components/export.component.ts**
- **angular/src/components/settings/vault-timeout-input.component.ts**


## Testing requirements

No functionality changes, just make sure the Export Vault form and Custom Vault Timeout forms behave as expected.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
