### PR TITLE
[Bug] Change method scope for internal StateMigrationService methods

### DIFF
--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -409,26 +409,26 @@ export class StateMigrationService {
     }
   }
 
-  private get options(): StorageOptions {
+  protected get options(): StorageOptions {
     return { htmlStorageLocation: HtmlStorageLocation.Local };
   }
 
-  private get<T>(key: string): Promise<T> {
+  protected get<T>(key: string): Promise<T> {
     return this.storageService.get<T>(key, this.options);
   }
 
-  private set(key: string, value: any): Promise<any> {
+  protected set(key: string, value: any): Promise<any> {
     if (value == null) {
       return this.storageService.remove(key, this.options);
     }
     return this.storageService.save(key, value, this.options);
   }
 
-  private async getGlobals(): Promise<GlobalState> {
+  protected async getGlobals(): Promise<GlobalState> {
     return await this.get<GlobalState>(keys.global);
   }
 
-  private async getCurrentStateVersion(): Promise<StateVersion> {
+  protected async getCurrentStateVersion(): Promise<StateVersion> {
     return (await this.getGlobals())?.stateVersion;
   }
 }


### PR DESCRIPTION


## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
A couple of helper methods were recently added to the StateMigrationService, but they were set to private and can't be used in children.

Some clients, like the Directory Connector, extend the StateMigrationService and need access to these methods.