### PR TITLE
[bug] Move enableBrowserIntegration to global state

### DIFF
--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -122,8 +122,6 @@ export class AccountSettings {
   enableAlwaysOnTop?: boolean;
   enableAutoFillOnPageLoad?: boolean;
   enableBiometric?: boolean;
-  enableBrowserIntegration?: boolean;
-  enableBrowserIntegrationFingerprint?: boolean;
   enableFullWidth?: boolean;
   enableGravitars?: boolean;
   environmentUrls: EnvironmentUrls = new EnvironmentUrls();

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -32,4 +32,6 @@ export class GlobalState {
   enableStartToTray?: boolean;
   openAtLogin?: boolean;
   alwaysShowDock?: boolean;
+  enableBrowserIntegration?: boolean;
+  enableBrowserIntegrationFingerprint?: boolean;
 }

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -988,26 +988,26 @@ export class StateService<TAccount extends Account = Account>
 
   async getEnableBrowserIntegration(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.enableBrowserIntegration ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.enableBrowserIntegration ?? false
     );
   }
 
   async setEnableBrowserIntegration(value: boolean, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.enableBrowserIntegration = value;
-    await this.saveAccount(
-      account,
+    globals.enableBrowserIntegration = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }
 
   async getEnableBrowserIntegrationFingerprint(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.enableBrowserIntegrationFingerprint ?? false
+      (await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
+        ?.enableBrowserIntegrationFingerprint ?? false
     );
   }
 
@@ -1015,12 +1015,12 @@ export class StateService<TAccount extends Account = Account>
     value: boolean,
     options?: StorageOptions
   ): Promise<void> {
-    const account = await this.getAccount(
+    const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.settings.enableBrowserIntegrationFingerprint = value;
-    await this.saveAccount(
-      account,
+    globals.enableBrowserIntegrationFingerprint = value;
+    await this.saveGlobals(
+      globals,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
   }

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -206,6 +206,12 @@ export class StateMigrationService {
     globals.openAtLogin = (await this.get<boolean>(v1Keys.openAtLogin)) ?? globals.openAtLogin;
     globals.alwaysShowDock =
       (await this.get<boolean>(v1Keys.alwaysShowDock)) ?? globals.alwaysShowDock;
+    globals.enableBrowserIntegration =
+      (await this.get<boolean>(v1Keys.enableBrowserIntegration)) ??
+      globals.enableBrowserIntegration;
+    globals.enableBrowserIntegrationFingerprint =
+      (await this.get<boolean>(v1Keys.enableBrowserIntegrationFingerprint)) ??
+      globals.enableBrowserIntegrationFingerprint;
 
     const userId =
       (await this.get<string>(v1Keys.userId)) ?? (await this.get<string>(v1Keys.entityId));
@@ -234,10 +240,6 @@ export class StateMigrationService {
         enableAlwaysOnTop: await this.get<boolean>(v1Keys.enableAlwaysOnTop),
         enableAutoFillOnPageLoad: await this.get<boolean>(v1Keys.enableAutoFillOnPageLoad),
         enableBiometric: await this.get<boolean>(v1Keys.enableBiometric),
-        enableBrowserIntegration: await this.get<boolean>(v1Keys.enableBrowserIntegration),
-        enableBrowserIntegrationFingerprint: await this.get<boolean>(
-          v1Keys.enableBrowserIntegrationFingerprint
-        ),
         enableFullWidth: await this.get<boolean>(v1Keys.enableFullWidth),
         enableGravitars: await this.get<boolean>(v1Keys.enableGravatars),
         environmentUrls: globals.environmentUrls,
@@ -365,10 +367,6 @@ export class StateMigrationService {
         enableAlwaysOnTop: await this.get<boolean>(v1Keys.enableAlwaysOnTop),
         enableAutoFillOnPageLoad: await this.get<boolean>(v1Keys.enableAutoFillOnPageLoad),
         enableBiometric: await this.get<boolean>(v1Keys.enableBiometric),
-        enableBrowserIntegration: await this.get<boolean>(v1Keys.enableBrowserIntegration),
-        enableBrowserIntegrationFingerprint: await this.get<boolean>(
-          v1Keys.enableBrowserIntegrationFingerprint
-        ),
         enableFullWidth: await this.get<boolean>(v1Keys.enableFullWidth),
         enableGravitars: await this.get<boolean>(v1Keys.enableGravatars),
         environmentUrls: globals.environmentUrls,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Enable Browser Integration should be a global setting, but currently we have it set at the account level.

## Code changes
* Remove enableBrowserIntegration from the AccountSettings model
* Add enableBrowserIntegration to the GlobalState model
* Update get/set functions in stateService to expect enableBrowserIntegration to be global
* Update state migrations to treat enableBrowserIntegration as a global setting

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
