### PR TITLE
[bug] Account for entityId as a userId alternative during state migration

### DIFF
--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -193,7 +193,8 @@ export class StateMigrationService {
       alwaysShowDock: await this.get<boolean>(v1Keys.alwaysShowDock),
     };
 
-    const userId = await this.get<string>(v1Keys.userId);
+    const userId =
+      (await this.get<string>(v1Keys.userId)) ?? (await this.get<string>(v1Keys.entityId));
 
     // (userId == null) = no logged in user (so no known userId) and we need to temporarily store account specific settings in state to migrate on first auth
     // (userId != null) = we have a currently authed user (so known userId) with encrypted data and other key settings we can move, no need to temporarily store account settings


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some clients, like Directory Connector, use different key for their user identifier: entityId
We currently only check for userId in the migration service, but need to account for both.

## Code changes
* Check for entityId as an alternative to userId in the state migrations service

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
