### PR TITLE
[Bug] [Account Switching] Ensure EnvironmentUrls Pull From The Correction Location On Account Add

### DIFF
--- a/common/src/abstractions/state.service.ts
+++ b/common/src/abstractions/state.service.ts
@@ -14,6 +14,7 @@ import { SendData } from "../models/data/sendData";
 
 import { Account } from "../models/domain/account";
 import { EncString } from "../models/domain/encString";
+import { EnvironmentUrls } from "../models/domain/environmentUrls";
 import { GeneratedPasswordHistory } from "../models/domain/generatedPasswordHistory";
 import { Policy } from "../models/domain/policy";
 import { StorageOptions } from "../models/domain/storageOptions";
@@ -213,8 +214,8 @@ export abstract class StateService<T extends Account = Account> {
   setEntityId: (value: string, options?: StorageOptions) => Promise<void>;
   getEntityType: (options?: StorageOptions) => Promise<any>;
   setEntityType: (value: string, options?: StorageOptions) => Promise<void>;
-  getEnvironmentUrls: (options?: StorageOptions) => Promise<any>;
-  setEnvironmentUrls: (value: any, options?: StorageOptions) => Promise<void>;
+  getEnvironmentUrls: (options?: StorageOptions) => Promise<EnvironmentUrls>;
+  setEnvironmentUrls: (value: EnvironmentUrls, options?: StorageOptions) => Promise<void>;
   getEquivalentDomains: (options?: StorageOptions) => Promise<any>;
   setEquivalentDomains: (value: string, options?: StorageOptions) => Promise<void>;
   getEventCollection: (options?: StorageOptions) => Promise<EventData[]>;

--- a/common/src/models/domain/environmentUrls.ts
+++ b/common/src/models/domain/environmentUrls.ts
@@ -1,10 +1,10 @@
 export class EnvironmentUrls {
-  base: string;
-  api: string;
-  identity: string;
-  icons: string;
-  notifications: string;
-  events: string;
-  webVault: string;
-  keyConnector: string;
+  base: string = null;
+  api: string = null;
+  identity: string = null;
+  icons: string = null;
+  notifications: string = null;
+  events: string = null;
+  webVault: string = null;
+  keyConnector: string = null;
 }

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1361,15 +1361,15 @@ export class StateService<TAccount extends Account = Account>
     );
   }
 
-  async getEnvironmentUrls(options?: StorageOptions): Promise<any> {
-    options = this.reconcileOptions(options, await this.defaultOnDiskOptions());
+  async getEnvironmentUrls(options?: StorageOptions): Promise<EnvironmentUrls> {
     if (this.state.activeUserId == null) {
-      return (await this.getGlobals(options)).environmentUrls ?? new EnvironmentUrls();
+      return await this.getGlobalEnvironmentUrls(options);
     }
+    options = this.reconcileOptions(options, await this.defaultOnDiskOptions());
     return (await this.getAccount(options))?.settings?.environmentUrls ?? new EnvironmentUrls();
   }
 
-  async setEnvironmentUrls(value: any, options?: StorageOptions): Promise<void> {
+  async setEnvironmentUrls(value: EnvironmentUrls, options?: StorageOptions): Promise<void> {
     // Global values are set on each change and the current global settings are passed to any newly authed accounts.
     // This is to allow setting environement values before an account is active, while still allowing individual accounts to have their own environments.
     const globals = await this.getGlobals(
@@ -2377,7 +2377,12 @@ export class StateService<TAccount extends Account = Account>
   }
 
   protected async setAccountEnvironmentUrls(account: TAccount): Promise<TAccount> {
-    account.settings.environmentUrls = await this.getEnvironmentUrls();
+    account.settings.environmentUrls = await this.getGlobalEnvironmentUrls();
     return account;
+  }
+
+  protected async getGlobalEnvironmentUrls(options?: StorageOptions): Promise<EnvironmentUrls> {
+    options = this.reconcileOptions(options, await this.defaultOnDiskOptions());
+    return (await this.getGlobals(options)).environmentUrls ?? new EnvironmentUrls();
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/inbox/1183359552741416/1201638560333663/1201628380941783

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
To allow for setting environmentUrls before an account is created we save that value as a global setting and then apply it to any newly authed accounts.

There is a bug that will instead save the urls used by the previous logged in account, making account switching with multiple servers cause errors. This PR addresses this.

## Code changes
See commits and descriptions

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
