### PR TITLE
Bump electron from 16.0.2 to 16.0.7

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-        "electron": "16.0.2",
+        "electron": "16.0.7",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.6.1",
@@ -546,9 +546,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "node_modules/electron": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
-      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.7.tgz",
+      "integrity": "sha512-/IMwpBf2svhA1X/7Q58RV+Nn0fvUJsHniG4TizaO7q4iKFYSQ6hBvsLz+cylcZ8hRMKmVy5G1XaMNJID2ah23w==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -2276,9 +2276,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "electron": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
-      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.7.tgz",
+      "integrity": "sha512-/IMwpBf2svhA1X/7Q58RV+Nn0fvUJsHniG4TizaO7q4iKFYSQ6hBvsLz+cylcZ8hRMKmVy5G1XaMNJID2ah23w==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",

--- a/electron/package.json
+++ b/electron/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@bitwarden/jslib-common": "file:../common",
     "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-    "electron": "16.0.2",
+    "electron": "16.0.7",
     "electron-log": "4.4.1",
     "electron-store": "8.0.1",
     "electron-updater": "4.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
       "dependencies": {
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-        "electron": "16.0.2",
+        "electron": "16.0.7",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.6.1",
@@ -3034,9 +3034,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
-      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.7.tgz",
+      "integrity": "sha512-/IMwpBf2svhA1X/7Q58RV+Nn0fvUJsHniG4TizaO7q4iKFYSQ6hBvsLz+cylcZ8hRMKmVy5G1XaMNJID2ah23w==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -10670,7 +10670,7 @@
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
         "@types/node": "^16.11.12",
-        "electron": "16.0.2",
+        "electron": "16.0.7",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.6.1",
@@ -12855,9 +12855,9 @@
       "dev": true
     },
     "electron": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
-      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.7.tgz",
+      "integrity": "sha512-/IMwpBf2svhA1X/7Q58RV+Nn0fvUJsHniG4TizaO7q4iKFYSQ6hBvsLz+cylcZ8hRMKmVy5G1XaMNJID2ah23w==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Bumping electron from 16.0.2 to 16.0.7

## Code changes

- **electron/package.json:** Updated electron to 16.0.7
- **electron/package-lock.json:** Changes after executing `npm i`
- **package-lock.json:** Changes after executing `npm i`

## Testing requirements
Regression testing on clients

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
