### PR TITLE
[bug] Always set environementUrls from client when scaffolding an account

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2210,14 +2210,15 @@ export class StateService<TAccount extends Account = Account>
       account.profile.userId,
       await this.defaultOnDiskLocalOptions()
     );
+    // EnvironmentUrls are set before authenticating and should override whatever is stored from any previous session
+    const environmentUrls = account.settings.environmentUrls;
     if (storedAccount?.settings != null) {
-      // EnvironmentUrls are set before authenticating and should override whatever is stored from last session
-      storedAccount.settings.environmentUrls = account.settings.environmentUrls;
       account.settings = storedAccount.settings;
     } else if (await this.storageService.has(keys.tempAccountSettings)) {
       account.settings = await this.storageService.get<any>(keys.tempAccountSettings);
       await this.storageService.remove(keys.tempAccountSettings);
     }
+    account.settings.environmentUrls = environmentUrls;
     await this.storageService.save(
       account.profile.userId,
       account,


### PR DESCRIPTION


## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
There is a use case that overrides locally set environmentUrls: an initial boot of a logged out application.
We override environmentUrls with whatever the temporary settings store has, even if different urls are added before authenticating.


## Code changes
This commit ensures we always use input environmentUrls.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
