### PR TITLE
Expose getKeyFromStorage with userId

### DIFF
--- a/common/src/abstractions/crypto.service.ts
+++ b/common/src/abstractions/crypto.service.ts
@@ -21,7 +21,7 @@ export abstract class CryptoService {
   ) => Promise<void>;
   setProviderKeys: (orgs: ProfileProviderResponse[]) => Promise<void>;
   getKey: (keySuffix?: KeySuffixOptions, userId?: string) => Promise<SymmetricCryptoKey>;
-  getKeyFromStorage: (keySuffix: KeySuffixOptions) => Promise<SymmetricCryptoKey>;
+  getKeyFromStorage: (keySuffix: KeySuffixOptions, userId?: string) => Promise<SymmetricCryptoKey>;
   getKeyHash: () => Promise<string>;
   compareAndUpdateKeyHash: (masterPassword: string, key: SymmetricCryptoKey) => Promise<boolean>;
   getEncKey: (key?: SymmetricCryptoKey) => Promise<SymmetricCryptoKey>;

--- a/electron/src/services/electronCrypto.service.ts
+++ b/electron/src/services/electronCrypto.service.ts
@@ -38,9 +38,9 @@ export class ElectronCryptoService extends CryptoService {
     }
   }
 
-  protected async retrieveKeyFromStorage(keySuffix: KeySuffixOptions) {
+  protected async retrieveKeyFromStorage(keySuffix: KeySuffixOptions, userId?: string) {
     await this.upgradeSecurelyStoredKey();
-    return super.retrieveKeyFromStorage(keySuffix);
+    return super.retrieveKeyFromStorage(keySuffix, userId);
   }
 
   /**


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Exposes the `userId` argument of `getKeyFromStorage` which is needed to support native messaging with multiple accounts.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
