### PR TITLE
[bug] Index search service when setting decrypted ciphers

### DIFF
--- a/common/src/services/cipher.service.ts
+++ b/common/src/services/cipher.service.ts
@@ -355,7 +355,7 @@ export class CipherService implements CipherServiceAbstraction {
 
     await Promise.all(promises);
     decCiphers.sort(this.getLocaleSortingFunction());
-    await this.stateService.setDecryptedCiphers(decCiphers);
+    await this.setDecryptedCipherCache(decCiphers);
     return decCiphers;
   }
 


### PR DESCRIPTION
## Relevant Work
https://app.asana.com/0/1201648796371593/1201630489910986

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Search indexing is not working across clients, resulting in slower search speeds and bugs like not being able to search deleted items.

## Code changes
This commit calls the method responsible for setting decrypted ciphers and indexing when decrypting, instead of setting decrypted ciphers directly. This is what we are doing in production right now, and we erroneously changed this behavior with the move to a central service for handling application state.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
