### PR TITLE
[bug] Correct scope for several data points

### DIFF
--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -104,7 +104,6 @@ export class AccountProfile {
 }
 
 export class AccountSettings {
-  alwaysShowDock?: boolean;
   autoConfirmFingerPrints?: boolean;
   autoFillOnPageLoadDefault?: boolean;
   biometricLocked?: boolean;
@@ -125,17 +124,12 @@ export class AccountSettings {
   enableBiometric?: boolean;
   enableBrowserIntegration?: boolean;
   enableBrowserIntegrationFingerprint?: boolean;
-  enableCloseToTray?: boolean;
   enableFullWidth?: boolean;
   enableGravitars?: boolean;
-  enableMinimizeToTray?: boolean;
-  enableStartToTray?: boolean;
-  enableTray?: boolean;
   environmentUrls: EnvironmentUrls = new EnvironmentUrls();
   equivalentDomains?: any;
   minimizeOnCopyToClipboard?: boolean;
   neverDomains?: { [id: string]: any };
-  openAtLogin?: boolean;
   passwordGenerationOptions?: any;
   pinProtected?: EncryptionPair<string, EncString> = new EncryptionPair<string, EncString>();
   protectedPin?: string;

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -5,7 +5,6 @@ export class GlobalState {
   enableAlwaysOnTop?: boolean;
   installedVersion?: string;
   locale?: string = "en";
-  openAtLogin?: boolean;
   organizationInvitation?: any;
   ssoCodeVerifier?: string;
   ssoOrganizationIdentifier?: string;
@@ -27,4 +26,10 @@ export class GlobalState {
   noAutoPromptBiometricsText?: string;
   stateVersion: StateVersion = StateVersion.One;
   environmentUrls: EnvironmentUrls = new EnvironmentUrls();
+  enableTray?: boolean;
+  enableMinimizeToTray?: boolean;
+  enableCloseToTray?: boolean;
+  enableStartToTray?: boolean;
+  openAtLogin?: boolean;
+  alwaysShowDock?: boolean;
 }

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -161,18 +161,18 @@ export class StateService<TAccount extends Account = Account>
 
   async getAlwaysShowDock(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.alwaysShowDock ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.alwaysShowDock ?? false
     );
   }
 
   async setAlwaysShowDock(value: boolean, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.alwaysShowDock = value;
-    await this.saveAccount(
-      account,
+    globals.alwaysShowDock = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }
@@ -1027,18 +1027,18 @@ export class StateService<TAccount extends Account = Account>
 
   async getEnableCloseToTray(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.enableCloseToTray ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.enableCloseToTray ?? false
     );
   }
 
   async setEnableCloseToTray(value: boolean, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.enableCloseToTray = value;
-    await this.saveAccount(
-      account,
+    globals.enableCloseToTray = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }
@@ -1087,54 +1087,54 @@ export class StateService<TAccount extends Account = Account>
 
   async getEnableMinimizeToTray(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.enableMinimizeToTray ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.enableMinimizeToTray ?? false
     );
   }
 
   async setEnableMinimizeToTray(value: boolean, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.enableMinimizeToTray = value;
-    await this.saveAccount(
-      account,
+    globals.enableMinimizeToTray = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }
 
   async getEnableStartToTray(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings.enableStartToTray ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.enableStartToTray ?? false
     );
   }
 
   async setEnableStartToTray(value: boolean, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.enableStartToTray = value;
-    await this.saveAccount(
-      account,
+    globals.enableStartToTray = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }
 
   async getEnableTray(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.enableTray ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.enableTray ?? false
     );
   }
 
   async setEnableTray(value: boolean, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.enableTray = value;
-    await this.saveAccount(
-      account,
+    globals.enableTray = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -176,7 +176,6 @@ export class StateMigrationService {
       mainWindowSize: null,
       noAutoPromptBiometrics: await this.get<boolean>(v1Keys.disableAutoBiometricsPrompt),
       noAutoPromptBiometricsText: await this.get<string>(v1Keys.noAutoPromptBiometricsText),
-      openAtLogin: await this.get<boolean>(v1Keys.openAtLogin),
       organizationInvitation: null,
       ssoCodeVerifier: await this.get<string>(v1Keys.ssoCodeVerifier),
       ssoOrganizationIdentifier: await this.get<string>(v1Keys.ssoIdentifier),
@@ -186,6 +185,12 @@ export class StateMigrationService {
       vaultTimeout: await this.get<number>(v1Keys.vaultTimeout),
       vaultTimeoutAction: await this.get<string>(v1Keys.vaultTimeoutAction),
       window: null,
+      enableTray: await this.get<boolean>(v1Keys.enableTray),
+      enableMinimizeToTray: await this.get<boolean>(v1Keys.enableMinimizeToTray),
+      enableCloseToTray: await this.get<boolean>(v1Keys.enableCloseToTray),
+      enableStartToTray: await this.get<boolean>(v1Keys.enableStartToTray),
+      openAtLogin: await this.get<boolean>(v1Keys.openAtLogin),
+      alwaysShowDock: await this.get<boolean>(v1Keys.alwaysShowDock),
     };
 
     const userId = await this.get<string>(v1Keys.userId);
@@ -194,7 +199,6 @@ export class StateMigrationService {
     // (userId != null) = we have a currently authed user (so known userId) with encrypted data and other key settings we can move, no need to temporarily store account settings
     if (userId == null) {
       await this.set(keys.tempAccountSettings, {
-        alwaysShowDock: await this.get<boolean>(v1Keys.alwaysShowDock),
         autoConfirmFingerPrints: await this.get<boolean>(v1Keys.autoConfirmFingerprints),
         autoFillOnPageLoadDefault: await this.get<boolean>(v1Keys.autoFillOnPageLoadDefault),
         biometricLocked: null,
@@ -219,17 +223,12 @@ export class StateMigrationService {
         enableBrowserIntegrationFingerprint: await this.get<boolean>(
           v1Keys.enableBrowserIntegrationFingerprint
         ),
-        enableCloseToTray: await this.get<boolean>(v1Keys.enableCloseToTray),
         enableFullWidth: await this.get<boolean>(v1Keys.enableFullWidth),
         enableGravitars: await this.get<boolean>(v1Keys.enableGravatars),
-        enableMinimizeToTray: await this.get<boolean>(v1Keys.enableMinimizeToTray),
-        enableStartToTray: await this.get<boolean>(v1Keys.enableStartToTray),
-        enableTray: await this.get<boolean>(v1Keys.enableTray),
         environmentUrls: globals.environmentUrls,
         equivalentDomains: await this.get<any>(v1Keys.equivalentDomains),
         minimizeOnCopyToClipboard: await this.get<boolean>(v1Keys.minimizeOnCopyToClipboard),
         neverDomains: await this.get<any>(v1Keys.neverDomains),
-        openAtLogin: await this.get<boolean>(v1Keys.openAtLogin),
         passwordGenerationOptions: await this.get<any>(v1Keys.passwordGenerationOptions),
         pinProtected: {
           decrypted: null,
@@ -331,7 +330,6 @@ export class StateMigrationService {
         usesKeyConnector: null,
       },
       settings: {
-        alwaysShowDock: await this.get<boolean>(v1Keys.alwaysShowDock),
         autoConfirmFingerPrints: await this.get<boolean>(v1Keys.autoConfirmFingerprints),
         autoFillOnPageLoadDefault: await this.get<boolean>(v1Keys.autoFillOnPageLoadDefault),
         biometricLocked: null,
@@ -356,17 +354,12 @@ export class StateMigrationService {
         enableBrowserIntegrationFingerprint: await this.get<boolean>(
           v1Keys.enableBrowserIntegrationFingerprint
         ),
-        enableCloseToTray: await this.get<boolean>(v1Keys.enableCloseToTray),
         enableFullWidth: await this.get<boolean>(v1Keys.enableFullWidth),
         enableGravitars: await this.get<boolean>(v1Keys.enableGravatars),
-        enableMinimizeToTray: await this.get<boolean>(v1Keys.enableMinimizeToTray),
-        enableStartToTray: await this.get<boolean>(v1Keys.enableStartToTray),
-        enableTray: await this.get<boolean>(v1Keys.enableTray),
         environmentUrls: globals.environmentUrls,
         equivalentDomains: await this.get<any>(v1Keys.equivalentDomains),
         minimizeOnCopyToClipboard: await this.get<boolean>(v1Keys.minimizeOnCopyToClipboard),
         neverDomains: await this.get<any>(v1Keys.neverDomains),
-        openAtLogin: await this.get<boolean>(v1Keys.openAtLogin),
         passwordGenerationOptions: await this.get<any>(v1Keys.passwordGenerationOptions),
         pinProtected: {
           decrypted: null,


### PR DESCRIPTION


## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The following data points are currently scoped to an account but are made global with this commit:
* Enable Menu Bar Icon
* Minimize To Menu Bar
* Close To Menu Bar
* Start To Menu Bar

Note: these are all electron specific fields

## Code changes
* Adjusted scope for the listed data points in models, services, and migrations

## Testing requirements
This would involve ensuring these settings persist across multiple logged in accounts instead of being toggle-able for each account separately 

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
