### PR TITLE
Make lowdbStorageService wait until initialised

### DIFF
--- a/node/src/services/lowdbStorage.service.ts
+++ b/node/src/services/lowdbStorage.service.ts
@@ -25,7 +25,7 @@ export class LowdbStorageService implements StorageService {
     this.defaults = defaults;
   }
 
-  @sequentialize(() => 'lowdbStorageInit')
+  @sequentialize(() => "lowdbStorageInit")
   async init() {
     if (this.ready) {
       return;

--- a/node/src/services/lowdbStorage.service.ts
+++ b/node/src/services/lowdbStorage.service.ts
@@ -7,12 +7,14 @@ import { LogService } from "jslib-common/abstractions/log.service";
 import { StorageService } from "jslib-common/abstractions/storage.service";
 
 import { NodeUtils } from "jslib-common/misc/nodeUtils";
+import { sequentialize } from "jslib-common/misc/sequentialize";
 import { Utils } from "jslib-common/misc/utils";
 
 export class LowdbStorageService implements StorageService {
   protected dataFilePath: string;
   private db: lowdb.LowdbSync<any>;
   private defaults: any;
+  private ready = false;
 
   constructor(
     protected logService: LogService,
@@ -23,7 +25,12 @@ export class LowdbStorageService implements StorageService {
     this.defaults = defaults;
   }
 
+  @sequentialize(() => 'lowdbStorageInit')
   async init() {
+    if (this.ready) {
+      return;
+    }
+
     this.logService.info("Initializing lowdb storage service.");
     let adapter: lowdb.AdapterSync<any>;
     if (Utils.isNode && this.dir != null) {
@@ -81,9 +88,12 @@ export class LowdbStorageService implements StorageService {
         this.logService.info("Successfully wrote defaults to db.");
       });
     }
+
+    this.ready = true;
   }
 
-  get<T>(key: string): Promise<T> {
+  async get<T>(key: string): Promise<T> {
+    await this.waitForReady();
     return this.lockDbFile(() => {
       this.readForNoCache();
       const val = this.db.get(key).value();
@@ -99,7 +109,8 @@ export class LowdbStorageService implements StorageService {
     return this.get(key).then((v) => v != null);
   }
 
-  save(key: string, obj: any): Promise<any> {
+  async save(key: string, obj: any): Promise<any> {
+    await this.waitForReady();
     return this.lockDbFile(() => {
       this.readForNoCache();
       this.db.set(key, obj).write();
@@ -108,7 +119,8 @@ export class LowdbStorageService implements StorageService {
     });
   }
 
-  remove(key: string): Promise<any> {
+  async remove(key: string): Promise<any> {
+    await this.waitForReady();
     return this.lockDbFile(() => {
       this.readForNoCache();
       this.db.unset(key).write();
@@ -125,6 +137,12 @@ export class LowdbStorageService implements StorageService {
   private readForNoCache() {
     if (!this.allowCache) {
       this.db.read();
+    }
+  }
+
+  private async waitForReady() {
+    if (!this.ready) {
+      await this.init();
     }
   }
 }

--- a/node/src/services/lowdbStorage.service.ts
+++ b/node/src/services/lowdbStorage.service.ts
@@ -25,7 +25,7 @@ export class LowdbStorageService implements StorageService {
     this.defaults = defaults;
   }
 
-  @sequentialize(() => "lowdbStorageInit")
+  @sequentialize(() => 'lowdbStorageInit')
   async init() {
     if (this.ready) {
       return;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Clients that use `lowdbStorageService` (CLI and bwdc CLI) need that service initialized before it can be used.

#600 added a subscription to the `environmentService` constructor, which indirectly calls `storageService` before it's initialized, resulting in the following error:

```
 /snapshot/directory-connector/build-cli/bwdc.js:1513
            this.db.read();
                    ^

TypeError: Cannot read properties of undefined (reading 'read')
```

I encountered this when trying to bump jslib in https://github.com/bitwarden/directory-connector/pull/204.

No other clients need to initialize their storage services, so this is unique to `lowdbStorageService`.

## Code changes

One solution would be to move the subscription out of the `environmentService` constructor and into its own `init` method. However, that would require every client to call `init()`, even though this is only really required for the CLI clients. Really this is a quirk of `lowdbStorageService` and should ideally be handled within that implementation.

Therefore, the solution is:
* each method of `lowdbStorageService` checks whether the service has been initialized before running. If the service is not initialized, it'll initialize itself
* add an early check on `init` so it can only be run once
* add the `sequentialize()` decorator to the `init` function. This decorator prevents multiple simultaneous calls to an async method (in case it's called a second time before it's set the `ready` flag).

## Testing requirements

None required, beyond basic/usual regression testing in CLI and bwdc CLI.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
