### PR TITLE
Feature/password protected export

### DIFF
--- a/common/src/abstractions/export.service.ts
+++ b/common/src/abstractions/export.service.ts
@@ -1,11 +1,9 @@
 import { EventView } from "../models/view/eventView";
 
 export abstract class ExportService {
-  getExport: (format?: "csv" | "json" | "encrypted_json") => Promise<string>;
-  getOrganizationExport: (
-    organizationId: string,
-    format?: "csv" | "json" | "encrypted_json"
-  ) => Promise<string>;
+  getExport: (format?: 'csv' | 'json' | 'encrypted_json') => Promise<string>;
+  getPasswordProtectedExport: (password: string, format?: 'csv' | 'json' | 'encrypted_json', organizationId?: string) => Promise<string>;
+  getOrganizationExport: (organizationId: string, format?: 'csv' | 'json' | 'encrypted_json') => Promise<string>;
   getEventExport: (events: EventView[]) => Promise<string>;
   getFileName: (prefix?: string, extension?: string) => string;
 }

--- a/common/src/abstractions/export.service.ts
+++ b/common/src/abstractions/export.service.ts
@@ -1,9 +1,16 @@
 import { EventView } from "../models/view/eventView";
 
 export abstract class ExportService {
-  getExport: (format?: 'csv' | 'json' | 'encrypted_json') => Promise<string>;
-  getPasswordProtectedExport: (password: string, format?: 'csv' | 'json' | 'encrypted_json', organizationId?: string) => Promise<string>;
-  getOrganizationExport: (organizationId: string, format?: 'csv' | 'json' | 'encrypted_json') => Promise<string>;
+  getExport: (format?: "csv" | "json" | "encrypted_json") => Promise<string>;
+  getPasswordProtectedExport: (
+    password: string,
+    format?: "csv" | "json" | "encrypted_json",
+    organizationId?: string
+  ) => Promise<string>;
+  getOrganizationExport: (
+    organizationId: string,
+    format?: "csv" | "json" | "encrypted_json"
+  ) => Promise<string>;
   getEventExport: (events: EventView[]) => Promise<string>;
   getFileName: (prefix?: string, extension?: string) => string;
 }

--- a/common/src/abstractions/import.service.ts
+++ b/common/src/abstractions/import.service.ts
@@ -1,13 +1,14 @@
 import { Importer } from "../importers/importer";
+import { ImportType } from '../services/import.service';
 
 export interface ImportOption {
   id: string;
   name: string;
 }
 export abstract class ImportService {
-  featuredImportOptions: ImportOption[];
-  regularImportOptions: ImportOption[];
+  featuredImportOptions: readonly ImportOption[];
+  regularImportOptions: readonly ImportOption[];
   getImportOptions: () => ImportOption[];
   import: (importer: Importer, fileContents: string, organizationId?: string) => Promise<Error>;
-  getImporter: (format: string, organizationId: string, password?: string) => Importer;
+  getImporter: (format: ImportType, organizationId: string, password?: string) => Importer;
 }

--- a/common/src/abstractions/import.service.ts
+++ b/common/src/abstractions/import.service.ts
@@ -1,5 +1,5 @@
 import { Importer } from "../importers/importer";
-import { ImportType } from '../services/import.service';
+import { ImportType } from "../services/import.service";
 
 export interface ImportOption {
   id: string;

--- a/common/src/abstractions/import.service.ts
+++ b/common/src/abstractions/import.service.ts
@@ -9,5 +9,5 @@ export abstract class ImportService {
   regularImportOptions: ImportOption[];
   getImportOptions: () => ImportOption[];
   import: (importer: Importer, fileContents: string, organizationId?: string) => Promise<Error>;
-  getImporter: (format: string, organizationId: string) => Importer;
+  getImporter: (format: string, organizationId: string, password?: string) => Importer;
 }

--- a/common/src/importers/bitwardenPasswordProtectedImporter.ts
+++ b/common/src/importers/bitwardenPasswordProtectedImporter.ts
@@ -1,0 +1,90 @@
+import { BaseImporter } from './baseImporter';
+import { Importer } from './importer';
+
+import { EncString } from '../models/domain/encString';
+import { ImportResult } from '../models/domain/importResult';
+
+import { CipherWithIds } from '../models/export/cipherWithIds';
+import { CollectionWithId } from '../models/export/collectionWithId';
+import { FolderWithId } from '../models/export/folderWithId';
+
+import { CryptoService } from '../abstractions/crypto.service';
+import { I18nService } from '../abstractions/i18n.service';
+import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
+import { BitwardenCsvImporter } from './bitwardenCsvImporter';
+import { BitwardenJsonImporter } from './bitwardenJsonImporter';
+import { KdfType } from '../enums/kdfType';
+import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
+
+class BitwardenPasswordProtectedFileFormat {
+    encrypted: boolean;
+    passwordProtected: boolean;
+    format: 'json' | 'csv' | 'encrypted_json';
+    salt: string;
+    kdfIterations: number;
+    encKeyValidation_DO_NOT_EDIT: string;
+    data: string;
+}
+
+export class BitwardenPasswordProtectedImporter extends BaseImporter implements Importer {
+    private results: BitwardenPasswordProtectedFileFormat;
+    private result: ImportResult;
+    private innerImporter: Importer;
+    private key: SymmetricCryptoKey;
+
+    constructor(private cryptoService: CryptoService, private i18nService: I18nService, private password: string) {
+        super();
+    }
+
+    async parse(data: string): Promise<ImportResult> {
+        this.result = new ImportResult();
+        this.results = JSON.parse(data);
+        if (!this.canParseFile(this.results)) {
+            this.result.success = false;
+            return this.result;
+        }
+
+        this.setInnerImporter(this.results.format);
+
+        if (!await this.checkPassword(this.results)) {
+            this.result.success = false;
+            this.result.errorMessage = this.i18nService.t('importEncKeyError');
+            return this.result;
+        }
+
+        const encData = new EncString(this.results.data);
+        const clearTextData = await this.cryptoService.decryptToUtf8(encData, this.key);
+        return this.innerImporter.parse(clearTextData);
+    }
+
+    private async checkPassword(jdoc: BitwardenPasswordProtectedFileFormat): Promise<boolean> {
+        this.key = await this.cryptoService.makePinKey(this.password, jdoc.salt, KdfType.PBKDF2_SHA256, jdoc.kdfIterations);
+
+        const encKeyValidation = new EncString(this.results.encKeyValidation_DO_NOT_EDIT);
+
+        const encKeyValidationDecrypt = await this.cryptoService.decryptToUtf8(encKeyValidation, this.key);
+        if (encKeyValidationDecrypt === null) {
+            return false;
+        }
+        return true;
+    }
+
+    private canParseFile(jdoc: BitwardenPasswordProtectedFileFormat): boolean {
+        if (!jdoc ||
+            !jdoc.encrypted ||
+            !jdoc.passwordProtected ||
+            !(jdoc.format === 'csv' || jdoc.format === 'json' || jdoc.format == 'encrypted_json') ||
+            !jdoc.salt ||
+            !jdoc.kdfIterations ||
+            !jdoc.encKeyValidation_DO_NOT_EDIT ||
+            !jdoc.data) {
+            return false;
+        }
+        return true;
+    }
+
+    private setInnerImporter(format: 'csv' | 'json' | 'encrypted_json') {
+        this.innerImporter = format === 'csv' ? new BitwardenCsvImporter() :
+            new BitwardenJsonImporter(this.cryptoService, this.i18nService);
+    }
+}

--- a/common/src/importers/bitwardenPasswordProtectedImporter.ts
+++ b/common/src/importers/bitwardenPasswordProtectedImporter.ts
@@ -1,90 +1,106 @@
-import { BaseImporter } from './baseImporter';
-import { Importer } from './importer';
+import { BaseImporter } from "./baseImporter";
+import { Importer } from "./importer";
 
-import { EncString } from '../models/domain/encString';
-import { ImportResult } from '../models/domain/importResult';
+import { EncString } from "../models/domain/encString";
+import { ImportResult } from "../models/domain/importResult";
 
-import { CipherWithIds } from '../models/export/cipherWithIds';
-import { CollectionWithId } from '../models/export/collectionWithId';
-import { FolderWithId } from '../models/export/folderWithId';
+import { CipherWithIds } from "../models/export/cipherWithIds";
+import { CollectionWithId } from "../models/export/collectionWithId";
+import { FolderWithId } from "../models/export/folderWithId";
 
-import { CryptoService } from '../abstractions/crypto.service';
-import { I18nService } from '../abstractions/i18n.service';
-import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
-import { BitwardenCsvImporter } from './bitwardenCsvImporter';
-import { BitwardenJsonImporter } from './bitwardenJsonImporter';
-import { KdfType } from '../enums/kdfType';
-import { SymmetricCryptoKey } from '../models/domain/symmetricCryptoKey';
+import { CryptoService } from "../abstractions/crypto.service";
+import { I18nService } from "../abstractions/i18n.service";
+import { CryptoFunctionService } from "../abstractions/cryptoFunction.service";
+import { BitwardenCsvImporter } from "./bitwardenCsvImporter";
+import { BitwardenJsonImporter } from "./bitwardenJsonImporter";
+import { KdfType } from "../enums/kdfType";
+import { SymmetricCryptoKey } from "../models/domain/symmetricCryptoKey";
 
 class BitwardenPasswordProtectedFileFormat {
-    encrypted: boolean;
-    passwordProtected: boolean;
-    format: 'json' | 'csv' | 'encrypted_json';
-    salt: string;
-    kdfIterations: number;
-    encKeyValidation_DO_NOT_EDIT: string;
-    data: string;
+  encrypted: boolean;
+  passwordProtected: boolean;
+  format: "json" | "csv" | "encrypted_json";
+  salt: string;
+  kdfIterations: number;
+  encKeyValidation_DO_NOT_EDIT: string;
+  data: string;
 }
 
 export class BitwardenPasswordProtectedImporter extends BaseImporter implements Importer {
-    private results: BitwardenPasswordProtectedFileFormat;
-    private result: ImportResult;
-    private innerImporter: Importer;
-    private key: SymmetricCryptoKey;
+  private results: BitwardenPasswordProtectedFileFormat;
+  private result: ImportResult;
+  private innerImporter: Importer;
+  private key: SymmetricCryptoKey;
 
-    constructor(private cryptoService: CryptoService, private i18nService: I18nService, private password: string) {
-        super();
+  constructor(
+    private cryptoService: CryptoService,
+    private i18nService: I18nService,
+    private password: string
+  ) {
+    super();
+  }
+
+  async parse(data: string): Promise<ImportResult> {
+    this.result = new ImportResult();
+    this.results = JSON.parse(data);
+    if (!this.canParseFile(this.results)) {
+      this.result.success = false;
+      return this.result;
     }
 
-    async parse(data: string): Promise<ImportResult> {
-        this.result = new ImportResult();
-        this.results = JSON.parse(data);
-        if (!this.canParseFile(this.results)) {
-            this.result.success = false;
-            return this.result;
-        }
+    this.setInnerImporter(this.results.format);
 
-        this.setInnerImporter(this.results.format);
-
-        if (!await this.checkPassword(this.results)) {
-            this.result.success = false;
-            this.result.errorMessage = this.i18nService.t('importEncKeyError');
-            return this.result;
-        }
-
-        const encData = new EncString(this.results.data);
-        const clearTextData = await this.cryptoService.decryptToUtf8(encData, this.key);
-        return this.innerImporter.parse(clearTextData);
+    if (!(await this.checkPassword(this.results))) {
+      this.result.success = false;
+      this.result.errorMessage = this.i18nService.t("importEncKeyError");
+      return this.result;
     }
 
-    private async checkPassword(jdoc: BitwardenPasswordProtectedFileFormat): Promise<boolean> {
-        this.key = await this.cryptoService.makePinKey(this.password, jdoc.salt, KdfType.PBKDF2_SHA256, jdoc.kdfIterations);
+    const encData = new EncString(this.results.data);
+    const clearTextData = await this.cryptoService.decryptToUtf8(encData, this.key);
+    return this.innerImporter.parse(clearTextData);
+  }
 
-        const encKeyValidation = new EncString(this.results.encKeyValidation_DO_NOT_EDIT);
+  private async checkPassword(jdoc: BitwardenPasswordProtectedFileFormat): Promise<boolean> {
+    this.key = await this.cryptoService.makePinKey(
+      this.password,
+      jdoc.salt,
+      KdfType.PBKDF2_SHA256,
+      jdoc.kdfIterations
+    );
 
-        const encKeyValidationDecrypt = await this.cryptoService.decryptToUtf8(encKeyValidation, this.key);
-        if (encKeyValidationDecrypt === null) {
-            return false;
-        }
-        return true;
+    const encKeyValidation = new EncString(this.results.encKeyValidation_DO_NOT_EDIT);
+
+    const encKeyValidationDecrypt = await this.cryptoService.decryptToUtf8(
+      encKeyValidation,
+      this.key
+    );
+    if (encKeyValidationDecrypt === null) {
+      return false;
     }
+    return true;
+  }
 
-    private canParseFile(jdoc: BitwardenPasswordProtectedFileFormat): boolean {
-        if (!jdoc ||
-            !jdoc.encrypted ||
-            !jdoc.passwordProtected ||
-            !(jdoc.format === 'csv' || jdoc.format === 'json' || jdoc.format == 'encrypted_json') ||
-            !jdoc.salt ||
-            !jdoc.kdfIterations ||
-            !jdoc.encKeyValidation_DO_NOT_EDIT ||
-            !jdoc.data) {
-            return false;
-        }
-        return true;
+  private canParseFile(jdoc: BitwardenPasswordProtectedFileFormat): boolean {
+    if (
+      !jdoc ||
+      !jdoc.encrypted ||
+      !jdoc.passwordProtected ||
+      !(jdoc.format === "csv" || jdoc.format === "json" || jdoc.format == "encrypted_json") ||
+      !jdoc.salt ||
+      !jdoc.kdfIterations ||
+      !jdoc.encKeyValidation_DO_NOT_EDIT ||
+      !jdoc.data
+    ) {
+      return false;
     }
+    return true;
+  }
 
-    private setInnerImporter(format: 'csv' | 'json' | 'encrypted_json') {
-        this.innerImporter = format === 'csv' ? new BitwardenCsvImporter() :
-            new BitwardenJsonImporter(this.cryptoService, this.i18nService);
-    }
+  private setInnerImporter(format: "csv" | "json" | "encrypted_json") {
+    this.innerImporter =
+      format === "csv"
+        ? new BitwardenCsvImporter()
+        : new BitwardenJsonImporter(this.cryptoService, this.i18nService);
+  }
 }

--- a/common/src/importers/bitwardenPasswordProtectedImporter.ts
+++ b/common/src/importers/bitwardenPasswordProtectedImporter.ts
@@ -4,12 +4,11 @@ import { Importer } from "./importer";
 import { EncString } from "../models/domain/encString";
 import { ImportResult } from "../models/domain/importResult";
 
-
 import { CryptoService } from "../abstractions/crypto.service";
 import { I18nService } from "../abstractions/i18n.service";
 import { KdfType } from "../enums/kdfType";
 import { SymmetricCryptoKey } from "../models/domain/symmetricCryptoKey";
-import { ImportService } from '../abstractions/import.service';
+import { ImportService } from "../abstractions/import.service";
 
 class BitwardenPasswordProtectedFileFormat {
   encrypted: boolean;
@@ -84,7 +83,8 @@ export class BitwardenPasswordProtectedImporter extends BaseImporter implements 
       !jdoc.passwordProtected ||
       !(jdoc.format === "csv" || jdoc.format === "json" || jdoc.format == "encrypted_json") ||
       !jdoc.salt ||
-      !jdoc.kdfIterations || typeof jdoc.kdfIterations !== 'number' ||
+      !jdoc.kdfIterations ||
+      typeof jdoc.kdfIterations !== "number" ||
       !jdoc.encKeyValidation_DO_NOT_EDIT ||
       !jdoc.data
     ) {

--- a/common/src/services/export.service.ts
+++ b/common/src/services/export.service.ts
@@ -1,14 +1,14 @@
 import * as papa from "papaparse";
 
-import { CipherType } from '../enums/cipherType';
-import { KdfType } from '../enums/kdfType';
+import { CipherType } from "../enums/cipherType";
+import { KdfType } from "../enums/kdfType";
 
-import { ApiService } from '../abstractions/api.service';
-import { CipherService } from '../abstractions/cipher.service';
-import { CryptoFunctionService } from '../abstractions/cryptoFunction.service';
-import { CryptoService } from '../abstractions/crypto.service';
-import { ExportService as ExportServiceAbstraction } from '../abstractions/export.service';
-import { FolderService } from '../abstractions/folder.service';
+import { ApiService } from "../abstractions/api.service";
+import { CipherService } from "../abstractions/cipher.service";
+import { CryptoFunctionService } from "../abstractions/cryptoFunction.service";
+import { CryptoService } from "../abstractions/crypto.service";
+import { ExportService as ExportServiceAbstraction } from "../abstractions/export.service";
+import { FolderService } from "../abstractions/folder.service";
 
 import { CipherView } from "../models/view/cipherView";
 import { CollectionView } from "../models/view/collectionView";
@@ -31,26 +31,39 @@ import { EventView } from "../models/view/eventView";
 import { Utils } from "../misc/utils";
 
 export class ExportService implements ExportServiceAbstraction {
-  constructor(private folderService: FolderService, private cipherService: CipherService,
-    private apiService: ApiService, private cryptoService: CryptoService,
-    private cryptoFunctionService: CryptoFunctionService) { }
+  constructor(
+    private folderService: FolderService,
+    private cipherService: CipherService,
+    private apiService: ApiService,
+    private cryptoService: CryptoService,
+    private cryptoFunctionService: CryptoFunctionService
+  ) {}
 
-  async getExport(format: 'csv' | 'json' | 'encrypted_json' = 'csv'): Promise<string> {
-    if (format === 'encrypted_json') {
+  async getExport(format: "csv" | "json" | "encrypted_json" = "csv"): Promise<string> {
+    if (format === "encrypted_json") {
       return this.getEncryptedExport();
     } else {
       return this.getDecryptedExport(format);
     }
   }
 
-  async getPasswordProtectedExport(password: string, format: 'csv' | 'json' | 'encrypted_json' = 'csv', organizationId?: string): Promise<string> {
-    const clearText = organizationId ?
-      await this.getOrganizationExport(organizationId, format) :
-      await this.getExport(format);
+  async getPasswordProtectedExport(
+    password: string,
+    format: "csv" | "json" | "encrypted_json" = "csv",
+    organizationId?: string
+  ): Promise<string> {
+    const clearText = organizationId
+      ? await this.getOrganizationExport(organizationId, format)
+      : await this.getExport(format);
 
     const salt = Utils.fromBufferToB64(await this.cryptoFunctionService.randomBytes(16));
     const kdfIterations = 100000;
-    const key = await this.cryptoService.makePinKey(password, salt, KdfType.PBKDF2_SHA256, kdfIterations);
+    const key = await this.cryptoService.makePinKey(
+      password,
+      salt,
+      KdfType.PBKDF2_SHA256,
+      kdfIterations
+    );
 
     const encKeyValidation = await this.cryptoService.encrypt(Utils.newGuid(), key);
     const encText = await this.cryptoService.encrypt(clearText, key);
@@ -62,18 +75,21 @@ export class ExportService implements ExportServiceAbstraction {
       salt: salt,
       kdfIterations: kdfIterations,
       encKeyValidation_DO_NOT_EDIT: encKeyValidation.encryptedString,
-      data: encText.encryptedString
+      data: encText.encryptedString,
     };
 
-    return JSON.stringify(jsonDoc, null, '  ');
+    return JSON.stringify(jsonDoc, null, "  ");
   }
 
-  async getOrganizationExport(organizationId: string,
-    format: 'csv' | 'json' | 'encrypted_json' = 'csv'): Promise<string> {
-    if (format === 'encrypted_json') {
+  async getOrganizationExport(
+    organizationId: string,
+    format: "csv" | "json" | "encrypted_json" = "csv"
+  ): Promise<string> {
+    if (format === "encrypted_json") {
       return this.getOrganizationEncryptedExport(organizationId);
     } else {
-      return this.getOrganizationDecryptedExport(organizationId, format); ``;
+      return this.getOrganizationDecryptedExport(organizationId, format);
+      ``;
     }
   }
 

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -225,6 +225,7 @@ export class ImportService implements ImportServiceAbstraction {
         return new BitwardenJsonImporter(this.cryptoService, this.i18nService);
       case "bitwardenpasswordprotected":
         return new BitwardenPasswordProtectedImporter(
+          this,
           this.cryptoService,
           this.i18nService,
           password

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -144,9 +144,10 @@ const regularImportOptions = [
   { id: "nordpasscsv", name: "Nordpass (csv)" },
 ] as const;
 
-export type ImportType = typeof featuredImportOptions[number]["id"] |
-  typeof regularImportOptions[number]["id"] |
-  "bitwardenpasswordprotected";
+export type ImportType =
+  | typeof featuredImportOptions[number]["id"]
+  | typeof regularImportOptions[number]["id"]
+  | "bitwardenpasswordprotected";
 
 export class ImportService implements ImportServiceAbstraction {
   featuredImportOptions = featuredImportOptions as readonly ImportOption[];
@@ -204,7 +205,11 @@ export class ImportService implements ImportServiceAbstraction {
     }
   }
 
-  getImporter(format: ImportType, organizationId: string = null, password: string = null): Importer {
+  getImporter(
+    format: ImportType,
+    organizationId: string = null,
+    password: string = null
+  ): Importer {
     const importer = this.getImporterInstance(format, password);
     if (importer == null) {
       return null;

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -82,68 +82,76 @@ import { UpmCsvImporter } from "../importers/upmCsvImporter";
 import { YotiCsvImporter } from "../importers/yotiCsvImporter";
 import { ZohoVaultCsvImporter } from "../importers/zohoVaultCsvImporter";
 
-export class ImportService implements ImportServiceAbstraction {
-  featuredImportOptions = [
-    { id: "bitwardenjson", name: "Bitwarden (json)" },
-    { id: "bitwardencsv", name: "Bitwarden (csv)" },
-    { id: "chromecsv", name: "Chrome (csv)" },
-    { id: "dashlanejson", name: "Dashlane (json)" },
-    { id: "firefoxcsv", name: "Firefox (csv)" },
-    { id: "keepass2xml", name: "KeePass 2 (xml)" },
-    { id: "lastpasscsv", name: "LastPass (csv)" },
-    { id: "safaricsv", name: "Safari and macOS (csv)" },
-    { id: "1password1pif", name: "1Password (1pif)" },
-  ];
+const featuredImportOptions = [
+  { id: "bitwardenjson", name: "Bitwarden (json)" },
+  { id: "bitwardencsv", name: "Bitwarden (csv)" },
+  { id: "chromecsv", name: "Chrome (csv)" },
+  { id: "dashlanejson", name: "Dashlane (json)" },
+  { id: "firefoxcsv", name: "Firefox (csv)" },
+  { id: "keepass2xml", name: "KeePass 2 (xml)" },
+  { id: "lastpasscsv", name: "LastPass (csv)" },
+  { id: "safaricsv", name: "Safari and macOS (csv)" },
+  { id: "1password1pif", name: "1Password (1pif)" },
+] as const;
 
-  regularImportOptions: ImportOption[] = [
-    { id: "keepassxcsv", name: "KeePassX (csv)" },
-    { id: "1passwordwincsv", name: "1Password 6 and 7 Windows (csv)" },
-    { id: "1passwordmaccsv", name: "1Password 6 and 7 Mac (csv)" },
-    { id: "roboformcsv", name: "RoboForm (csv)" },
-    { id: "keepercsv", name: "Keeper (csv)" },
-    { id: "enpasscsv", name: "Enpass (csv)" },
-    { id: "enpassjson", name: "Enpass (json)" },
-    { id: "safeincloudxml", name: "SafeInCloud (xml)" },
-    { id: "pwsafexml", name: "Password Safe (xml)" },
-    { id: "stickypasswordxml", name: "Sticky Password (xml)" },
-    { id: "msecurecsv", name: "mSecure (csv)" },
-    { id: "truekeycsv", name: "True Key (csv)" },
-    { id: "passwordbossjson", name: "Password Boss (json)" },
-    { id: "zohovaultcsv", name: "Zoho Vault (csv)" },
-    { id: "splashidcsv", name: "SplashID (csv)" },
-    { id: "passworddragonxml", name: "Password Dragon (xml)" },
-    { id: "padlockcsv", name: "Padlock (csv)" },
-    { id: "passboltcsv", name: "Passbolt (csv)" },
-    { id: "clipperzhtml", name: "Clipperz (html)" },
-    { id: "aviracsv", name: "Avira (csv)" },
-    { id: "saferpasscsv", name: "SaferPass (csv)" },
-    { id: "upmcsv", name: "Universal Password Manager (csv)" },
-    { id: "ascendocsv", name: "Ascendo DataVault (csv)" },
-    { id: "meldiumcsv", name: "Meldium (csv)" },
-    { id: "passkeepcsv", name: "PassKeep (csv)" },
-    { id: "operacsv", name: "Opera (csv)" },
-    { id: "vivaldicsv", name: "Vivaldi (csv)" },
-    { id: "gnomejson", name: "GNOME Passwords and Keys/Seahorse (json)" },
-    { id: "blurcsv", name: "Blur (csv)" },
-    { id: "passwordagentcsv", name: "Password Agent (csv)" },
-    { id: "passpackcsv", name: "Passpack (csv)" },
-    { id: "passmanjson", name: "Passman (json)" },
-    { id: "avastcsv", name: "Avast Passwords (csv)" },
-    { id: "avastjson", name: "Avast Passwords (json)" },
-    { id: "fsecurefsk", name: "F-Secure KEY (fsk)" },
-    { id: "kasperskytxt", name: "Kaspersky Password Manager (txt)" },
-    { id: "remembearcsv", name: "RememBear (csv)" },
-    { id: "passwordwallettxt", name: "PasswordWallet (txt)" },
-    { id: "mykicsv", name: "Myki (csv)" },
-    { id: "securesafecsv", name: "SecureSafe (csv)" },
-    { id: "logmeoncecsv", name: "LogMeOnce (csv)" },
-    { id: "blackberrycsv", name: "BlackBerry Password Keeper (csv)" },
-    { id: "buttercupcsv", name: "Buttercup (csv)" },
-    { id: "codebookcsv", name: "Codebook (csv)" },
-    { id: "encryptrcsv", name: "Encryptr (csv)" },
-    { id: "yoticsv", name: "Yoti (csv)" },
-    { id: "nordpasscsv", name: "Nordpass (csv)" },
-  ];
+const regularImportOptions = [
+  { id: "keepassxcsv", name: "KeePassX (csv)" },
+  { id: "1passwordwincsv", name: "1Password 6 and 7 Windows (csv)" },
+  { id: "1passwordmaccsv", name: "1Password 6 and 7 Mac (csv)" },
+  { id: "roboformcsv", name: "RoboForm (csv)" },
+  { id: "keepercsv", name: "Keeper (csv)" },
+  { id: "enpasscsv", name: "Enpass (csv)" },
+  { id: "enpassjson", name: "Enpass (json)" },
+  { id: "safeincloudxml", name: "SafeInCloud (xml)" },
+  { id: "pwsafexml", name: "Password Safe (xml)" },
+  { id: "stickypasswordxml", name: "Sticky Password (xml)" },
+  { id: "msecurecsv", name: "mSecure (csv)" },
+  { id: "truekeycsv", name: "True Key (csv)" },
+  { id: "passwordbossjson", name: "Password Boss (json)" },
+  { id: "zohovaultcsv", name: "Zoho Vault (csv)" },
+  { id: "splashidcsv", name: "SplashID (csv)" },
+  { id: "passworddragonxml", name: "Password Dragon (xml)" },
+  { id: "padlockcsv", name: "Padlock (csv)" },
+  { id: "passboltcsv", name: "Passbolt (csv)" },
+  { id: "clipperzhtml", name: "Clipperz (html)" },
+  { id: "aviracsv", name: "Avira (csv)" },
+  { id: "saferpasscsv", name: "SaferPass (csv)" },
+  { id: "upmcsv", name: "Universal Password Manager (csv)" },
+  { id: "ascendocsv", name: "Ascendo DataVault (csv)" },
+  { id: "meldiumcsv", name: "Meldium (csv)" },
+  { id: "passkeepcsv", name: "PassKeep (csv)" },
+  { id: "operacsv", name: "Opera (csv)" },
+  { id: "vivaldicsv", name: "Vivaldi (csv)" },
+  { id: "gnomejson", name: "GNOME Passwords and Keys/Seahorse (json)" },
+  { id: "blurcsv", name: "Blur (csv)" },
+  { id: "passwordagentcsv", name: "Password Agent (csv)" },
+  { id: "passpackcsv", name: "Passpack (csv)" },
+  { id: "passmanjson", name: "Passman (json)" },
+  { id: "avastcsv", name: "Avast Passwords (csv)" },
+  { id: "avastjson", name: "Avast Passwords (json)" },
+  { id: "fsecurefsk", name: "F-Secure KEY (fsk)" },
+  { id: "kasperskytxt", name: "Kaspersky Password Manager (txt)" },
+  { id: "remembearcsv", name: "RememBear (csv)" },
+  { id: "passwordwallettxt", name: "PasswordWallet (txt)" },
+  { id: "mykicsv", name: "Myki (csv)" },
+  { id: "securesafecsv", name: "SecureSafe (csv)" },
+  { id: "logmeoncecsv", name: "LogMeOnce (csv)" },
+  { id: "blackberrycsv", name: "BlackBerry Password Keeper (csv)" },
+  { id: "buttercupcsv", name: "Buttercup (csv)" },
+  { id: "codebookcsv", name: "Codebook (csv)" },
+  { id: "encryptrcsv", name: "Encryptr (csv)" },
+  { id: "yoticsv", name: "Yoti (csv)" },
+  { id: "nordpasscsv", name: "Nordpass (csv)" },
+] as const;
+
+export type ImportType = typeof featuredImportOptions[number]["id"] |
+  typeof regularImportOptions[number]["id"] |
+  "bitwardenpasswordprotected";
+
+export class ImportService implements ImportServiceAbstraction {
+  featuredImportOptions = featuredImportOptions as readonly ImportOption[];
+
+  regularImportOptions = regularImportOptions as readonly ImportOption[];
 
   constructor(
     private cipherService: CipherService,
@@ -196,7 +204,7 @@ export class ImportService implements ImportServiceAbstraction {
     }
   }
 
-  getImporter(format: string, organizationId: string = null, password: string = null): Importer {
+  getImporter(format: ImportType, organizationId: string = null, password: string = null): Importer {
     const importer = this.getImporterInstance(format, password);
     if (importer == null) {
       return null;
@@ -205,8 +213,8 @@ export class ImportService implements ImportServiceAbstraction {
     return importer;
   }
 
-  private getImporterInstance(format: string, password: string) {
-    if (format == null || format === "") {
+  private getImporterInstance(format: ImportType, password: string) {
+    if (format == null) {
       return null;
     }
 
@@ -215,7 +223,7 @@ export class ImportService implements ImportServiceAbstraction {
         return new BitwardenCsvImporter();
       case "bitwardenjson":
         return new BitwardenJsonImporter(this.cryptoService, this.i18nService);
-      case "bitwardenPasswordProtected":
+      case "bitwardenpasswordprotected":
         return new BitwardenPasswordProtectedImporter(
           this.cryptoService,
           this.i18nService,

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -26,60 +26,61 @@ import { KvpRequest } from "../models/request/kvpRequest";
 import { ErrorResponse } from "../models/response/errorResponse";
 import { CipherView } from "../models/view/cipherView";
 
-import { AscendoCsvImporter } from "../importers/ascendoCsvImporter";
-import { AvastCsvImporter } from "../importers/avastCsvImporter";
-import { AvastJsonImporter } from "../importers/avastJsonImporter";
-import { AviraCsvImporter } from "../importers/aviraCsvImporter";
-import { BitwardenCsvImporter } from "../importers/bitwardenCsvImporter";
-import { BitwardenJsonImporter } from "../importers/bitwardenJsonImporter";
-import { BlackBerryCsvImporter } from "../importers/blackBerryCsvImporter";
-import { BlurCsvImporter } from "../importers/blurCsvImporter";
-import { ButtercupCsvImporter } from "../importers/buttercupCsvImporter";
-import { ChromeCsvImporter } from "../importers/chromeCsvImporter";
-import { ClipperzHtmlImporter } from "../importers/clipperzHtmlImporter";
-import { CodebookCsvImporter } from "../importers/codebookCsvImporter";
-import { DashlaneJsonImporter } from "../importers/dashlaneJsonImporter";
-import { EncryptrCsvImporter } from "../importers/encryptrCsvImporter";
-import { EnpassCsvImporter } from "../importers/enpassCsvImporter";
-import { EnpassJsonImporter } from "../importers/enpassJsonImporter";
-import { FirefoxCsvImporter } from "../importers/firefoxCsvImporter";
-import { FSecureFskImporter } from "../importers/fsecureFskImporter";
-import { GnomeJsonImporter } from "../importers/gnomeJsonImporter";
-import { Importer } from "../importers/importer";
-import { KasperskyTxtImporter } from "../importers/kasperskyTxtImporter";
-import { KeePass2XmlImporter } from "../importers/keepass2XmlImporter";
-import { KeePassXCsvImporter } from "../importers/keepassxCsvImporter";
-import { KeeperCsvImporter } from "../importers/keeperCsvImporter";
-import { LastPassCsvImporter } from "../importers/lastpassCsvImporter";
-import { LogMeOnceCsvImporter } from "../importers/logMeOnceCsvImporter";
-import { MeldiumCsvImporter } from "../importers/meldiumCsvImporter";
-import { MSecureCsvImporter } from "../importers/msecureCsvImporter";
-import { MykiCsvImporter } from "../importers/mykiCsvImporter";
-import { NordPassCsvImporter } from "../importers/nordpassCsvImporter";
-import { OnePassword1PifImporter } from "../importers/onepasswordImporters/onepassword1PifImporter";
-import { OnePasswordMacCsvImporter } from "../importers/onepasswordImporters/onepasswordMacCsvImporter";
-import { OnePasswordWinCsvImporter } from "../importers/onepasswordImporters/onepasswordWinCsvImporter";
-import { PadlockCsvImporter } from "../importers/padlockCsvImporter";
-import { PassKeepCsvImporter } from "../importers/passkeepCsvImporter";
-import { PassmanJsonImporter } from "../importers/passmanJsonImporter";
-import { PasspackCsvImporter } from "../importers/passpackCsvImporter";
-import { PasswordAgentCsvImporter } from "../importers/passwordAgentCsvImporter";
-import { PasswordBossJsonImporter } from "../importers/passwordBossJsonImporter";
-import { PasswordDragonXmlImporter } from "../importers/passwordDragonXmlImporter";
-import { PasswordSafeXmlImporter } from "../importers/passwordSafeXmlImporter";
-import { PasswordWalletTxtImporter } from "../importers/passwordWalletTxtImporter";
-import { RememBearCsvImporter } from "../importers/rememBearCsvImporter";
-import { RoboFormCsvImporter } from "../importers/roboformCsvImporter";
-import { SafariCsvImporter } from "../importers/safariCsvImporter";
-import { SafeInCloudXmlImporter } from "../importers/safeInCloudXmlImporter";
-import { SaferPassCsvImporter } from "../importers/saferpassCsvImport";
-import { SecureSafeCsvImporter } from "../importers/secureSafeCsvImporter";
-import { SplashIdCsvImporter } from "../importers/splashIdCsvImporter";
-import { StickyPasswordXmlImporter } from "../importers/stickyPasswordXmlImporter";
-import { TrueKeyCsvImporter } from "../importers/truekeyCsvImporter";
-import { UpmCsvImporter } from "../importers/upmCsvImporter";
-import { YotiCsvImporter } from "../importers/yotiCsvImporter";
-import { ZohoVaultCsvImporter } from "../importers/zohoVaultCsvImporter";
+import { AscendoCsvImporter } from '../importers/ascendoCsvImporter';
+import { AvastCsvImporter } from '../importers/avastCsvImporter';
+import { AvastJsonImporter } from '../importers/avastJsonImporter';
+import { AviraCsvImporter } from '../importers/aviraCsvImporter';
+import { BitwardenCsvImporter } from '../importers/bitwardenCsvImporter';
+import { BitwardenJsonImporter } from '../importers/bitwardenJsonImporter';
+import { BitwardenPasswordProtectedImporter } from '../importers/bitwardenPasswordProtectedImporter';
+import { BlackBerryCsvImporter } from '../importers/blackBerryCsvImporter';
+import { BlurCsvImporter } from '../importers/blurCsvImporter';
+import { ButtercupCsvImporter } from '../importers/buttercupCsvImporter';
+import { ChromeCsvImporter } from '../importers/chromeCsvImporter';
+import { ClipperzHtmlImporter } from '../importers/clipperzHtmlImporter';
+import { CodebookCsvImporter } from '../importers/codebookCsvImporter';
+import { DashlaneJsonImporter } from '../importers/dashlaneJsonImporter';
+import { EncryptrCsvImporter } from '../importers/encryptrCsvImporter';
+import { EnpassCsvImporter } from '../importers/enpassCsvImporter';
+import { EnpassJsonImporter } from '../importers/enpassJsonImporter';
+import { FirefoxCsvImporter } from '../importers/firefoxCsvImporter';
+import { FSecureFskImporter } from '../importers/fsecureFskImporter';
+import { GnomeJsonImporter } from '../importers/gnomeJsonImporter';
+import { Importer } from '../importers/importer';
+import { KasperskyTxtImporter } from '../importers/kasperskyTxtImporter';
+import { KeePass2XmlImporter } from '../importers/keepass2XmlImporter';
+import { KeePassXCsvImporter } from '../importers/keepassxCsvImporter';
+import { KeeperCsvImporter } from '../importers/keeperCsvImporter';
+import { LastPassCsvImporter } from '../importers/lastpassCsvImporter';
+import { LogMeOnceCsvImporter } from '../importers/logMeOnceCsvImporter';
+import { MeldiumCsvImporter } from '../importers/meldiumCsvImporter';
+import { MSecureCsvImporter } from '../importers/msecureCsvImporter';
+import { MykiCsvImporter } from '../importers/mykiCsvImporter';
+import { NordPassCsvImporter } from '../importers/nordpassCsvImporter';
+import { OnePassword1PifImporter } from '../importers/onepasswordImporters/onepassword1PifImporter';
+import { OnePasswordMacCsvImporter } from '../importers/onepasswordImporters/onepasswordMacCsvImporter';
+import { OnePasswordWinCsvImporter } from '../importers/onepasswordImporters/onepasswordWinCsvImporter';
+import { PadlockCsvImporter } from '../importers/padlockCsvImporter';
+import { PassKeepCsvImporter } from '../importers/passkeepCsvImporter';
+import { PassmanJsonImporter } from '../importers/passmanJsonImporter';
+import { PasspackCsvImporter } from '../importers/passpackCsvImporter';
+import { PasswordAgentCsvImporter } from '../importers/passwordAgentCsvImporter';
+import { PasswordBossJsonImporter } from '../importers/passwordBossJsonImporter';
+import { PasswordDragonXmlImporter } from '../importers/passwordDragonXmlImporter';
+import { PasswordSafeXmlImporter } from '../importers/passwordSafeXmlImporter';
+import { PasswordWalletTxtImporter } from '../importers/passwordWalletTxtImporter';
+import { RememBearCsvImporter } from '../importers/rememBearCsvImporter';
+import { RoboFormCsvImporter } from '../importers/roboformCsvImporter';
+import { SafariCsvImporter } from '../importers/safariCsvImporter';
+import { SafeInCloudXmlImporter } from '../importers/safeInCloudXmlImporter';
+import { SaferPassCsvImporter } from '../importers/saferpassCsvImport';
+import { SecureSafeCsvImporter } from '../importers/secureSafeCsvImporter';
+import { SplashIdCsvImporter } from '../importers/splashIdCsvImporter';
+import { StickyPasswordXmlImporter } from '../importers/stickyPasswordXmlImporter';
+import { TrueKeyCsvImporter } from '../importers/truekeyCsvImporter';
+import { UpmCsvImporter } from '../importers/upmCsvImporter';
+import { YotiCsvImporter } from '../importers/yotiCsvImporter';
+import { ZohoVaultCsvImporter } from '../importers/zohoVaultCsvImporter';
 
 export class ImportService implements ImportServiceAbstraction {
   featuredImportOptions = [
@@ -152,7 +153,7 @@ export class ImportService implements ImportServiceAbstraction {
     private collectionService: CollectionService,
     private platformUtilsService: PlatformUtilsService,
     private cryptoService: CryptoService
-  ) {}
+  ) { }
 
   getImportOptions(): ImportOption[] {
     return this.featuredImportOptions.concat(this.regularImportOptions);
@@ -195,8 +196,8 @@ export class ImportService implements ImportServiceAbstraction {
     }
   }
 
-  getImporter(format: string, organizationId: string = null): Importer {
-    const importer = this.getImporterInstance(format);
+  getImporter(format: string, organizationId: string = null, password: string = null): Importer {
+    const importer = this.getImporterInstance(format, password);
     if (importer == null) {
       return null;
     }
@@ -204,120 +205,122 @@ export class ImportService implements ImportServiceAbstraction {
     return importer;
   }
 
-  private getImporterInstance(format: string) {
-    if (format == null || format === "") {
+  private getImporterInstance(format: string, password: string) {
+    if (format == null || format === '') {
       return null;
     }
 
     switch (format) {
-      case "bitwardencsv":
+      case 'bitwardencsv':
         return new BitwardenCsvImporter();
-      case "bitwardenjson":
+      case 'bitwardenjson':
         return new BitwardenJsonImporter(this.cryptoService, this.i18nService);
-      case "lastpasscsv":
-      case "passboltcsv":
+      case 'bitwardenPasswordProtected':
+        return new BitwardenPasswordProtectedImporter(this.cryptoService, this.i18nService, password);
+      case 'lastpasscsv':
+      case 'passboltcsv':
         return new LastPassCsvImporter();
-      case "keepassxcsv":
+      case 'keepassxcsv':
         return new KeePassXCsvImporter();
-      case "aviracsv":
+      case 'aviracsv':
         return new AviraCsvImporter();
-      case "blurcsv":
+      case 'blurcsv':
         return new BlurCsvImporter();
-      case "safeincloudxml":
+      case 'safeincloudxml':
         return new SafeInCloudXmlImporter();
-      case "padlockcsv":
+      case 'padlockcsv':
         return new PadlockCsvImporter();
-      case "keepass2xml":
+      case 'keepass2xml':
         return new KeePass2XmlImporter();
-      case "chromecsv":
-      case "operacsv":
-      case "vivaldicsv":
+      case 'chromecsv':
+      case 'operacsv':
+      case 'vivaldicsv':
         return new ChromeCsvImporter();
-      case "firefoxcsv":
+      case 'firefoxcsv':
         return new FirefoxCsvImporter();
-      case "upmcsv":
+      case 'upmcsv':
         return new UpmCsvImporter();
-      case "saferpasscsv":
+      case 'saferpasscsv':
         return new SaferPassCsvImporter();
-      case "safaricsv":
+      case 'safaricsv':
         return new SafariCsvImporter();
-      case "meldiumcsv":
+      case 'meldiumcsv':
         return new MeldiumCsvImporter();
-      case "1password1pif":
+      case '1password1pif':
         return new OnePassword1PifImporter();
-      case "1passwordwincsv":
+      case '1passwordwincsv':
         return new OnePasswordWinCsvImporter();
-      case "1passwordmaccsv":
+      case '1passwordmaccsv':
         return new OnePasswordMacCsvImporter();
-      case "keepercsv":
+      case 'keepercsv':
         return new KeeperCsvImporter();
-      case "passworddragonxml":
+      case 'passworddragonxml':
         return new PasswordDragonXmlImporter();
-      case "enpasscsv":
+      case 'enpasscsv':
         return new EnpassCsvImporter();
-      case "enpassjson":
+      case 'enpassjson':
         return new EnpassJsonImporter();
-      case "pwsafexml":
+      case 'pwsafexml':
         return new PasswordSafeXmlImporter();
-      case "dashlanejson":
+      case 'dashlanejson':
         return new DashlaneJsonImporter();
-      case "msecurecsv":
+      case 'msecurecsv':
         return new MSecureCsvImporter();
-      case "stickypasswordxml":
+      case 'stickypasswordxml':
         return new StickyPasswordXmlImporter();
-      case "truekeycsv":
+      case 'truekeycsv':
         return new TrueKeyCsvImporter();
-      case "clipperzhtml":
+      case 'clipperzhtml':
         return new ClipperzHtmlImporter();
-      case "roboformcsv":
+      case 'roboformcsv':
         return new RoboFormCsvImporter();
-      case "ascendocsv":
+      case 'ascendocsv':
         return new AscendoCsvImporter();
-      case "passwordbossjson":
+      case 'passwordbossjson':
         return new PasswordBossJsonImporter();
-      case "zohovaultcsv":
+      case 'zohovaultcsv':
         return new ZohoVaultCsvImporter();
-      case "splashidcsv":
+      case 'splashidcsv':
         return new SplashIdCsvImporter();
-      case "passkeepcsv":
+      case 'passkeepcsv':
         return new PassKeepCsvImporter();
-      case "gnomejson":
+      case 'gnomejson':
         return new GnomeJsonImporter();
-      case "passwordagentcsv":
+      case 'passwordagentcsv':
         return new PasswordAgentCsvImporter();
-      case "passpackcsv":
+      case 'passpackcsv':
         return new PasspackCsvImporter();
-      case "passmanjson":
+      case 'passmanjson':
         return new PassmanJsonImporter();
-      case "avastcsv":
+      case 'avastcsv':
         return new AvastCsvImporter();
-      case "avastjson":
+      case 'avastjson':
         return new AvastJsonImporter();
-      case "fsecurefsk":
+      case 'fsecurefsk':
         return new FSecureFskImporter();
-      case "kasperskytxt":
+      case 'kasperskytxt':
         return new KasperskyTxtImporter();
-      case "remembearcsv":
+      case 'remembearcsv':
         return new RememBearCsvImporter();
-      case "passwordwallettxt":
+      case 'passwordwallettxt':
         return new PasswordWalletTxtImporter();
-      case "mykicsv":
+      case 'mykicsv':
         return new MykiCsvImporter();
-      case "securesafecsv":
+      case 'securesafecsv':
         return new SecureSafeCsvImporter();
-      case "logmeoncecsv":
+      case 'logmeoncecsv':
         return new LogMeOnceCsvImporter();
-      case "blackberrycsv":
+      case 'blackberrycsv':
         return new BlackBerryCsvImporter();
-      case "buttercupcsv":
+      case 'buttercupcsv':
         return new ButtercupCsvImporter();
-      case "codebookcsv":
+      case 'codebookcsv':
         return new CodebookCsvImporter();
-      case "encryptrcsv":
+      case 'encryptrcsv':
         return new EncryptrCsvImporter();
-      case "yoticsv":
+      case 'yoticsv':
         return new YotiCsvImporter();
-      case "nordpasscsv":
+      case 'nordpasscsv':
         return new NordPassCsvImporter();
       default:
         return null;

--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -26,61 +26,61 @@ import { KvpRequest } from "../models/request/kvpRequest";
 import { ErrorResponse } from "../models/response/errorResponse";
 import { CipherView } from "../models/view/cipherView";
 
-import { AscendoCsvImporter } from '../importers/ascendoCsvImporter';
-import { AvastCsvImporter } from '../importers/avastCsvImporter';
-import { AvastJsonImporter } from '../importers/avastJsonImporter';
-import { AviraCsvImporter } from '../importers/aviraCsvImporter';
-import { BitwardenCsvImporter } from '../importers/bitwardenCsvImporter';
-import { BitwardenJsonImporter } from '../importers/bitwardenJsonImporter';
-import { BitwardenPasswordProtectedImporter } from '../importers/bitwardenPasswordProtectedImporter';
-import { BlackBerryCsvImporter } from '../importers/blackBerryCsvImporter';
-import { BlurCsvImporter } from '../importers/blurCsvImporter';
-import { ButtercupCsvImporter } from '../importers/buttercupCsvImporter';
-import { ChromeCsvImporter } from '../importers/chromeCsvImporter';
-import { ClipperzHtmlImporter } from '../importers/clipperzHtmlImporter';
-import { CodebookCsvImporter } from '../importers/codebookCsvImporter';
-import { DashlaneJsonImporter } from '../importers/dashlaneJsonImporter';
-import { EncryptrCsvImporter } from '../importers/encryptrCsvImporter';
-import { EnpassCsvImporter } from '../importers/enpassCsvImporter';
-import { EnpassJsonImporter } from '../importers/enpassJsonImporter';
-import { FirefoxCsvImporter } from '../importers/firefoxCsvImporter';
-import { FSecureFskImporter } from '../importers/fsecureFskImporter';
-import { GnomeJsonImporter } from '../importers/gnomeJsonImporter';
-import { Importer } from '../importers/importer';
-import { KasperskyTxtImporter } from '../importers/kasperskyTxtImporter';
-import { KeePass2XmlImporter } from '../importers/keepass2XmlImporter';
-import { KeePassXCsvImporter } from '../importers/keepassxCsvImporter';
-import { KeeperCsvImporter } from '../importers/keeperCsvImporter';
-import { LastPassCsvImporter } from '../importers/lastpassCsvImporter';
-import { LogMeOnceCsvImporter } from '../importers/logMeOnceCsvImporter';
-import { MeldiumCsvImporter } from '../importers/meldiumCsvImporter';
-import { MSecureCsvImporter } from '../importers/msecureCsvImporter';
-import { MykiCsvImporter } from '../importers/mykiCsvImporter';
-import { NordPassCsvImporter } from '../importers/nordpassCsvImporter';
-import { OnePassword1PifImporter } from '../importers/onepasswordImporters/onepassword1PifImporter';
-import { OnePasswordMacCsvImporter } from '../importers/onepasswordImporters/onepasswordMacCsvImporter';
-import { OnePasswordWinCsvImporter } from '../importers/onepasswordImporters/onepasswordWinCsvImporter';
-import { PadlockCsvImporter } from '../importers/padlockCsvImporter';
-import { PassKeepCsvImporter } from '../importers/passkeepCsvImporter';
-import { PassmanJsonImporter } from '../importers/passmanJsonImporter';
-import { PasspackCsvImporter } from '../importers/passpackCsvImporter';
-import { PasswordAgentCsvImporter } from '../importers/passwordAgentCsvImporter';
-import { PasswordBossJsonImporter } from '../importers/passwordBossJsonImporter';
-import { PasswordDragonXmlImporter } from '../importers/passwordDragonXmlImporter';
-import { PasswordSafeXmlImporter } from '../importers/passwordSafeXmlImporter';
-import { PasswordWalletTxtImporter } from '../importers/passwordWalletTxtImporter';
-import { RememBearCsvImporter } from '../importers/rememBearCsvImporter';
-import { RoboFormCsvImporter } from '../importers/roboformCsvImporter';
-import { SafariCsvImporter } from '../importers/safariCsvImporter';
-import { SafeInCloudXmlImporter } from '../importers/safeInCloudXmlImporter';
-import { SaferPassCsvImporter } from '../importers/saferpassCsvImport';
-import { SecureSafeCsvImporter } from '../importers/secureSafeCsvImporter';
-import { SplashIdCsvImporter } from '../importers/splashIdCsvImporter';
-import { StickyPasswordXmlImporter } from '../importers/stickyPasswordXmlImporter';
-import { TrueKeyCsvImporter } from '../importers/truekeyCsvImporter';
-import { UpmCsvImporter } from '../importers/upmCsvImporter';
-import { YotiCsvImporter } from '../importers/yotiCsvImporter';
-import { ZohoVaultCsvImporter } from '../importers/zohoVaultCsvImporter';
+import { AscendoCsvImporter } from "../importers/ascendoCsvImporter";
+import { AvastCsvImporter } from "../importers/avastCsvImporter";
+import { AvastJsonImporter } from "../importers/avastJsonImporter";
+import { AviraCsvImporter } from "../importers/aviraCsvImporter";
+import { BitwardenCsvImporter } from "../importers/bitwardenCsvImporter";
+import { BitwardenJsonImporter } from "../importers/bitwardenJsonImporter";
+import { BitwardenPasswordProtectedImporter } from "../importers/bitwardenPasswordProtectedImporter";
+import { BlackBerryCsvImporter } from "../importers/blackBerryCsvImporter";
+import { BlurCsvImporter } from "../importers/blurCsvImporter";
+import { ButtercupCsvImporter } from "../importers/buttercupCsvImporter";
+import { ChromeCsvImporter } from "../importers/chromeCsvImporter";
+import { ClipperzHtmlImporter } from "../importers/clipperzHtmlImporter";
+import { CodebookCsvImporter } from "../importers/codebookCsvImporter";
+import { DashlaneJsonImporter } from "../importers/dashlaneJsonImporter";
+import { EncryptrCsvImporter } from "../importers/encryptrCsvImporter";
+import { EnpassCsvImporter } from "../importers/enpassCsvImporter";
+import { EnpassJsonImporter } from "../importers/enpassJsonImporter";
+import { FirefoxCsvImporter } from "../importers/firefoxCsvImporter";
+import { FSecureFskImporter } from "../importers/fsecureFskImporter";
+import { GnomeJsonImporter } from "../importers/gnomeJsonImporter";
+import { Importer } from "../importers/importer";
+import { KasperskyTxtImporter } from "../importers/kasperskyTxtImporter";
+import { KeePass2XmlImporter } from "../importers/keepass2XmlImporter";
+import { KeePassXCsvImporter } from "../importers/keepassxCsvImporter";
+import { KeeperCsvImporter } from "../importers/keeperCsvImporter";
+import { LastPassCsvImporter } from "../importers/lastpassCsvImporter";
+import { LogMeOnceCsvImporter } from "../importers/logMeOnceCsvImporter";
+import { MeldiumCsvImporter } from "../importers/meldiumCsvImporter";
+import { MSecureCsvImporter } from "../importers/msecureCsvImporter";
+import { MykiCsvImporter } from "../importers/mykiCsvImporter";
+import { NordPassCsvImporter } from "../importers/nordpassCsvImporter";
+import { OnePassword1PifImporter } from "../importers/onepasswordImporters/onepassword1PifImporter";
+import { OnePasswordMacCsvImporter } from "../importers/onepasswordImporters/onepasswordMacCsvImporter";
+import { OnePasswordWinCsvImporter } from "../importers/onepasswordImporters/onepasswordWinCsvImporter";
+import { PadlockCsvImporter } from "../importers/padlockCsvImporter";
+import { PassKeepCsvImporter } from "../importers/passkeepCsvImporter";
+import { PassmanJsonImporter } from "../importers/passmanJsonImporter";
+import { PasspackCsvImporter } from "../importers/passpackCsvImporter";
+import { PasswordAgentCsvImporter } from "../importers/passwordAgentCsvImporter";
+import { PasswordBossJsonImporter } from "../importers/passwordBossJsonImporter";
+import { PasswordDragonXmlImporter } from "../importers/passwordDragonXmlImporter";
+import { PasswordSafeXmlImporter } from "../importers/passwordSafeXmlImporter";
+import { PasswordWalletTxtImporter } from "../importers/passwordWalletTxtImporter";
+import { RememBearCsvImporter } from "../importers/rememBearCsvImporter";
+import { RoboFormCsvImporter } from "../importers/roboformCsvImporter";
+import { SafariCsvImporter } from "../importers/safariCsvImporter";
+import { SafeInCloudXmlImporter } from "../importers/safeInCloudXmlImporter";
+import { SaferPassCsvImporter } from "../importers/saferpassCsvImport";
+import { SecureSafeCsvImporter } from "../importers/secureSafeCsvImporter";
+import { SplashIdCsvImporter } from "../importers/splashIdCsvImporter";
+import { StickyPasswordXmlImporter } from "../importers/stickyPasswordXmlImporter";
+import { TrueKeyCsvImporter } from "../importers/truekeyCsvImporter";
+import { UpmCsvImporter } from "../importers/upmCsvImporter";
+import { YotiCsvImporter } from "../importers/yotiCsvImporter";
+import { ZohoVaultCsvImporter } from "../importers/zohoVaultCsvImporter";
 
 export class ImportService implements ImportServiceAbstraction {
   featuredImportOptions = [
@@ -153,7 +153,7 @@ export class ImportService implements ImportServiceAbstraction {
     private collectionService: CollectionService,
     private platformUtilsService: PlatformUtilsService,
     private cryptoService: CryptoService
-  ) { }
+  ) {}
 
   getImportOptions(): ImportOption[] {
     return this.featuredImportOptions.concat(this.regularImportOptions);
@@ -206,121 +206,125 @@ export class ImportService implements ImportServiceAbstraction {
   }
 
   private getImporterInstance(format: string, password: string) {
-    if (format == null || format === '') {
+    if (format == null || format === "") {
       return null;
     }
 
     switch (format) {
-      case 'bitwardencsv':
+      case "bitwardencsv":
         return new BitwardenCsvImporter();
-      case 'bitwardenjson':
+      case "bitwardenjson":
         return new BitwardenJsonImporter(this.cryptoService, this.i18nService);
-      case 'bitwardenPasswordProtected':
-        return new BitwardenPasswordProtectedImporter(this.cryptoService, this.i18nService, password);
-      case 'lastpasscsv':
-      case 'passboltcsv':
+      case "bitwardenPasswordProtected":
+        return new BitwardenPasswordProtectedImporter(
+          this.cryptoService,
+          this.i18nService,
+          password
+        );
+      case "lastpasscsv":
+      case "passboltcsv":
         return new LastPassCsvImporter();
-      case 'keepassxcsv':
+      case "keepassxcsv":
         return new KeePassXCsvImporter();
-      case 'aviracsv':
+      case "aviracsv":
         return new AviraCsvImporter();
-      case 'blurcsv':
+      case "blurcsv":
         return new BlurCsvImporter();
-      case 'safeincloudxml':
+      case "safeincloudxml":
         return new SafeInCloudXmlImporter();
-      case 'padlockcsv':
+      case "padlockcsv":
         return new PadlockCsvImporter();
-      case 'keepass2xml':
+      case "keepass2xml":
         return new KeePass2XmlImporter();
-      case 'chromecsv':
-      case 'operacsv':
-      case 'vivaldicsv':
+      case "chromecsv":
+      case "operacsv":
+      case "vivaldicsv":
         return new ChromeCsvImporter();
-      case 'firefoxcsv':
+      case "firefoxcsv":
         return new FirefoxCsvImporter();
-      case 'upmcsv':
+      case "upmcsv":
         return new UpmCsvImporter();
-      case 'saferpasscsv':
+      case "saferpasscsv":
         return new SaferPassCsvImporter();
-      case 'safaricsv':
+      case "safaricsv":
         return new SafariCsvImporter();
-      case 'meldiumcsv':
+      case "meldiumcsv":
         return new MeldiumCsvImporter();
-      case '1password1pif':
+      case "1password1pif":
         return new OnePassword1PifImporter();
-      case '1passwordwincsv':
+      case "1passwordwincsv":
         return new OnePasswordWinCsvImporter();
-      case '1passwordmaccsv':
+      case "1passwordmaccsv":
         return new OnePasswordMacCsvImporter();
-      case 'keepercsv':
+      case "keepercsv":
         return new KeeperCsvImporter();
-      case 'passworddragonxml':
+      case "passworddragonxml":
         return new PasswordDragonXmlImporter();
-      case 'enpasscsv':
+      case "enpasscsv":
         return new EnpassCsvImporter();
-      case 'enpassjson':
+      case "enpassjson":
         return new EnpassJsonImporter();
-      case 'pwsafexml':
+      case "pwsafexml":
         return new PasswordSafeXmlImporter();
-      case 'dashlanejson':
+      case "dashlanejson":
         return new DashlaneJsonImporter();
-      case 'msecurecsv':
+      case "msecurecsv":
         return new MSecureCsvImporter();
-      case 'stickypasswordxml':
+      case "stickypasswordxml":
         return new StickyPasswordXmlImporter();
-      case 'truekeycsv':
+      case "truekeycsv":
         return new TrueKeyCsvImporter();
-      case 'clipperzhtml':
+      case "clipperzhtml":
         return new ClipperzHtmlImporter();
-      case 'roboformcsv':
+      case "roboformcsv":
         return new RoboFormCsvImporter();
-      case 'ascendocsv':
+      case "ascendocsv":
         return new AscendoCsvImporter();
-      case 'passwordbossjson':
+      case "passwordbossjson":
         return new PasswordBossJsonImporter();
-      case 'zohovaultcsv':
+      case "zohovaultcsv":
         return new ZohoVaultCsvImporter();
-      case 'splashidcsv':
+      case "splashidcsv":
         return new SplashIdCsvImporter();
-      case 'passkeepcsv':
+      case "passkeepcsv":
         return new PassKeepCsvImporter();
-      case 'gnomejson':
+      case "gnomejson":
         return new GnomeJsonImporter();
-      case 'passwordagentcsv':
+      case "passwordagentcsv":
         return new PasswordAgentCsvImporter();
-      case 'passpackcsv':
+      case "passpackcsv":
         return new PasspackCsvImporter();
-      case 'passmanjson':
+      case "passmanjson":
         return new PassmanJsonImporter();
-      case 'avastcsv':
+      case "avastcsv":
         return new AvastCsvImporter();
-      case 'avastjson':
+      case "avastjson":
         return new AvastJsonImporter();
-      case 'fsecurefsk':
+      case "fsecurefsk":
         return new FSecureFskImporter();
-      case 'kasperskytxt':
+      case "kasperskytxt":
         return new KasperskyTxtImporter();
-      case 'remembearcsv':
+      case "remembearcsv":
         return new RememBearCsvImporter();
-      case 'passwordwallettxt':
+      case "passwordwallettxt":
         return new PasswordWalletTxtImporter();
-      case 'mykicsv':
+      case "mykicsv":
         return new MykiCsvImporter();
-      case 'securesafecsv':
+      case "securesafecsv":
         return new SecureSafeCsvImporter();
-      case 'logmeoncecsv':
+      case "logmeoncecsv":
         return new LogMeOnceCsvImporter();
-      case 'blackberrycsv':
+      case "blackberrycsv":
         return new BlackBerryCsvImporter();
-      case 'buttercupcsv':
+      case "buttercupcsv":
         return new ButtercupCsvImporter();
-      case 'codebookcsv':
+      case "codebookcsv":
         return new CodebookCsvImporter();
-      case 'encryptrcsv':
+      case "encryptrcsv":
         return new EncryptrCsvImporter();
-      case 'yoticsv':
+      case "yoticsv":
         return new YotiCsvImporter();
-      case 'nordpasscsv':
+      case "nordpasscsv":
         return new NordPassCsvImporter();
       default:
         return null;

--- a/spec/common/importers/bitwardenPasswordProtectedImporter.spec.ts
+++ b/spec/common/importers/bitwardenPasswordProtectedImporter.spec.ts
@@ -1,0 +1,173 @@
+import Substitute, { Arg, SubstituteOf } from '@fluffy-spoon/substitute';
+
+import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { ImportService } from 'jslib-common/abstractions/import.service';
+
+import { BitwardenPasswordProtectedImporter } from 'jslib-common/importers/bitwardenPasswordProtectedImporter';
+import { Importer } from 'jslib-common/importers/importer';
+
+import { Utils } from 'jslib-common/misc/utils';
+import { ImportResult } from 'jslib-common/models/domain/importResult';
+
+describe("BitwardenPasswordProtectedImporter", () => {
+    let importer: BitwardenPasswordProtectedImporter;
+    let innerImporter: SubstituteOf<Importer>;
+    let importService: SubstituteOf<ImportService>;
+    let cryptoService: SubstituteOf<CryptoService>;
+    let i18nService: SubstituteOf<I18nService>;
+    const password = Utils.newGuid();
+    const result = new ImportResult();
+    let jDoc: { encrypted?: boolean, passwordProtected?: boolean, format?: string, salt?: string, kdfIterations?: any, encKeyValidation_DO_NOT_EDIT?: string, data?: string; };
+
+    beforeEach(() => {
+        cryptoService = Substitute.for<CryptoService>();
+        i18nService = Substitute.for<I18nService>();
+        importService = Substitute.for<ImportService>();
+        innerImporter = Substitute.for<Importer>();
+
+        jDoc = {
+            encrypted: true,
+            passwordProtected: true,
+            format: "csv",
+            salt: "c2FsdA==",
+            kdfIterations: 100000,
+            encKeyValidation_DO_NOT_EDIT: Utils.newGuid(),
+            data: Utils.newGuid(),
+        };
+
+        result.success = true;
+        innerImporter.parse(Arg.any()).resolves(result);
+        importer = new BitwardenPasswordProtectedImporter(importService, cryptoService, i18nService, password);
+    });
+
+    describe("Required Json Data", () => {
+
+        it("succeeds with default jdoc", async () => {
+            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+        });
+
+        it("accepts json format", async () => {
+            jDoc.format = "json";
+            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+        });
+
+        it("accepts encrypted_json format", async () => {
+            jDoc.format = "encrypted_json";
+            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+        });
+
+        it("fails if encrypted === false", async () => {
+            jDoc.encrypted = false;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if encrypted === null", async () => {
+            jDoc.encrypted = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if passwordProtected === false", async () => {
+            jDoc.passwordProtected = false;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if passwordProtected === null", async () => {
+            jDoc.passwordProtected = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if format === null", async () => {
+            jDoc.format = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if format not known", async () => {
+            jDoc.format = "Not a real format";
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if salt === null", async () => {
+            jDoc.salt = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if kdfIterations === null", async () => {
+            jDoc.kdfIterations = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if kdfIterations is not a number", async () => {
+            jDoc.kdfIterations = "not a number";
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if encKeyValidation_DO_NOT_EDIT === null", async () => {
+            jDoc.encKeyValidation_DO_NOT_EDIT = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("fails if data === null", async () => {
+            jDoc.data = null;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+    });
+
+    describe("inner importer", () => {
+        beforeEach(() => {
+            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+        });
+        it("delegates success", async () => {
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+            result.success = false;
+            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+        });
+
+        it("passes on organization Id", async () => {
+            jDoc.format = "csv";
+            importer.organizationId = Utils.newGuid();
+            await importer.parse(JSON.stringify(jDoc));
+
+            importService.received(1).getImporter("bitwardencsv", importer.organizationId);
+        });
+
+        it("passes null organizationId if none set", async () => {
+            jDoc.format = "csv";
+            importer.organizationId = null;
+            await importer.parse(JSON.stringify(jDoc));
+
+            importService.received(1).getImporter("bitwardencsv", null);
+        });
+
+        it("gets csv importer for csv format", async () => {
+            jDoc.format = "csv";
+
+            await importer.parse(JSON.stringify(jDoc));
+
+            importService.received(1).getImporter("bitwardencsv", Arg.any());
+        });
+
+
+        it("gets json importer for json format", async () => {
+            jDoc.format = "json";
+
+            await importer.parse(JSON.stringify(jDoc));
+
+            importService.received(1).getImporter("bitwardenjson", Arg.any());
+        });
+
+        it("gets json importer for encrypted_json format", async () => {
+            jDoc.format = "encrypted_json";
+
+            await importer.parse(JSON.stringify(jDoc));
+
+            importService.received(1).getImporter("bitwardenjson", Arg.any());
+        });
+    });
+});

--- a/spec/common/importers/bitwardenPasswordProtectedImporter.spec.ts
+++ b/spec/common/importers/bitwardenPasswordProtectedImporter.spec.ts
@@ -1,173 +1,184 @@
-import Substitute, { Arg, SubstituteOf } from '@fluffy-spoon/substitute';
+import Substitute, { Arg, SubstituteOf } from "@fluffy-spoon/substitute";
 
-import { CryptoService } from 'jslib-common/abstractions/crypto.service';
-import { I18nService } from 'jslib-common/abstractions/i18n.service';
-import { ImportService } from 'jslib-common/abstractions/import.service';
+import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { I18nService } from "jslib-common/abstractions/i18n.service";
+import { ImportService } from "jslib-common/abstractions/import.service";
 
-import { BitwardenPasswordProtectedImporter } from 'jslib-common/importers/bitwardenPasswordProtectedImporter';
-import { Importer } from 'jslib-common/importers/importer';
+import { BitwardenPasswordProtectedImporter } from "jslib-common/importers/bitwardenPasswordProtectedImporter";
+import { Importer } from "jslib-common/importers/importer";
 
-import { Utils } from 'jslib-common/misc/utils';
-import { ImportResult } from 'jslib-common/models/domain/importResult';
+import { Utils } from "jslib-common/misc/utils";
+import { ImportResult } from "jslib-common/models/domain/importResult";
 
 describe("BitwardenPasswordProtectedImporter", () => {
-    let importer: BitwardenPasswordProtectedImporter;
-    let innerImporter: SubstituteOf<Importer>;
-    let importService: SubstituteOf<ImportService>;
-    let cryptoService: SubstituteOf<CryptoService>;
-    let i18nService: SubstituteOf<I18nService>;
-    const password = Utils.newGuid();
-    const result = new ImportResult();
-    let jDoc: { encrypted?: boolean, passwordProtected?: boolean, format?: string, salt?: string, kdfIterations?: any, encKeyValidation_DO_NOT_EDIT?: string, data?: string; };
+  let importer: BitwardenPasswordProtectedImporter;
+  let innerImporter: SubstituteOf<Importer>;
+  let importService: SubstituteOf<ImportService>;
+  let cryptoService: SubstituteOf<CryptoService>;
+  let i18nService: SubstituteOf<I18nService>;
+  const password = Utils.newGuid();
+  const result = new ImportResult();
+  let jDoc: {
+    encrypted?: boolean;
+    passwordProtected?: boolean;
+    format?: string;
+    salt?: string;
+    kdfIterations?: any;
+    encKeyValidation_DO_NOT_EDIT?: string;
+    data?: string;
+  };
 
+  beforeEach(() => {
+    cryptoService = Substitute.for<CryptoService>();
+    i18nService = Substitute.for<I18nService>();
+    importService = Substitute.for<ImportService>();
+    innerImporter = Substitute.for<Importer>();
+
+    jDoc = {
+      encrypted: true,
+      passwordProtected: true,
+      format: "csv",
+      salt: "c2FsdA==",
+      kdfIterations: 100000,
+      encKeyValidation_DO_NOT_EDIT: Utils.newGuid(),
+      data: Utils.newGuid(),
+    };
+
+    result.success = true;
+    innerImporter.parse(Arg.any()).resolves(result);
+    importer = new BitwardenPasswordProtectedImporter(
+      importService,
+      cryptoService,
+      i18nService,
+      password
+    );
+  });
+
+  describe("Required Json Data", () => {
+    it("succeeds with default jdoc", async () => {
+      cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+    });
+
+    it("accepts json format", async () => {
+      jDoc.format = "json";
+      cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+    });
+
+    it("accepts encrypted_json format", async () => {
+      jDoc.format = "encrypted_json";
+      cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+    });
+
+    it("fails if encrypted === false", async () => {
+      jDoc.encrypted = false;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if encrypted === null", async () => {
+      jDoc.encrypted = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if passwordProtected === false", async () => {
+      jDoc.passwordProtected = false;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if passwordProtected === null", async () => {
+      jDoc.passwordProtected = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if format === null", async () => {
+      jDoc.format = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if format not known", async () => {
+      jDoc.format = "Not a real format";
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if salt === null", async () => {
+      jDoc.salt = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if kdfIterations === null", async () => {
+      jDoc.kdfIterations = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if kdfIterations is not a number", async () => {
+      jDoc.kdfIterations = "not a number";
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if encKeyValidation_DO_NOT_EDIT === null", async () => {
+      jDoc.encKeyValidation_DO_NOT_EDIT = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    it("fails if data === null", async () => {
+      jDoc.data = null;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+  });
+
+  describe("inner importer", () => {
     beforeEach(() => {
-        cryptoService = Substitute.for<CryptoService>();
-        i18nService = Substitute.for<I18nService>();
-        importService = Substitute.for<ImportService>();
-        innerImporter = Substitute.for<Importer>();
-
-        jDoc = {
-            encrypted: true,
-            passwordProtected: true,
-            format: "csv",
-            salt: "c2FsdA==",
-            kdfIterations: 100000,
-            encKeyValidation_DO_NOT_EDIT: Utils.newGuid(),
-            data: Utils.newGuid(),
-        };
-
-        result.success = true;
-        innerImporter.parse(Arg.any()).resolves(result);
-        importer = new BitwardenPasswordProtectedImporter(importService, cryptoService, i18nService, password);
+      cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
+    });
+    it("delegates success", async () => {
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+      result.success = false;
+      expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
     });
 
-    describe("Required Json Data", () => {
+    it("passes on organization Id", async () => {
+      jDoc.format = "csv";
+      importer.organizationId = Utils.newGuid();
+      await importer.parse(JSON.stringify(jDoc));
 
-        it("succeeds with default jdoc", async () => {
-            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
-
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
-        });
-
-        it("accepts json format", async () => {
-            jDoc.format = "json";
-            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
-
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
-        });
-
-        it("accepts encrypted_json format", async () => {
-            jDoc.format = "encrypted_json";
-            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
-
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
-        });
-
-        it("fails if encrypted === false", async () => {
-            jDoc.encrypted = false;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if encrypted === null", async () => {
-            jDoc.encrypted = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if passwordProtected === false", async () => {
-            jDoc.passwordProtected = false;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if passwordProtected === null", async () => {
-            jDoc.passwordProtected = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if format === null", async () => {
-            jDoc.format = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if format not known", async () => {
-            jDoc.format = "Not a real format";
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if salt === null", async () => {
-            jDoc.salt = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if kdfIterations === null", async () => {
-            jDoc.kdfIterations = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if kdfIterations is not a number", async () => {
-            jDoc.kdfIterations = "not a number";
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if encKeyValidation_DO_NOT_EDIT === null", async () => {
-            jDoc.encKeyValidation_DO_NOT_EDIT = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
-
-        it("fails if data === null", async () => {
-            jDoc.data = null;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
+      importService.received(1).getImporter("bitwardencsv", importer.organizationId);
     });
 
-    describe("inner importer", () => {
-        beforeEach(() => {
-            cryptoService.decryptToUtf8(Arg.any(), Arg.any()).resolves("successful decryption");
-        });
-        it("delegates success", async () => {
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
-            result.success = false;
-            expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
-        });
+    it("passes null organizationId if none set", async () => {
+      jDoc.format = "csv";
+      importer.organizationId = null;
+      await importer.parse(JSON.stringify(jDoc));
 
-        it("passes on organization Id", async () => {
-            jDoc.format = "csv";
-            importer.organizationId = Utils.newGuid();
-            await importer.parse(JSON.stringify(jDoc));
-
-            importService.received(1).getImporter("bitwardencsv", importer.organizationId);
-        });
-
-        it("passes null organizationId if none set", async () => {
-            jDoc.format = "csv";
-            importer.organizationId = null;
-            await importer.parse(JSON.stringify(jDoc));
-
-            importService.received(1).getImporter("bitwardencsv", null);
-        });
-
-        it("gets csv importer for csv format", async () => {
-            jDoc.format = "csv";
-
-            await importer.parse(JSON.stringify(jDoc));
-
-            importService.received(1).getImporter("bitwardencsv", Arg.any());
-        });
-
-
-        it("gets json importer for json format", async () => {
-            jDoc.format = "json";
-
-            await importer.parse(JSON.stringify(jDoc));
-
-            importService.received(1).getImporter("bitwardenjson", Arg.any());
-        });
-
-        it("gets json importer for encrypted_json format", async () => {
-            jDoc.format = "encrypted_json";
-
-            await importer.parse(JSON.stringify(jDoc));
-
-            importService.received(1).getImporter("bitwardenjson", Arg.any());
-        });
+      importService.received(1).getImporter("bitwardencsv", null);
     });
+
+    it("gets csv importer for csv format", async () => {
+      jDoc.format = "csv";
+
+      await importer.parse(JSON.stringify(jDoc));
+
+      importService.received(1).getImporter("bitwardencsv", Arg.any());
+    });
+
+    it("gets json importer for json format", async () => {
+      jDoc.format = "json";
+
+      await importer.parse(JSON.stringify(jDoc));
+
+      importService.received(1).getImporter("bitwardenjson", Arg.any());
+    });
+
+    it("gets json importer for encrypted_json format", async () => {
+      jDoc.format = "encrypted_json";
+
+      await importer.parse(JSON.stringify(jDoc));
+
+      importService.received(1).getImporter("bitwardenjson", Arg.any());
+    });
+  });
 });

--- a/spec/common/services/export.service.spec.ts
+++ b/spec/common/services/export.service.spec.ts
@@ -3,7 +3,7 @@ import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
-import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
+import { CryptoFunctionService } from "jslib-common/abstractions/cryptoFunction.service";
 import { FolderService } from "jslib-common/abstractions/folder.service";
 
 import { ExportService } from "jslib-common/services/export.service";
@@ -14,7 +14,7 @@ import { Login } from "jslib-common/models/domain/login";
 import { CipherWithIds as CipherExport } from "jslib-common/models/export/cipherWithIds";
 
 import { CipherType } from "jslib-common/enums/cipherType";
-import { Utils } from 'jslib-common/misc/utils';
+import { Utils } from "jslib-common/misc/utils";
 import { CipherView } from "jslib-common/models/view/cipherView";
 import { LoginView } from "jslib-common/models/view/loginView";
 
@@ -102,7 +102,13 @@ describe("ExportService", () => {
     folderService.getAllDecrypted().resolves([]);
     folderService.getAll().resolves([]);
 
-    exportService = new ExportService(folderService, cipherService, apiService, cryptoService, cryptoFunctionService);
+    exportService = new ExportService(
+      folderService,
+      cipherService,
+      apiService,
+      cryptoService,
+      cryptoFunctionService
+    );
   });
 
   it("exports unecrypted user ciphers", async () => {
@@ -153,7 +159,6 @@ describe("ExportService", () => {
         mac.encryptedString = "mac";
         data.encryptedString = "encData";
 
-
         spyOn(Utils, "fromBufferToB64").and.returnValue(salt);
         cipherService.getAllDecrypted().resolves(UserCipherViews.slice(0, 1));
 
@@ -174,7 +179,6 @@ describe("ExportService", () => {
       });
 
       it("specifies salt", () => {
-
         expect(exportObject.salt).toEqual("salt");
       });
 

--- a/spec/common/services/export.service.spec.ts
+++ b/spec/common/services/export.service.spec.ts
@@ -1,8 +1,9 @@
-import { Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
 import { FolderService } from "jslib-common/abstractions/folder.service";
 
 import { ExportService } from "jslib-common/services/export.service";
@@ -13,6 +14,7 @@ import { Login } from "jslib-common/models/domain/login";
 import { CipherWithIds as CipherExport } from "jslib-common/models/export/cipherWithIds";
 
 import { CipherType } from "jslib-common/enums/cipherType";
+import { Utils } from 'jslib-common/misc/utils';
 import { CipherView } from "jslib-common/models/view/cipherView";
 import { LoginView } from "jslib-common/models/view/loginView";
 
@@ -85,12 +87,14 @@ function expectEqualCiphers(ciphers: CipherView[] | Cipher[], jsonResult: string
 describe("ExportService", () => {
   let exportService: ExportService;
   let apiService: SubstituteOf<ApiService>;
+  let cryptoFunctionService: SubstituteOf<CryptoFunctionService>;
   let cipherService: SubstituteOf<CipherService>;
   let folderService: SubstituteOf<FolderService>;
   let cryptoService: SubstituteOf<CryptoService>;
 
   beforeEach(() => {
     apiService = Substitute.for<ApiService>();
+    cryptoFunctionService = Substitute.for<CryptoFunctionService>();
     cipherService = Substitute.for<CipherService>();
     folderService = Substitute.for<FolderService>();
     cryptoService = Substitute.for<CryptoService>();
@@ -98,7 +102,7 @@ describe("ExportService", () => {
     folderService.getAllDecrypted().resolves([]);
     folderService.getAll().resolves([]);
 
-    exportService = new ExportService(folderService, cipherService, apiService, cryptoService);
+    exportService = new ExportService(folderService, cipherService, apiService, cryptoService, cryptoFunctionService);
   });
 
   it("exports unecrypted user ciphers", async () => {
@@ -131,5 +135,67 @@ describe("ExportService", () => {
     const actual = await exportService.getExport("encrypted_json");
 
     expectEqualCiphers(UserCipherDomains.slice(0, 2), actual);
+  });
+
+  describe("password protected export", () => {
+    let exportString: string;
+    let exportObject: any;
+    let mac: SubstituteOf<EncString>;
+    let data: SubstituteOf<EncString>;
+    const password = "password";
+    const salt = "salt";
+
+    describe("export json object", () => {
+      beforeEach(async () => {
+        mac = Substitute.for<EncString>();
+        data = Substitute.for<EncString>();
+
+        mac.encryptedString = "mac";
+        data.encryptedString = "encData";
+
+
+        spyOn(Utils, "fromBufferToB64").and.returnValue(salt);
+        cipherService.getAllDecrypted().resolves(UserCipherViews.slice(0, 1));
+
+        exportString = await exportService.getPasswordProtectedExport(password);
+        exportObject = JSON.parse(exportString);
+      });
+
+      it("specifies it is encrypted", () => {
+        expect(exportObject.encrypted).toBe(true);
+      });
+
+      it("specifies it's password protected", () => {
+        expect(exportObject.passwordProtected).toBe(true);
+      });
+
+      it("specifies format", () => {
+        expect(exportObject).toEqual(jasmine.objectContaining({ format: jasmine.any(String) }));
+      });
+
+      it("specifies salt", () => {
+
+        expect(exportObject.salt).toEqual("salt");
+      });
+
+      it("specifies kdfIterations", () => {
+        expect(exportObject.kdfIterations).toEqual(100000);
+      });
+
+      it("has a mac property", () => {
+        cryptoService.encrypt(Arg.any(), Arg.any()).resolves(mac);
+        expect(exportObject.encKeyValidation_DO_NOT_EDIT).toEqual(mac.encryptedString);
+      });
+
+      it("has data property", () => {
+        cryptoService.encrypt(Arg.any(), Arg.any()).resolves(data);
+        expect(exportObject.data).toEqual(data.encryptedString);
+      });
+
+      it("encrypts the data property", async () => {
+        const unencrypted = await exportService.getExport();
+        expect(exportObject.data).not.toEqual(unencrypted);
+      });
+    });
   });
 });

--- a/spec/common/services/import.service.spec.ts
+++ b/spec/common/services/import.service.spec.ts
@@ -1,63 +1,74 @@
-import Substitute, { Arg, SubstituteOf } from '@fluffy-spoon/substitute';
-import { ApiService } from 'jslib-common/abstractions/api.service';
+import Substitute, { Arg, SubstituteOf } from "@fluffy-spoon/substitute";
+import { ApiService } from "jslib-common/abstractions/api.service";
 
-import { CipherService } from 'jslib-common/abstractions/cipher.service';
-import { CollectionService } from 'jslib-common/abstractions/collection.service';
-import { CryptoService } from 'jslib-common/abstractions/crypto.service';
-import { FolderService } from 'jslib-common/abstractions/folder.service';
-import { I18nService } from 'jslib-common/abstractions/i18n.service';
-import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
-import { BitwardenPasswordProtectedImporter } from 'jslib-common/importers/bitwardenPasswordProtectedImporter';
+import { CipherService } from "jslib-common/abstractions/cipher.service";
+import { CollectionService } from "jslib-common/abstractions/collection.service";
+import { CryptoService } from "jslib-common/abstractions/crypto.service";
+import { FolderService } from "jslib-common/abstractions/folder.service";
+import { I18nService } from "jslib-common/abstractions/i18n.service";
+import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
+import { BitwardenPasswordProtectedImporter } from "jslib-common/importers/bitwardenPasswordProtectedImporter";
 
-import { Importer } from 'jslib-common/importers/importer';
-import { Utils } from 'jslib-common/misc/utils';
+import { Importer } from "jslib-common/importers/importer";
+import { Utils } from "jslib-common/misc/utils";
 
-import { ImportService } from 'jslib-common/services/import.service';
+import { ImportService } from "jslib-common/services/import.service";
 
 describe("ImportService", () => {
-    let importService: ImportService;
-    let cipherService: SubstituteOf<CipherService>;
-    let folderService: SubstituteOf<FolderService>;
-    let apiService: SubstituteOf<ApiService>;
-    let i18nService: SubstituteOf<I18nService>;
-    let collectionService: SubstituteOf<CollectionService>;
-    let platformUtilsService: SubstituteOf<PlatformUtilsService>;
-    let cryptoService: SubstituteOf<CryptoService>;
+  let importService: ImportService;
+  let cipherService: SubstituteOf<CipherService>;
+  let folderService: SubstituteOf<FolderService>;
+  let apiService: SubstituteOf<ApiService>;
+  let i18nService: SubstituteOf<I18nService>;
+  let collectionService: SubstituteOf<CollectionService>;
+  let platformUtilsService: SubstituteOf<PlatformUtilsService>;
+  let cryptoService: SubstituteOf<CryptoService>;
 
-    beforeEach(() => {
-        cipherService = Substitute.for<CipherService>();
-        folderService = Substitute.for<FolderService>();
-        apiService = Substitute.for<ApiService>();
-        i18nService = Substitute.for<I18nService>();
-        collectionService = Substitute.for<CollectionService>();
-        platformUtilsService = Substitute.for<PlatformUtilsService>();
-        cryptoService = Substitute.for<CryptoService>();
+  beforeEach(() => {
+    cipherService = Substitute.for<CipherService>();
+    folderService = Substitute.for<FolderService>();
+    apiService = Substitute.for<ApiService>();
+    i18nService = Substitute.for<I18nService>();
+    collectionService = Substitute.for<CollectionService>();
+    platformUtilsService = Substitute.for<PlatformUtilsService>();
+    cryptoService = Substitute.for<CryptoService>();
 
-        importService = new ImportService(cipherService, folderService, apiService, i18nService, collectionService, platformUtilsService, cryptoService);
+    importService = new ImportService(
+      cipherService,
+      folderService,
+      apiService,
+      i18nService,
+      collectionService,
+      platformUtilsService,
+      cryptoService
+    );
+  });
+
+  describe("getImporterInstance", () => {
+    describe("Get bitPasswordProtected importer", () => {
+      let importer: Importer;
+      const organizationId = Utils.newGuid();
+      const password = Utils.newGuid();
+
+      beforeEach(() => {
+        importer = importService.getImporter(
+          "bitwardenpasswordprotected",
+          organizationId,
+          password
+        );
+      });
+
+      it("returns an instance of BitwardenPasswordProtectedImporter", () => {
+        expect(importer).toBeInstanceOf(BitwardenPasswordProtectedImporter);
+      });
+
+      it("has the appropriate organization Id", () => {
+        expect(importer.organizationId).toEqual(organizationId);
+      });
+
+      it("has the appropriate password", () => {
+        expect(Object.entries(importer)).toEqual(jasmine.arrayContaining([["password", password]]));
+      });
     });
-
-    describe("getImporterInstance", () => {
-        describe("Get bitPasswordProtected importer", () => {
-            let importer: Importer;
-            const organizationId = Utils.newGuid();
-            const password = Utils.newGuid();
-
-            beforeEach(() => {
-                importer = importService.getImporter("bitwardenpasswordprotected", organizationId, password);
-            });
-
-            it('returns an instance of BitwardenPasswordProtectedImporter', () => {
-                expect(importer).toBeInstanceOf(BitwardenPasswordProtectedImporter);
-            });
-
-            it('has the appropriate organization Id', () => {
-                expect(importer.organizationId).toEqual(organizationId);
-            });
-
-            it('has the appropriate password', () => {
-                expect(Object.entries(importer)).toEqual(jasmine.arrayContaining([["password", password]]));
-            });
-        });
-    });
-
+  });
 });

--- a/spec/common/services/import.service.spec.ts
+++ b/spec/common/services/import.service.spec.ts
@@ -1,0 +1,63 @@
+import Substitute, { Arg, SubstituteOf } from '@fluffy-spoon/substitute';
+import { ApiService } from 'jslib-common/abstractions/api.service';
+
+import { CipherService } from 'jslib-common/abstractions/cipher.service';
+import { CollectionService } from 'jslib-common/abstractions/collection.service';
+import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { FolderService } from 'jslib-common/abstractions/folder.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { BitwardenPasswordProtectedImporter } from 'jslib-common/importers/bitwardenPasswordProtectedImporter';
+
+import { Importer } from 'jslib-common/importers/importer';
+import { Utils } from 'jslib-common/misc/utils';
+
+import { ImportService } from 'jslib-common/services/import.service';
+
+describe("ImportService", () => {
+    let importService: ImportService;
+    let cipherService: SubstituteOf<CipherService>;
+    let folderService: SubstituteOf<FolderService>;
+    let apiService: SubstituteOf<ApiService>;
+    let i18nService: SubstituteOf<I18nService>;
+    let collectionService: SubstituteOf<CollectionService>;
+    let platformUtilsService: SubstituteOf<PlatformUtilsService>;
+    let cryptoService: SubstituteOf<CryptoService>;
+
+    beforeEach(() => {
+        cipherService = Substitute.for<CipherService>();
+        folderService = Substitute.for<FolderService>();
+        apiService = Substitute.for<ApiService>();
+        i18nService = Substitute.for<I18nService>();
+        collectionService = Substitute.for<CollectionService>();
+        platformUtilsService = Substitute.for<PlatformUtilsService>();
+        cryptoService = Substitute.for<CryptoService>();
+
+        importService = new ImportService(cipherService, folderService, apiService, i18nService, collectionService, platformUtilsService, cryptoService);
+    });
+
+    describe("getImporterInstance", () => {
+        describe("Get bitPasswordProtected importer", () => {
+            let importer: Importer;
+            const organizationId = Utils.newGuid();
+            const password = Utils.newGuid();
+
+            beforeEach(() => {
+                importer = importService.getImporter("bitwardenpasswordprotected", organizationId, password);
+            });
+
+            it('returns an instance of BitwardenPasswordProtectedImporter', () => {
+                expect(importer).toBeInstanceOf(BitwardenPasswordProtectedImporter);
+            });
+
+            it('has the appropriate organization Id', () => {
+                expect(importer.organizationId).toEqual(organizationId);
+            });
+
+            it('has the appropriate password', () => {
+                expect(Object.entries(importer)).toEqual(jasmine.arrayContaining([["password", password]]));
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add a new Bitwarden Import/Export that is encrypted with a user-supplied password. This should enable secure storage of Bitwarden vaults without the worry that Bitwarden instance data-loss or key rotations will impact your ability to decrypt!

CLI PR is incoming, but we're still working on exactly how we want to present this in Web.

## Code changes
Largely this is just a new importer and a wrapper function for exports, but further breakdown below.

* **export.service**: `getPasswordProtectedExport` calls an inner exporter depending on format and organizationId, then encrypts the result with the given password.
* **import.service**: I've extracted the ImportTypes to constants so that I can generate union type strings for each importer's Id. That way we can't give invalid Ids to the import service. Types are good 🥳 
  * Type safety changes: There will be small changes in `web` and `cli` due to the change in type of the import options to `readonly`. Basically we can't `sort` in place or pass in `string` formats anymore.
* **bitwardenPasswordProtectedImporter**: Handles decryption of a password protected export file and passes the decrypted inner data to an inner importer. Uses the same mac validation scheme we use for `encrypted_json` files, where we write a short string with a mac and validate we were able to decrypt it.

## Testing requirements
### Test coverage
* password protected importer 
  * We validate that the imported json doc has all the fields we need in the correct types.
  * We validate we're grabbing the right inner importers
* import service
  * Validates we get the right kind of importer for the appropriate importer type request
  * validates we're passing on organizationId and password appropriately
* Export service
  * Validates we're password protecting the export
  * Validates we're adding all the required fields property to the export json

We'll need integration tests that validate round-tripped password protected exports.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
