### PR TITLE
Master password policy is not checked when accepting invite from an existing account

### DIFF
--- a/angular/src/components/update-password.component.ts
+++ b/angular/src/components/update-password.component.ts
@@ -1,0 +1,134 @@
+import { Directive } from "@angular/core";
+import { Router } from "@angular/router";
+
+import { ApiService } from "jslib-common/abstractions/api.service";
+import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { I18nService } from "jslib-common/abstractions/i18n.service";
+import { LogService } from "jslib-common/abstractions/log.service";
+import { MessagingService } from "jslib-common/abstractions/messaging.service";
+import { PasswordGenerationService } from "jslib-common/abstractions/passwordGeneration.service";
+import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
+import { PolicyService } from "jslib-common/abstractions/policy.service";
+import { UserVerificationService } from "jslib-common/abstractions/userVerification.service";
+import { StateService } from "jslib-common/abstractions/state.service";
+
+import { ChangePasswordComponent as BaseChangePasswordComponent } from "./change-password.component";
+
+import { EncString } from "jslib-common/models/domain/encString";
+import { MasterPasswordPolicyOptions } from "jslib-common/models/domain/masterPasswordPolicyOptions";
+import { SymmetricCryptoKey } from "jslib-common/models/domain/symmetricCryptoKey";
+
+import { PasswordRequest } from "jslib-common/models/request/passwordRequest";
+import { VerificationType } from "jslib-common/enums/verificationType";
+import { Verification } from "jslib-common/types/verification";
+
+@Directive()
+export class UpdatePasswordComponent extends BaseChangePasswordComponent {
+  hint: string;
+  key: string;
+  enforcedPolicyOptions: MasterPasswordPolicyOptions;
+  showPassword: boolean = false;
+  currentMasterPassword: string;
+
+  onSuccessfulChangePassword: () => Promise<any>;
+
+  constructor(
+    protected router:Router,
+    i18nService: I18nService,
+    platformUtilsService: PlatformUtilsService,
+    passwordGenerationService: PasswordGenerationService,
+    policyService: PolicyService,
+    cryptoService: CryptoService,
+    messagingService: MessagingService,
+    private apiService: ApiService,
+    stateService: StateService,
+    private userVerificationService: UserVerificationService,
+    private logService: LogService
+  ) {
+    super(
+      i18nService,
+      cryptoService,
+      messagingService,
+      passwordGenerationService,
+      platformUtilsService,
+      policyService,
+      stateService
+    );
+  }
+
+  togglePassword(confirmField: boolean) {
+    this.showPassword = !this.showPassword;
+    document.getElementById(confirmField ? "masterPasswordRetype" : "masterPassword").focus();
+  }
+
+  async cancel() {
+    await this.stateService.setOrganizationInvitation(null);
+    await this.stateService.setLoginRedirect(null);
+    this.router.navigate(["/vault"]);
+  }
+
+  async setupSubmitActions(): Promise<boolean> {
+    if (this.currentMasterPassword == null || this.currentMasterPassword === "") {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        this.i18nService.t("masterPassRequired")
+      );
+      return false;
+    }
+
+    const secret: Verification = {
+      type: VerificationType.MasterPassword,
+      secret: this.currentMasterPassword
+    };
+    try {
+      await this.userVerificationService.verifyUser(secret);
+    } catch (e) {
+      this.platformUtilsService.showToast(
+        "error",
+        this.i18nService.t("errorOccurred"),
+        e.message
+      );
+      return false;
+    }
+
+
+    this.kdf = await this.stateService.getKdfType();
+    this.kdfIterations = await this.stateService.getKdfIterations();
+    return true;
+  }
+
+  async performSubmitActions(
+    masterPasswordHash: string,
+    key: SymmetricCryptoKey,
+    encKey: [SymmetricCryptoKey, EncString]
+  ) {
+    try {
+      // Create Request
+      const request = new PasswordRequest();
+      request.masterPasswordHash = await this.cryptoService.hashPassword(
+        this.currentMasterPassword,
+        null
+      );
+      request.newMasterPasswordHash = masterPasswordHash;
+      request.key = encKey[1].encryptedString;
+
+      //Update user's password
+       var k = this.apiService.postPassword(request);
+
+      this.platformUtilsService.showToast(
+        "success",
+        this.i18nService.t("masterPasswordChanged"),
+        this.i18nService.t("logBackIn")
+      );
+
+      if (this.onSuccessfulChangePassword != null) {
+        this.onSuccessfulChangePassword();
+      } else {
+        this.messagingService.send("logout");
+      }
+    } catch (e) {
+      this.logService.error(e);
+    }
+  }
+}

--- a/angular/src/components/update-password.component.ts
+++ b/angular/src/components/update-password.component.ts
@@ -9,18 +9,19 @@ import { MessagingService } from "jslib-common/abstractions/messaging.service";
 import { PasswordGenerationService } from "jslib-common/abstractions/passwordGeneration.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { PolicyService } from "jslib-common/abstractions/policy.service";
-import { UserVerificationService } from "jslib-common/abstractions/userVerification.service";
 import { StateService } from "jslib-common/abstractions/state.service";
+import { UserVerificationService } from "jslib-common/abstractions/userVerification.service";
 
 import { ChangePasswordComponent as BaseChangePasswordComponent } from "./change-password.component";
 
 import { EncString } from "jslib-common/models/domain/encString";
 import { MasterPasswordPolicyOptions } from "jslib-common/models/domain/masterPasswordPolicyOptions";
-import { SymmetricCryptoKey } from "jslib-common/models/domain/symmetricCryptoKey";
-
 import { PasswordRequest } from "jslib-common/models/request/passwordRequest";
+
 import { VerificationType } from "jslib-common/enums/verificationType";
 import { Verification } from "jslib-common/types/verification";
+
+import { SymmetricCryptoKey } from "jslib-common/models/domain/symmetricCryptoKey";
 
 @Directive()
 export class UpdatePasswordComponent extends BaseChangePasswordComponent {
@@ -33,7 +34,7 @@ export class UpdatePasswordComponent extends BaseChangePasswordComponent {
   onSuccessfulChangePassword: () => Promise<any>;
 
   constructor(
-    protected router:Router,
+    protected router: Router,
     i18nService: I18nService,
     platformUtilsService: PlatformUtilsService,
     passwordGenerationService: PasswordGenerationService,
@@ -79,19 +80,14 @@ export class UpdatePasswordComponent extends BaseChangePasswordComponent {
 
     const secret: Verification = {
       type: VerificationType.MasterPassword,
-      secret: this.currentMasterPassword
+      secret: this.currentMasterPassword,
     };
     try {
       await this.userVerificationService.verifyUser(secret);
     } catch (e) {
-      this.platformUtilsService.showToast(
-        "error",
-        this.i18nService.t("errorOccurred"),
-        e.message
-      );
+      this.platformUtilsService.showToast("error", this.i18nService.t("errorOccurred"), e.message);
       return false;
     }
-
 
     this.kdf = await this.stateService.getKdfType();
     this.kdfIterations = await this.stateService.getKdfIterations();
@@ -113,8 +109,8 @@ export class UpdatePasswordComponent extends BaseChangePasswordComponent {
       request.newMasterPasswordHash = masterPasswordHash;
       request.key = encKey[1].encryptedString;
 
-      //Update user's password
-       var k = this.apiService.postPassword(request);
+      // Update user's password
+      this.apiService.postPassword(request);
 
       this.platformUtilsService.showToast(
         "success",


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Asana: https://app.asana.com/0/1169444489336079/1200003629652775/f

We currently don't check master passwords against the org policy when accepting an invite from an existing account. We can't perform this server side as the password is encrypted, so this PR introduces the validation in the web client.

When a user logs in to accept an invite, we will check the password against the organization policy. If it fails, we ask the user to change their password to accept the invitation. Once the user changes it, we log out and require the user to log in once more with the changed password to accept the invitation. If the user cancels, we clear the org invite from storage and navigate them to the vault. 

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **angular/src/components/update-password.component.ts:** Create a new update-password component. We can't reuse the update-temp-password component because temporary password changes don't require the current password in the API call. We also perform validation to make sure the current password they enter is correct.
- Web: https://github.com/bitwarden/web/pull/1371

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Entire log in workflow should be tested to make sure the new update-password component doesn't show erroneously.
- Check the log in (and password update) workflow when accepting invite.
- Check the log in (and password update) workflow when accepting an invite for additional orgs.
- These changes shouldn't impact SSO or new user registration workflow.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
