### PR TITLE
[Account Switching] Fix options dropdowns being empty

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -355,8 +355,12 @@ export class StateService<TAccount extends Account = Account>
 
   async getClearClipboard(options?: StorageOptions): Promise<number> {
     return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.settings?.clearClipboard ?? null;
+      (
+        await this.getAccount(
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+        )
+      )?.settings?.clearClipboard ?? null
+    );
   }
 
   async setClearClipboard(value: number, options?: StorageOptions): Promise<void> {
@@ -1603,8 +1607,12 @@ export class StateService<TAccount extends Account = Account>
 
   async getLocale(options?: StorageOptions): Promise<string> {
     return (
-      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.locale ?? null;
+      (
+        await this.getGlobals(
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+        )
+      )?.locale ?? null
+    );
   }
 
   async setLocale(value: string, options?: StorageOptions): Promise<void> {
@@ -1945,8 +1953,12 @@ export class StateService<TAccount extends Account = Account>
 
   async getTheme(options?: StorageOptions): Promise<string> {
     return (
-      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.theme ?? null;
+      (
+        await this.getGlobals(
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+        )
+      )?.theme ?? null
+    );
   }
 
   async setTheme(value: string, options?: StorageOptions): Promise<void> {

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1607,12 +1607,8 @@ export class StateService<TAccount extends Account = Account>
 
   async getLocale(options?: StorageOptions): Promise<string> {
     return (
-      (
-        await this.getGlobals(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
-        )
-      )?.locale ?? null
-    );
+      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.locale;
   }
 
   async setLocale(value: string, options?: StorageOptions): Promise<void> {
@@ -1953,12 +1949,8 @@ export class StateService<TAccount extends Account = Account>
 
   async getTheme(options?: StorageOptions): Promise<string> {
     return (
-      (
-        await this.getGlobals(
-          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
-        )
-      )?.theme ?? null
-    );
+      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.theme;
   }
 
   async setTheme(value: string, options?: StorageOptions): Promise<void> {

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -356,7 +356,7 @@ export class StateService<TAccount extends Account = Account>
   async getClearClipboard(options?: StorageOptions): Promise<number> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.settings?.clearClipboard;
+    )?.settings?.clearClipboard ?? null;
   }
 
   async setClearClipboard(value: number, options?: StorageOptions): Promise<void> {
@@ -1604,7 +1604,7 @@ export class StateService<TAccount extends Account = Account>
   async getLocale(options?: StorageOptions): Promise<string> {
     return (
       await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.locale;
+    )?.locale ?? null;
   }
 
   async setLocale(value: string, options?: StorageOptions): Promise<void> {
@@ -1946,7 +1946,7 @@ export class StateService<TAccount extends Account = Account>
   async getTheme(options?: StorageOptions): Promise<string> {
     return (
       await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.theme;
+    )?.theme ?? null;
   }
 
   async setTheme(value: string, options?: StorageOptions): Promise<void> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix for some dropdowns defaulting to empty.
Fixes: https://app.asana.com/0/1153292148278596/1201632897395074/f

## Code changes

The reason this is an issue is because the values are coming back as undefined in state service. Angular is doing a strict check to determine the selected option, so the value of null isn't mapping as expected. 

We could also approach this by changing the the default options in the components to be selected when they are null or undefined, but I observed this as an issue in Browser as well and doing it this way fixes it there too without having to manually update the select options in the components there as well. I waffled on which was the better approach, so I went with this way as it fixes it from the deepest level and will fix it for Browser when jslib is updated :) 

- **common/src/services/state.service.ts:** Return null explicitly for theme, clearClipboard, and locale if the values are undefined.

## Testing requirements

Ensure that the dropdowns for new accounts have options for clearClipboard, theme, and local selected as defaults.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
