### PR TITLE
[bug] Set envUrls after assigning defaults during scaffolding

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2218,8 +2218,8 @@ export class StateService<TAccount extends Account = Account>
       account.settings = await this.storageService.get<any>(keys.tempAccountSettings);
       await this.storageService.remove(keys.tempAccountSettings);
     }
-    account.settings.environmentUrls = environmentUrls;
     Object.assign(account.settings, this.createAccount().settings);
+    account.settings.environmentUrls = environmentUrls;
     await this.storageService.save(
       account.profile.userId,
       account,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Set environmentUrls after assigning defaults for scaffolding to prevent clearing

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
