### PR TITLE
[Account switching] Ensure that initialization and migration only run once

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -58,6 +58,8 @@ export class StateService<TAccount extends Account = Account>
 
   protected state: State<TAccount> = new State<TAccount>();
 
+  private hasBeenInited: boolean = false;
+
   constructor(
     protected storageService: StorageService,
     protected secureStorageService: StorageService,
@@ -67,11 +69,16 @@ export class StateService<TAccount extends Account = Account>
   ) {}
 
   async init(): Promise<void> {
+    if (this.hasBeenInited) {
+      return;
+    }
+
     if (await this.stateMigrationService.needsMigration()) {
       await this.stateMigrationService.migrate();
     }
 
     await this.initAccountState();
+    this.hasBeenInited = true;
   }
 
   async initAccountState() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
While testing on browser the `stateService.init()` is called every time when opening the extension window. Which causes issues with access to dead objects when initAccountState is called. To ensure migrations and initialization only happen once, I've added a boolean to check the state.

## Code changes
- **common/src/services/state.service.ts:** Add boolean to only call init once

## Testing requirements
Tested this change locally on browser and desktop and did not experience any issues.
Regression testing on account switching needed

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
