### PR TITLE
[bug] Ensure globals set before migration is run are not lost

### DIFF
--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -167,32 +167,45 @@ export class StateMigrationService {
       }
     };
 
-    // Some processes, like biometrics, may have already defined a value before migrations are run. 
+    // Some processes, like biometrics, may have already defined a value before migrations are run.
     // We don't want to null out those values if they don't exist in the old storage scheme (like for new installs)
     // So, the OOO for migration is that we:
     // 1. Check for an existing storage value from the old storage structure OR
     // 2. Check for a value already set by processes that run before migration OR
     // 3. Assign the default value
-    let globals = await this.get<GlobalState>(keys.global) ?? new GlobalState();
-    globals.stateVersion = StateVersion.Two,
-    globals.environmentUrls = (await this.get<EnvironmentUrls>(v1Keys.environmentUrls)) ?? globals.environmentUrls,
-    globals.locale = await this.get<string>(v1Keys.locale) ?? globals.locale;
-    globals.noAutoPromptBiometrics = await this.get<boolean>(v1Keys.disableAutoBiometricsPrompt) ?? globals.noAutoPromptBiometrics,
-    globals.noAutoPromptBiometricsText = await this.get<string>(v1Keys.noAutoPromptBiometricsText) ?? globals.noAutoPromptBiometricsText,
-    globals.ssoCodeVerifier = await this.get<string>(v1Keys.ssoCodeVerifier) ?? globals.ssoCodeVerifier;
-    globals.ssoOrganizationIdentifier = await this.get<string>(v1Keys.ssoIdentifier) ?? globals.ssoOrganizationIdentifier;
-    globals.ssoState = await this.get<any>(v1Keys.ssoState) ?? globals.ssoState,
-    globals.rememberedEmail = await this.get<string>(v1Keys.rememberedEmail) ?? globals.rememberedEmail;
-    globals.theme = await this.get<string>(v1Keys.theme) ?? globals.theme;
-    globals.vaultTimeout = await this.get<number>(v1Keys.vaultTimeout) ?? globals.vaultTimeout;
-    globals.vaultTimeoutAction = await this.get<string>(v1Keys.vaultTimeoutAction) ?? globals.vaultTimeoutAction,
-    globals.window = await this.get<any>(v1Keys.mainWindowSize) ?? globals.window;
-    globals.enableTray = await this.get<boolean>(v1Keys.enableTray) ?? globals.enableTray;
-    globals.enableMinimizeToTray = await this.get<boolean>(v1Keys.enableMinimizeToTray) ?? globals.enableMinimizeToTray;
-    globals.enableCloseToTray = await this.get<boolean>(v1Keys.enableCloseToTray) ?? globals.enableCloseToTray;
-    globals.enableStartToTray = await this.get<boolean>(v1Keys.enableStartToTray) ?? globals.enableStartToTray;
-    globals.openAtLogin = await this.get<boolean>(v1Keys.openAtLogin) ?? globals.openAtLogin;
-    globals.alwaysShowDock = await this.get<boolean>(v1Keys.alwaysShowDock) ?? globals.alwaysShowDock;
+    const globals = (await this.get<GlobalState>(keys.global)) ?? new GlobalState();
+    globals.stateVersion = StateVersion.Two;
+    globals.environmentUrls =
+      (await this.get<EnvironmentUrls>(v1Keys.environmentUrls)) ?? globals.environmentUrls;
+    globals.locale = (await this.get<string>(v1Keys.locale)) ?? globals.locale;
+    globals.noAutoPromptBiometrics =
+      (await this.get<boolean>(v1Keys.disableAutoBiometricsPrompt)) ??
+      globals.noAutoPromptBiometrics;
+    globals.noAutoPromptBiometricsText =
+      (await this.get<string>(v1Keys.noAutoPromptBiometricsText)) ??
+      globals.noAutoPromptBiometricsText;
+    globals.ssoCodeVerifier =
+      (await this.get<string>(v1Keys.ssoCodeVerifier)) ?? globals.ssoCodeVerifier;
+    globals.ssoOrganizationIdentifier =
+      (await this.get<string>(v1Keys.ssoIdentifier)) ?? globals.ssoOrganizationIdentifier;
+    globals.ssoState = (await this.get<any>(v1Keys.ssoState)) ?? globals.ssoState;
+    globals.rememberedEmail =
+      (await this.get<string>(v1Keys.rememberedEmail)) ?? globals.rememberedEmail;
+    globals.theme = (await this.get<string>(v1Keys.theme)) ?? globals.theme;
+    globals.vaultTimeout = (await this.get<number>(v1Keys.vaultTimeout)) ?? globals.vaultTimeout;
+    globals.vaultTimeoutAction =
+      (await this.get<string>(v1Keys.vaultTimeoutAction)) ?? globals.vaultTimeoutAction;
+    globals.window = (await this.get<any>(v1Keys.mainWindowSize)) ?? globals.window;
+    globals.enableTray = (await this.get<boolean>(v1Keys.enableTray)) ?? globals.enableTray;
+    globals.enableMinimizeToTray =
+      (await this.get<boolean>(v1Keys.enableMinimizeToTray)) ?? globals.enableMinimizeToTray;
+    globals.enableCloseToTray =
+      (await this.get<boolean>(v1Keys.enableCloseToTray)) ?? globals.enableCloseToTray;
+    globals.enableStartToTray =
+      (await this.get<boolean>(v1Keys.enableStartToTray)) ?? globals.enableStartToTray;
+    globals.openAtLogin = (await this.get<boolean>(v1Keys.openAtLogin)) ?? globals.openAtLogin;
+    globals.alwaysShowDock =
+      (await this.get<boolean>(v1Keys.alwaysShowDock)) ?? globals.alwaysShowDock;
 
     const userId =
       (await this.get<string>(v1Keys.userId)) ?? (await this.get<string>(v1Keys.entityId));

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -167,37 +167,32 @@ export class StateMigrationService {
       }
     };
 
-    const globals: GlobalState = {
-      stateVersion: StateVersion.Two,
-      environmentUrls:
-        (await this.get<EnvironmentUrls>(v1Keys.environmentUrls)) ?? new EnvironmentUrls(),
-      locale: await this.get<string>(v1Keys.locale),
-      loginRedirect: null,
-      mainWindowSize: null,
-      noAutoPromptBiometrics: await this.get<boolean>(v1Keys.disableAutoBiometricsPrompt),
-      noAutoPromptBiometricsText: await this.get<string>(v1Keys.noAutoPromptBiometricsText),
-      organizationInvitation: null,
-      ssoCodeVerifier: await this.get<string>(v1Keys.ssoCodeVerifier),
-      ssoOrganizationIdentifier: await this.get<string>(v1Keys.ssoIdentifier),
-      ssoState: null,
-      rememberedEmail: await this.get<string>(v1Keys.rememberedEmail),
-      theme: await this.get<string>(v1Keys.theme),
-      vaultTimeout: await this.get<number>(v1Keys.vaultTimeout),
-      vaultTimeoutAction: await this.get<string>(v1Keys.vaultTimeoutAction),
-      window: null,
-      enableTray: await this.get<boolean>(v1Keys.enableTray),
-      enableMinimizeToTray: await this.get<boolean>(v1Keys.enableMinimizeToTray),
-      enableCloseToTray: await this.get<boolean>(v1Keys.enableCloseToTray),
-      enableStartToTray: await this.get<boolean>(v1Keys.enableStartToTray),
-      openAtLogin: await this.get<boolean>(v1Keys.openAtLogin),
-      alwaysShowDock: await this.get<boolean>(v1Keys.alwaysShowDock),
-    };
-
-    // Some processes, like biometrics, may have already defined a value before migrations are run
-    const existingGlobals = await this.get<GlobalState>(keys.global);
-    if (existingGlobals != null) {
-      Object.assign(globals, existingGlobals);
-    }
+    // Some processes, like biometrics, may have already defined a value before migrations are run. 
+    // We don't want to null out those values if they don't exist in the old storage scheme (like for new installs)
+    // So, the OOO for migration is that we:
+    // 1. Check for an existing storage value from the old storage structure OR
+    // 2. Check for a value already set by processes that run before migration OR
+    // 3. Assign the default value
+    let globals = await this.get<GlobalState>(keys.global) ?? new GlobalState();
+    globals.stateVersion = StateVersion.Two,
+    globals.environmentUrls = (await this.get<EnvironmentUrls>(v1Keys.environmentUrls)) ?? globals.environmentUrls,
+    globals.locale = await this.get<string>(v1Keys.locale) ?? globals.locale;
+    globals.noAutoPromptBiometrics = await this.get<boolean>(v1Keys.disableAutoBiometricsPrompt) ?? globals.noAutoPromptBiometrics,
+    globals.noAutoPromptBiometricsText = await this.get<string>(v1Keys.noAutoPromptBiometricsText) ?? globals.noAutoPromptBiometricsText,
+    globals.ssoCodeVerifier = await this.get<string>(v1Keys.ssoCodeVerifier) ?? globals.ssoCodeVerifier;
+    globals.ssoOrganizationIdentifier = await this.get<string>(v1Keys.ssoIdentifier) ?? globals.ssoOrganizationIdentifier;
+    globals.ssoState = await this.get<any>(v1Keys.ssoState) ?? globals.ssoState,
+    globals.rememberedEmail = await this.get<string>(v1Keys.rememberedEmail) ?? globals.rememberedEmail;
+    globals.theme = await this.get<string>(v1Keys.theme) ?? globals.theme;
+    globals.vaultTimeout = await this.get<number>(v1Keys.vaultTimeout) ?? globals.vaultTimeout;
+    globals.vaultTimeoutAction = await this.get<string>(v1Keys.vaultTimeoutAction) ?? globals.vaultTimeoutAction,
+    globals.window = await this.get<any>(v1Keys.mainWindowSize) ?? globals.window;
+    globals.enableTray = await this.get<boolean>(v1Keys.enableTray) ?? globals.enableTray;
+    globals.enableMinimizeToTray = await this.get<boolean>(v1Keys.enableMinimizeToTray) ?? globals.enableMinimizeToTray;
+    globals.enableCloseToTray = await this.get<boolean>(v1Keys.enableCloseToTray) ?? globals.enableCloseToTray;
+    globals.enableStartToTray = await this.get<boolean>(v1Keys.enableStartToTray) ?? globals.enableStartToTray;
+    globals.openAtLogin = await this.get<boolean>(v1Keys.openAtLogin) ?? globals.openAtLogin;
+    globals.alwaysShowDock = await this.get<boolean>(v1Keys.alwaysShowDock) ?? globals.alwaysShowDock;
 
     const userId =
       (await this.get<string>(v1Keys.userId)) ?? (await this.get<string>(v1Keys.entityId));


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some fields, like biometrics, are set before we can run the state migration
For some use cases, like initial install, this can lead to migration clearing those fields when it doesn't find them in storage.

Another issue found with this is that StateVersion will remain 1 and never upgrade to 2, resulting in accounts being deauthenticated on each run of the app.

## Code changes
This commit sets up an order of checks for migrating globals that considers fields that may already have been set.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
