### PR TITLE
BEEEP: Add importer for Keeper in json format

### DIFF
--- a/common/src/importers/keeperImporters/keeperCsvImporter.ts
+++ b/common/src/importers/keeperImporters/keeperCsvImporter.ts
@@ -1,9 +1,9 @@
-import { BaseImporter } from "./baseImporter";
-import { Importer } from "./importer";
+import { BaseImporter } from "../baseImporter";
+import { Importer } from "../importer";
 
-import { ImportResult } from "../models/domain/importResult";
+import { ImportResult } from "../../models/domain/importResult";
 
-import { FolderView } from "../models/view/folderView";
+import { FolderView } from "../../models/view/folderView";
 
 export class KeeperCsvImporter extends BaseImporter implements Importer {
   parse(data: string): Promise<ImportResult> {

--- a/common/src/importers/keeperImporters/keeperJsonImporter.ts
+++ b/common/src/importers/keeperImporters/keeperJsonImporter.ts
@@ -1,0 +1,68 @@
+import { BaseImporter } from ".././baseImporter";
+import { Importer } from ".././importer";
+
+import { ImportResult } from "../../models/domain/importResult";
+
+import { KeeperJsonExport, RecordsEntity } from "./types/keeperJsonTypes";
+
+export class KeeperJsonImporter extends BaseImporter implements Importer {
+  parse(data: string): Promise<ImportResult> {
+    const result = new ImportResult();
+    const keeperExport: KeeperJsonExport = JSON.parse(data);
+    if (keeperExport == null || keeperExport.records == null || keeperExport.records.length === 0) {
+      result.success = false;
+      return Promise.resolve(result);
+    }
+
+    keeperExport.records.forEach((record) => {
+      this.parseFolders(result, record);
+
+      const cipher = this.initLoginCipher();
+      cipher.name = record.title;
+      cipher.login.username = record.login;
+      cipher.login.password = record.password;
+
+      cipher.login.uris = this.makeUriArray(record.login_url);
+      cipher.notes = record.notes;
+
+      let customfieldKeys = Object.keys(record.custom_fields);
+      if (customfieldKeys.includes("TFC:Keeper") && record.custom_fields["TFC:Keeper"] != null) {
+        customfieldKeys = customfieldKeys.filter((item) => item !== "TFC:Keeper");
+        cipher.login.totp = record.custom_fields["TFC:Keeper"];
+      }
+
+      customfieldKeys.forEach((key) => {
+        this.processKvp(cipher, key, record.custom_fields[key]);
+      });
+
+      this.convertToNoteIfNeeded(cipher);
+      this.cleanupCipher(cipher);
+      result.ciphers.push(cipher);
+    });
+
+    if (this.organization) {
+      this.moveFoldersToCollections(result);
+    }
+
+    result.success = true;
+    return Promise.resolve(result);
+  }
+
+  private parseFolders(result: ImportResult, record: RecordsEntity) {
+    if (record.folders == null || record.folders.length === 0) {
+      return;
+    }
+
+    record.folders.forEach((item) => {
+      if (item.folder != null) {
+        this.processFolder(result, item.folder);
+        return;
+      }
+
+      if (item.shared_folder != null) {
+        this.processFolder(result, item.shared_folder);
+        return;
+      }
+    });
+  }
+}

--- a/common/src/importers/keeperImporters/keeperJsonImporter.ts
+++ b/common/src/importers/keeperImporters/keeperJsonImporter.ts
@@ -1,4 +1,4 @@
-import { BaseImporter } from ".././baseImporter";
+import { BaseImporter } from "../baseImporter";
 import { Importer } from ".././importer";
 
 import { ImportResult } from "../../models/domain/importResult";

--- a/common/src/importers/keeperImporters/keeperJsonImporter.ts
+++ b/common/src/importers/keeperImporters/keeperJsonImporter.ts
@@ -26,7 +26,7 @@ export class KeeperJsonImporter extends BaseImporter implements Importer {
       cipher.notes = record.notes;
 
       let customfieldKeys = Object.keys(record.custom_fields);
-      if (customfieldKeys.includes("TFC:Keeper") && record.custom_fields["TFC:Keeper"] != null) {
+      if (record.custom_fields["TFC:Keeper"] != null) {
         customfieldKeys = customfieldKeys.filter((item) => item !== "TFC:Keeper");
         cipher.login.totp = record.custom_fields["TFC:Keeper"];
       }

--- a/common/src/importers/keeperImporters/keeperJsonImporter.ts
+++ b/common/src/importers/keeperImporters/keeperJsonImporter.ts
@@ -25,15 +25,17 @@ export class KeeperJsonImporter extends BaseImporter implements Importer {
       cipher.login.uris = this.makeUriArray(record.login_url);
       cipher.notes = record.notes;
 
-      let customfieldKeys = Object.keys(record.custom_fields);
-      if (record.custom_fields["TFC:Keeper"] != null) {
-        customfieldKeys = customfieldKeys.filter((item) => item !== "TFC:Keeper");
-        cipher.login.totp = record.custom_fields["TFC:Keeper"];
-      }
+      if (record.custom_fields != null) {
+        let customfieldKeys = Object.keys(record.custom_fields);
+        if (record.custom_fields["TFC:Keeper"] != null) {
+          customfieldKeys = customfieldKeys.filter((item) => item !== "TFC:Keeper");
+          cipher.login.totp = record.custom_fields["TFC:Keeper"];
+        }
 
-      customfieldKeys.forEach((key) => {
-        this.processKvp(cipher, key, record.custom_fields[key]);
-      });
+        customfieldKeys.forEach((key) => {
+          this.processKvp(cipher, key, record.custom_fields[key]);
+        });
+      }
 
       this.convertToNoteIfNeeded(cipher);
       this.cleanupCipher(cipher);

--- a/common/src/importers/keeperImporters/keeperJsonImporter.ts
+++ b/common/src/importers/keeperImporters/keeperJsonImporter.ts
@@ -1,5 +1,5 @@
 import { BaseImporter } from "../baseImporter";
-import { Importer } from ".././importer";
+import { Importer } from "../importer";
 
 import { ImportResult } from "../../models/domain/importResult";
 

--- a/common/src/importers/keeperImporters/types/keeperJsonTypes.ts
+++ b/common/src/importers/keeperImporters/types/keeperJsonTypes.ts
@@ -24,8 +24,8 @@ export interface RecordsEntity {
   login: string;
   password: string;
   login_url: string;
-  notes: string;
-  custom_fields: CustomFields;
+  notes?: string;
+  custom_fields?: CustomFields;
   folders?: FoldersEntity[] | null;
 }
 

--- a/common/src/importers/keeperImporters/types/keeperJsonTypes.ts
+++ b/common/src/importers/keeperImporters/types/keeperJsonTypes.ts
@@ -1,0 +1,41 @@
+export interface KeeperJsonExport {
+  shared_folders?: SharedFoldersEntity[] | null;
+  records?: RecordsEntity[] | null;
+}
+
+export interface SharedFoldersEntity {
+  path: string;
+  manage_users: boolean;
+  manage_records: boolean;
+  can_edit: boolean;
+  can_share: boolean;
+  permissions?: PermissionsEntity[] | null;
+}
+
+export interface PermissionsEntity {
+  uid?: string | null;
+  manage_users: boolean;
+  manage_records: boolean;
+  name?: string | null;
+}
+
+export interface RecordsEntity {
+  title: string;
+  login: string;
+  password: string;
+  login_url: string;
+  notes: string;
+  custom_fields: CustomFields;
+  folders?: FoldersEntity[] | null;
+}
+
+export type CustomFields = {
+  [key: string]: string | null;
+};
+
+export interface FoldersEntity {
+  folder?: string | null;
+  shared_folder?: string | null;
+  can_edit?: boolean | null;
+  can_share?: boolean | null;
+}

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -50,6 +50,7 @@ import { KasperskyTxtImporter } from "../importers/kasperskyTxtImporter";
 import { KeePass2XmlImporter } from "../importers/keepass2XmlImporter";
 import { KeePassXCsvImporter } from "../importers/keepassxCsvImporter";
 import { KeeperCsvImporter } from "../importers/keeperCsvImporter";
+import { KeeperJsonImporter } from "../importers/keeperImporters/keeperJsonImporter";
 import { LastPassCsvImporter } from "../importers/lastpassCsvImporter";
 import { LogMeOnceCsvImporter } from "../importers/logMeOnceCsvImporter";
 import { MeldiumCsvImporter } from "../importers/meldiumCsvImporter";
@@ -100,6 +101,7 @@ export class ImportService implements ImportServiceAbstraction {
     { id: "1passwordmaccsv", name: "1Password 6 and 7 Mac (csv)" },
     { id: "roboformcsv", name: "RoboForm (csv)" },
     { id: "keepercsv", name: "Keeper (csv)" },
+    { id: "keeperjson", name: "Keeper (json)" },
     { id: "enpasscsv", name: "Enpass (csv)" },
     { id: "enpassjson", name: "Enpass (json)" },
     { id: "safeincloudxml", name: "SafeInCloud (xml)" },
@@ -251,6 +253,8 @@ export class ImportService implements ImportServiceAbstraction {
         return new OnePasswordMacCsvImporter();
       case "keepercsv":
         return new KeeperCsvImporter();
+      case "keeperjson":
+        return new KeeperJsonImporter();
       case "passworddragonxml":
         return new PasswordDragonXmlImporter();
       case "enpasscsv":

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -49,7 +49,7 @@ import { Importer } from "../importers/importer";
 import { KasperskyTxtImporter } from "../importers/kasperskyTxtImporter";
 import { KeePass2XmlImporter } from "../importers/keepass2XmlImporter";
 import { KeePassXCsvImporter } from "../importers/keepassxCsvImporter";
-import { KeeperCsvImporter } from "../importers/keeperCsvImporter";
+import { KeeperCsvImporter } from "../importers/keeperImporters/keeperCsvImporter";
 import { KeeperJsonImporter } from "../importers/keeperImporters/keeperJsonImporter";
 import { LastPassCsvImporter } from "../importers/lastpassCsvImporter";
 import { LogMeOnceCsvImporter } from "../importers/logMeOnceCsvImporter";

--- a/spec/common/importers/keeperJsonImporter.spec.ts
+++ b/spec/common/importers/keeperJsonImporter.spec.ts
@@ -33,6 +33,17 @@ describe("Keeper Json Importer", () => {
     const uriView2 = cipher2.login.uris.shift();
     expect(uriView2.uri).toEqual("https://amex.com");
     expect(cipher2.notes).toEqual("Some great information here.");
+
+    const cipher3 = result.ciphers.shift();
+    expect(cipher3.name).toEqual("Some Account");
+    expect(cipher3.login.username).toEqual("someUserName");
+    expect(cipher3.login.password).toEqual("w4k4k1wergf$^&@#*%2");
+    expect(cipher3.login.hasUris).toBeFalse;
+    expect(cipher3.notes).toBeNull();
+    expect(cipher3.fields).toBeNull();
+    expect(cipher3.login.uris.length).toEqual(1);
+    const uriView3 = cipher3.login.uris.shift();
+    expect(uriView3.uri).toEqual("https://example.com");
   });
 
   it("should import TOTP when present", async () => {

--- a/spec/common/importers/keeperJsonImporter.spec.ts
+++ b/spec/common/importers/keeperJsonImporter.spec.ts
@@ -38,7 +38,6 @@ describe("Keeper Json Importer", () => {
     expect(cipher3.name).toEqual("Some Account");
     expect(cipher3.login.username).toEqual("someUserName");
     expect(cipher3.login.password).toEqual("w4k4k1wergf$^&@#*%2");
-    expect(cipher3.login.hasUris).toBeFalse;
     expect(cipher3.notes).toBeNull();
     expect(cipher3.fields).toBeNull();
     expect(cipher3.login.uris.length).toEqual(1);

--- a/spec/common/importers/keeperJsonImporter.spec.ts
+++ b/spec/common/importers/keeperJsonImporter.spec.ts
@@ -7,8 +7,12 @@ import { testData as TestData } from "./testData/keeperJson/testData";
 describe("Keeper Json Importer", () => {
   const testDataJson = JSON.stringify(TestData);
 
+  let importer: Importer;
+  beforeEach(() => {
+    importer = new Importer();
+  });
+
   it("should parse login data", async () => {
-    const importer = new Importer();
     const result = await importer.parse(testDataJson);
     expect(result != null).toBe(true);
 
@@ -32,7 +36,6 @@ describe("Keeper Json Importer", () => {
   });
 
   it("should import TOTP when present", async () => {
-    const importer = new Importer();
     const result = await importer.parse(testDataJson);
     expect(result != null).toBe(true);
 
@@ -47,7 +50,6 @@ describe("Keeper Json Importer", () => {
   });
 
   it("should parse custom fields", async () => {
-    const importer = new Importer();
     const result = await importer.parse(testDataJson);
     expect(result != null).toBe(true);
 
@@ -67,7 +69,6 @@ describe("Keeper Json Importer", () => {
   });
 
   it("should create folders and assigned ciphers to them", async () => {
-    const importer = new Importer();
     const result = await importer.parse(testDataJson);
     expect(result != null).toBe(true);
 
@@ -82,7 +83,6 @@ describe("Keeper Json Importer", () => {
   });
 
   it("should create collections if part of an organization", async () => {
-    const importer = new Importer();
     importer.organizationId = Utils.newGuid();
     const result = await importer.parse(testDataJson);
     expect(result != null).toBe(true);

--- a/spec/common/importers/keeperJsonImporter.spec.ts
+++ b/spec/common/importers/keeperJsonImporter.spec.ts
@@ -1,0 +1,99 @@
+import { Utils } from "jslib-common/misc/utils";
+
+import { KeeperJsonImporter as Importer } from "jslib-common/importers/keeperImporters/keeperJsonImporter";
+
+import { testData as TestData } from "./testData/keeperJson/testData";
+
+describe("Keeper Json Importer", () => {
+  const testDataJson = JSON.stringify(TestData);
+
+  it("should parse login data", async () => {
+    const importer = new Importer();
+    const result = await importer.parse(testDataJson);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.name).toEqual("Bank Account 1");
+    expect(cipher.login.username).toEqual("customer1234");
+    expect(cipher.login.password).toEqual("4813fJDHF4239fdk");
+    expect(cipher.login.uris.length).toEqual(1);
+    const uriView = cipher.login.uris.shift();
+    expect(uriView.uri).toEqual("https://chase.com");
+    expect(cipher.notes).toEqual("These are some notes.");
+
+    const cipher2 = result.ciphers.shift();
+    expect(cipher2.name).toEqual("Bank Account 2");
+    expect(cipher2.login.username).toEqual("mybankusername");
+    expect(cipher2.login.password).toEqual("w4k4k193f$^&@#*%2");
+    expect(cipher2.login.uris.length).toEqual(1);
+    const uriView2 = cipher2.login.uris.shift();
+    expect(uriView2.uri).toEqual("https://amex.com");
+    expect(cipher2.notes).toEqual("Some great information here.");
+  });
+
+  it("should import TOTP when present", async () => {
+    const importer = new Importer();
+    const result = await importer.parse(testDataJson);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.login.totp).toBeNull();
+
+    // 2nd Cipher
+    const cipher2 = result.ciphers.shift();
+    expect(cipher2.login.totp).toEqual(
+      "otpauth://totp/Amazon:me@company.com?secret=JBSWY3DPEHPK3PXP&issuer=Amazon&algorithm=SHA1&digits=6&period=30"
+    );
+  });
+
+  it("should parse custom fields", async () => {
+    const importer = new Importer();
+    const result = await importer.parse(testDataJson);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.fields.length).toBe(1);
+    expect(cipher.fields[0].name).toEqual("Account Number");
+    expect(cipher.fields[0].value).toEqual("123-456-789");
+
+    // 2nd Cipher
+    const cipher2 = result.ciphers.shift();
+    expect(cipher2.fields.length).toBe(2);
+    expect(cipher2.fields[0].name).toEqual("Security Group");
+    expect(cipher2.fields[0].value).toEqual("Public");
+
+    expect(cipher2.fields[1].name).toEqual("IP Address");
+    expect(cipher2.fields[1].value).toEqual("12.45.67.8");
+  });
+
+  it("should create folders and assigned ciphers to them", async () => {
+    const importer = new Importer();
+    const result = await importer.parse(testDataJson);
+    expect(result != null).toBe(true);
+
+    const folders = result.folders;
+    expect(folders.length).toBe(2);
+    expect(folders[0].name).toBe("Optional Private Folder 1");
+    expect(folders[1].name).toBe("My Customer 1");
+
+    expect(result.folderRelationships[0]).toEqual([0, 0]);
+    expect(result.folderRelationships[1]).toEqual([1, 0]);
+    expect(result.folderRelationships[2]).toEqual([1, 1]);
+  });
+
+  it("should create collections if part of an organization", async () => {
+    const importer = new Importer();
+    importer.organizationId = Utils.newGuid();
+    const result = await importer.parse(testDataJson);
+    expect(result != null).toBe(true);
+
+    const collections = result.collections;
+    expect(collections.length).toBe(2);
+    expect(collections[0].name).toBe("Optional Private Folder 1");
+    expect(collections[1].name).toBe("My Customer 1");
+
+    expect(result.collectionRelationships[0]).toEqual([0, 0]);
+    expect(result.collectionRelationships[1]).toEqual([1, 0]);
+    expect(result.collectionRelationships[2]).toEqual([1, 1]);
+  });
+});

--- a/spec/common/importers/testData/keeperJson/testData.ts
+++ b/spec/common/importers/testData/keeperJson/testData.ts
@@ -80,5 +80,11 @@ export const testData: KeeperJsonExport = {
         },
       ],
     },
+    {
+      title: "Some Account",
+      login: "someUserName",
+      password: "w4k4k1wergf$^&@#*%2",
+      login_url: "https://example.com",
+    },
   ],
 };

--- a/spec/common/importers/testData/keeperJson/testData.ts
+++ b/spec/common/importers/testData/keeperJson/testData.ts
@@ -1,0 +1,84 @@
+import { KeeperJsonExport } from "jslib-common/importers/keeperImporters/types/keeperJsonTypes";
+
+export const testData: KeeperJsonExport = {
+  shared_folders: [
+    {
+      path: "My Customer 1",
+      manage_users: true,
+      manage_records: true,
+      can_edit: true,
+      can_share: true,
+      permissions: [
+        {
+          uid: "kVM96KGEoGxhskZoSTd_jw",
+          manage_users: true,
+          manage_records: true,
+        },
+        {
+          name: "user@mycompany.com",
+          manage_users: true,
+          manage_records: true,
+        },
+      ],
+    },
+    {
+      path: "Testing\\My Customer 2",
+      manage_users: true,
+      manage_records: true,
+      can_edit: true,
+      can_share: true,
+      permissions: [
+        {
+          uid: "ih1CggiQ-3ENXcn4G0sl-g",
+          manage_users: true,
+          manage_records: true,
+        },
+        {
+          name: "user@mycompany.com",
+          manage_users: true,
+          manage_records: true,
+        },
+      ],
+    },
+  ],
+  records: [
+    {
+      title: "Bank Account 1",
+      login: "customer1234",
+      password: "4813fJDHF4239fdk",
+      login_url: "https://chase.com",
+      notes: "These are some notes.",
+      custom_fields: {
+        "Account Number": "123-456-789",
+      },
+      folders: [
+        {
+          folder: "Optional Private Folder 1",
+        },
+      ],
+    },
+    {
+      title: "Bank Account 2",
+      login: "mybankusername",
+      password: "w4k4k193f$^&@#*%2",
+      login_url: "https://amex.com",
+      notes: "Some great information here.",
+      custom_fields: {
+        "Security Group": "Public",
+        "IP Address": "12.45.67.8",
+        "TFC:Keeper":
+          "otpauth://totp/Amazon:me@company.com?secret=JBSWY3DPEHPK3PXP&issuer=Amazon&algorithm=SHA1&digits=6&period=30",
+      },
+      folders: [
+        {
+          folder: "Optional Private Folder 1",
+        },
+        {
+          shared_folder: "My Customer 1",
+          can_edit: true,
+          can_share: true,
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
To aid new users in migrating to Bitwarden we offer a wide variety of importers. This PR adds importing `.json` exports from Keeper, providing our new users a really smooth transition into Bitwarden.

The importer supports creating Login types with the following fields:
- Title
- Username
- Password
- URIs
- TOTP
- Notes
- Folders/Collections (Only creates collections when an import is done from within an organization)
- and creates custom fields for any fields in the custom_fields that could not be mapped

**The permissions present in the shared_folders are not imported. These will have to be set once the data has been imported.**

For more information on exporting from Keeper: https://docs.keeper.io/user-guides/export-and-reports/vault-export
and for information on the json export: https://docs.keeper.io/user-guides/import-records-1/import-json#creating-a-json-file-from-keeper-commander

Asana task: https://app.asana.com/0/1200804338582616/1201664207082273/f
## Code changes
- **spec/common/importers/testData/keeperJson/testData.ts:** Added testdata which I pulled from keeper's website linked above.
- **common/src/importers/keeperImporters/types/keeperJsonTypes.ts:** Added types to describe the exported json file
- **common/src/importers/keeperImporters/keeperJsonImporter.ts:** Created the actual importer to handle json exports from Keeper
- **spec/common/importers/keeperJsonImporter.spec.ts:** Several unit tests to test the behavior of the importer
- **common/src/importers/keeperCsvImporter.ts:** Moved to `common/src/importers/keeperImporters/keeperCsvImporter.ts`
- **common/src/services/import.service.ts:** Registered new KeeperJsonImporter and updated import for moved KeeperCsvImporter

## Testing requirements
The pre-existing importer for csv-files from Keeper should still work
All of the above mentioned mappings should work when importing a json export from Keeper into Bitwarden.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
