### PR TITLE
[bug] Address existing data & defaults when migrating from an unauthenticated state

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2219,6 +2219,7 @@ export class StateService<TAccount extends Account = Account>
       await this.storageService.remove(keys.tempAccountSettings);
     }
     account.settings.environmentUrls = environmentUrls;
+    Object.assign(account.settings, this.createAccount().settings);
     await this.storageService.save(
       account.profile.userId,
       account,

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -196,7 +196,7 @@ export class StateMigrationService {
     // Some processes, like biometrics, may have already defined a value before migrations are run
     const existingGlobals = await this.get<GlobalState>(keys.global);
     if (existingGlobals != null) {
-        Object.assign(globals, existingGlobals);
+      Object.assign(globals, existingGlobals);
     }
 
     const userId =

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -193,6 +193,12 @@ export class StateMigrationService {
       alwaysShowDock: await this.get<boolean>(v1Keys.alwaysShowDock),
     };
 
+    // Some processes, like biometrics, may have already defined a value before migrations are run
+    const existingGlobals = await this.get<GlobalState>(keys.global);
+    if (existingGlobals != null) {
+        Object.assign(globals, existingGlobals);
+    }
+
     const userId =
       (await this.get<string>(v1Keys.userId)) ?? (await this.get<string>(v1Keys.entityId));
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some processes, like biometrics, will have already begun modifying state before migrations are run.
We currently don't account for this when migrating, leaving first time startups in a state where some expected values, like biometrics, will be null.

Additionally some clients set default values for specific account settings, like vaultTimeout, that are being lost when migrating temp storage. This results in unexpected behavior like vaultTimeout being set to "never" for fresh installs and even clients that don't allow this setting.

## Code changes
* Check for existing globals during migration and merge it with the migration globals if found
* Assign copied temp storage to a client's Account class to ensure defaults are being honored.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
