### PR TITLE
Always migrate envUrls to new storage format

### DIFF
--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -177,9 +177,7 @@ export class StateMigrationService {
                 v1Keys.enableBiometric,
                 options
               ),
-              environmentUrls:
-                (await this.storageService.get<EnvironmentUrls>(v1Keys.environmentUrls, options)) ??
-                new EnvironmentUrls(),
+              environmentUrls: null,
               installedVersion: await this.storageService.get<string>(
                 v1Keys.installedVersion,
                 options
@@ -488,6 +486,10 @@ export class StateMigrationService {
               }),
             },
           };
+
+    initialState.globals.environmentUrls =
+      (await this.storageService.get<EnvironmentUrls>(v1Keys.environmentUrls, options)) ??
+      new EnvironmentUrls();
 
     await this.storageService.save("state", initialState, options);
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix the following defect in CLI: 
1. run a pre-account switching version of CLI
2. set your environment urls using `bw config server`
3. log out
4. upgrade CLI and try to log in

Expected result: saved urls are migrated
Actual result: saved urls are lost and it defaults to production servers

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* `stateMigrationService.ts` - always migrate the environment urls to `global` settings, regardless of whether the user is logged in (which I believe is what the `userId` storage key indicates). This seems like a reasonable course of action for all clients.

Incidentally, it appears that the environment urls are copied to the user's settings when the migration runs, but after that point they're only read from and written to the global settings. This seems like it could cause problems down the line because we'll have unused values sitting in user's settings, but we won't know whether they're valid or not. However, I haven't been doing account switching work, so I haven't changed anything here yet without some feedback from the team.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Will be covered in general account switching regression testing. But note that the migration path should be tested specifically.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
