### PR TITLE
Fix migration to Key Connector in cli commands

### DIFF
--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -43,9 +43,9 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
   async migrateUser() {
     const organization = await this.getManagingOrganization();
     const key = await this.cryptoService.getKey();
+    const keyConnectorRequest = new KeyConnectorUserKeyRequest(key.encKeyB64);
 
     try {
-      const keyConnectorRequest = new KeyConnectorUserKeyRequest(key.encKeyB64);
       await this.apiService.postUserKeyToKeyConnector(
         organization.keyConnectorUrl,
         keyConnectorRequest

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -33,7 +33,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
   }
 
   async userNeedsMigration() {
-    const loggedInUsingSso = this.tokenService.getIsExternal();
+    const loggedInUsingSso = await this.tokenService.getIsExternal();
     const requiredByOrganization = (await this.getManagingOrganization()) != null;
     const userIsNotUsingKeyConnector = !(await this.getUsesKeyConnector());
 

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -334,6 +334,7 @@ export class SyncService implements SyncServiceAbstraction {
     ]);
 
     if (await this.keyConnectorService.userNeedsMigration()) {
+      await this.keyConnectorService.setConvertAccountRequired(true);
       this.messagingService.send("convertAccountToKeyConnector");
     } else {
       this.keyConnectorService.removeConvertAccountRequired();

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -18,7 +18,6 @@ import { PasswordGenerationService } from "jslib-common/abstractions/passwordGen
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { PolicyService } from "jslib-common/abstractions/policy.service";
 import { StateService } from "jslib-common/abstractions/state.service";
-import { SyncService } from "jslib-common/abstractions/sync.service";
 
 import { Response } from "../models/response";
 
@@ -54,8 +53,7 @@ export class LoginCommand {
     protected stateService: StateService,
     protected cryptoService: CryptoService,
     protected policyService: PolicyService,
-    clientId: string,
-    protected syncService: SyncService
+    clientId: string
   ) {
     this.clientId = clientId;
   }

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -14,16 +14,13 @@ import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { CryptoFunctionService } from "jslib-common/abstractions/cryptoFunction.service";
 import { EnvironmentService } from "jslib-common/abstractions/environment.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
-import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.service";
 import { PasswordGenerationService } from "jslib-common/abstractions/passwordGeneration.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { PolicyService } from "jslib-common/abstractions/policy.service";
 import { StateService } from "jslib-common/abstractions/state.service";
-import { SyncService } from "jslib-common/abstractions/sync.service";
 
 import { Response } from "../models/response";
 
-import { KeyConnectorUserKeyRequest } from "jslib-common/models/request/keyConnectorUserKeyRequest";
 import { UpdateTempPasswordRequest } from "jslib-common/models/request/updateTempPasswordRequest";
 
 import { MessageResponse } from "../models/response/messageResponse";
@@ -36,7 +33,6 @@ const open = require("open");
 
 export class LoginCommand {
   protected validatedParams: () => Promise<any>;
-  protected success: () => Promise<MessageResponse>;
   protected logout: () => Promise<void>;
   protected canInteract: boolean;
   protected clientId: string;
@@ -57,8 +53,6 @@ export class LoginCommand {
     protected cryptoService: CryptoService,
     protected policyService: PolicyService,
     clientId: string,
-    private syncService: SyncService,
-    protected keyConnectorService: KeyConnectorService
   ) {
     this.clientId = clientId;
   }
@@ -315,33 +309,20 @@ export class LoginCommand {
         );
       }
 
-      // Full sync required for the reset password and key connector checks
-      await this.syncService.fullSync(true);
-
-      // Handle converting to Key Connector if required
-      if (await this.keyConnectorService.userNeedsMigration()) {
-        return await this.migrateToKeyConnector();
-      }
-
       // Handle Updating Temp Password if NOT using an API Key for authentication
       if (response.forcePasswordReset && clientId == null && clientSecret == null) {
         return await this.updateTempPassword();
       }
 
-      return await this.handleSuccessResponse();
+      return await this.onSuccessfulLogin();
     } catch (e) {
       return Response.error(e);
     }
   }
 
-  private async handleSuccessResponse(): Promise<Response> {
-    if (this.success != null) {
-      const res = await this.success();
-      return Response.success(res);
-    } else {
-      const res = new MessageResponse("You are logged in!", null);
-      return Response.success(res);
-    }
+  protected async onSuccessfulLogin(): Promise<Response> {
+    const res = new MessageResponse("You are logged in!", null);
+    return Response.success(res);
   }
 
   private async updateTempPassword(error?: string): Promise<Response> {
@@ -454,7 +435,7 @@ export class LoginCommand {
 
       // Update user's password
       await this.apiService.putUpdateTempPassword(request);
-      return this.handleSuccessResponse();
+      return this.onSuccessfulLogin();
     } catch (e) {
       await this.logout();
       this.authService.logOut(() => {
@@ -477,68 +458,6 @@ export class LoginCommand {
       );
     }
     return userInput;
-  }
-
-  private async migrateToKeyConnector() {
-    // If no interaction available, alert user to use web vault
-    if (!this.canInteract) {
-      await this.logout();
-      this.authService.logOut(() => {
-        /* Do nothing */
-      });
-      return Response.error(
-        new MessageResponse(
-          "An organization you are a member of is using Key Connector. " +
-            "In order to access the vault, you must opt-in to Key Connector now via the web vault. You have been logged out.",
-          null
-        )
-      );
-    }
-
-    const organization = await this.keyConnectorService.getManagingOrganization();
-
-    const answer: inquirer.Answers = await inquirer.createPromptModule({ output: process.stderr })({
-      type: "list",
-      name: "convert",
-      message:
-        organization.name +
-        " is using a self-hosted key server. A master password is no longer required to log in for members of this organization. ",
-      choices: [
-        {
-          name: "Remove master password and log in",
-          value: "remove",
-        },
-        {
-          name: "Leave organization and log in",
-          value: "leave",
-        },
-        {
-          name: "Exit",
-          value: "exit",
-        },
-      ],
-    });
-
-    if (answer.convert === "remove") {
-      await this.keyConnectorService.migrateUser();
-
-      // Update environment URL - required for api key login
-      const urls = this.environmentService.getUrls();
-      urls.keyConnector = organization.keyConnectorUrl;
-      await this.environmentService.setUrls(urls, true);
-
-      return await this.handleSuccessResponse();
-    } else if (answer.convert === "leave") {
-      await this.apiService.postLeaveOrganization(organization.id);
-      await this.syncService.fullSync(true);
-      return await this.handleSuccessResponse();
-    } else {
-      await this.logout();
-      this.authService.logOut(() => {
-        /* Do nothing */
-      });
-      return Response.error("You have been logged out.");
-    }
   }
 
   private async apiClientId(): Promise<string> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
See https://github.com/bitwarden/cli/pull/452.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **common/src/services/sync.service.ts** - set the KC conversion flag in sync service. This is done by all clients anyway, but needs to be done here for cli because it doesn't have a messaging service. I'll go through and remove the duplicate logic in each client after merging.
- **node/src/cli/commands/login.command.ts** - remove KC conversion check and syncing.

Other minor fixes:
- **common/src/services/keyConnector.service.ts**
  - add missing await (whoops!)
  - move the request model constructor call out of the try/catch block, it was giving me misleading error messages otherwise

**directory-connector will need a jslib update after this is merged.**

## Testing requirements

See linked cli ticket.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
