### PR TITLE
[bug] Ensure clients that always remember emails have an avenue to do so

### DIFF
--- a/angular/src/components/login.component.ts
+++ b/angular/src/components/login.component.ts
@@ -35,6 +35,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
   protected twoFactorRoute = "2fa";
   protected successRoute = "vault";
   protected forcePasswordResetRoute = "update-temp-password";
+  protected alwaysRememberEmail: boolean = false;
 
   constructor(
     protected authService: AuthService,
@@ -58,7 +59,9 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
         this.email = "";
       }
     }
-    this.rememberEmail = (await this.stateService.getRememberedEmail()) != null;
+    if (!this.alwaysRememberEmail) {
+      this.rememberEmail = (await this.stateService.getRememberedEmail()) != null;
+    }
     if (Utils.isBrowser && !Utils.isNode) {
       this.focusInput();
     }
@@ -95,7 +98,7 @@ export class LoginComponent extends CaptchaProtectedComponent implements OnInit 
     try {
       this.formPromise = this.authService.logIn(this.email, this.masterPassword, this.captchaToken);
       const response = await this.formPromise;
-      if (this.rememberEmail) {
+      if (this.rememberEmail || this.alwaysRememberEmail) {
         await this.stateService.setRememberedEmail(this.email);
       } else {
         await this.stateService.setRememberedEmail(null);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With Account Switching we tweaked the way logic determined if an email should be remembered or not. Instead of storing a specific boolean key to know whether or not we had a remembered email on init, we just check to see if a remembered email already exists. This works well for apps like web, where remember email is also controllable with an input, but not so much for apps that always remember email like browser and desktop.

## Code changes
Instead of going back to the way things were and having client specific logic in the base login component, we should ensure that we always remember emails for clients that behave that way in the clients that need to special case.

This commit exposes a component variable that can be set by clients to determine if email should always be remembered.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
