### PR TITLE
[bug] Ensure neverLock vaults can be manually locked

### DIFF
--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -53,7 +53,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
   async isLocked(userId?: string): Promise<boolean> {
     const neverLock =
       (await this.cryptoService.hasKeyStored(KeySuffixOptions.Auto, userId)) &&
-      (await this.stateService.getEverBeenUnlocked({ userId: userId }));
+      !(await this.stateService.getEverBeenUnlocked({ userId: userId }));
     if (neverLock) {
       // TODO: This also _sets_ the key so when we check memory in the next line it finds a key.
       // We should refactor here.


### PR DESCRIPTION

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The client side storage restructuring work incorrectly checks if a vault has ever been unlocked to determine neverLock scenarios, but production does the opposite.

This creates an inability to never manually lock neverLock vaults.
This commit sets that condition back to the way it was.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
