### PR TITLE
[bug] Set all urls when setting urls from storage

### DIFF
--- a/common/src/services/environment.service.ts
+++ b/common/src/services/environment.service.ts
@@ -116,11 +116,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     const urls: any = await this.stateService.getEnvironmentUrls();
     const envUrls = new EnvironmentUrls();
 
-    if (urls.base) {
-      this.baseUrl = envUrls.base = urls.base;
-      return;
-    }
-
+    this.baseUrl = envUrls.base = urls.base;
     this.webVaultUrl = urls.webVault;
     this.apiUrl = envUrls.api = urls.api;
     this.identityUrl = envUrls.identity = urls.identity;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Bug Description
Previously when only one account could be authenticated at a time if a baseUrl was found we didn't need to worry about setting other urls in the environmentService, and simply returned after setting base.

With account switching it is possible to have multiple url configurations, some with a baseUrl and some without, and this early return was causing accounts configured this way to clash. It became possible to have something like:

urls.baseUrl = 'https://testdo.bitwarden.com' set as the base url for an account that was intended to target the cloud, causing deauthenticated sessions.

## Code changes
This commit ensures that all urls are set each time getUrlsFromStorage is called.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
