### PR TITLE
[bug] Use the correct login url in lock guard

### DIFF
--- a/angular/src/services/lock-guard.service.ts
+++ b/angular/src/services/lock-guard.service.ts
@@ -7,7 +7,7 @@ import { VaultTimeoutService } from "jslib-common/abstractions/vaultTimeout.serv
 @Injectable()
 export class LockGuardService implements CanActivate {
   protected homepage = "vault";
-  protected loginpage = "";
+  protected loginpage = "login";
   constructor(
     private vaultTimeoutService: VaultTimeoutService,
     private router: Router,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
A recent refactor of the lock guard applied the wrong url to the login screen. This PR correct it.

