### PR TITLE
[bug] Properly define stored window state

### DIFF
--- a/common/src/abstractions/state.service.ts
+++ b/common/src/abstractions/state.service.ts
@@ -19,6 +19,7 @@ import { GeneratedPasswordHistory } from "../models/domain/generatedPasswordHist
 import { Policy } from "../models/domain/policy";
 import { StorageOptions } from "../models/domain/storageOptions";
 import { SymmetricCryptoKey } from "../models/domain/symmetricCryptoKey";
+import { WindowState } from "../models/domain/windowState";
 
 import { CipherView } from "../models/view/cipherView";
 import { CollectionView } from "../models/view/collectionView";
@@ -299,6 +300,6 @@ export abstract class StateService<T extends Account = Account> {
   setVaultTimeoutAction: (value: string, options?: StorageOptions) => Promise<void>;
   getStateVersion: () => Promise<number>;
   setStateVersion: (value: number) => Promise<void>;
-  getWindow: () => Promise<Map<string, any>>;
-  setWindow: (value: Map<string, any>) => Promise<void>;
+  getWindow: () => Promise<WindowState>;
+  setWindow: (value: WindowState) => Promise<void>;
 }

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -1,5 +1,6 @@
 import { StateVersion } from "../../enums/stateVersion";
 import { EnvironmentUrls } from "./environmentUrls";
+import { WindowState } from "./windowState";
 
 export class GlobalState {
   enableAlwaysOnTop?: boolean;
@@ -11,7 +12,7 @@ export class GlobalState {
   ssoState?: string;
   rememberedEmail?: string;
   theme?: string = "light";
-  window?: Map<string, any> = new Map<string, any>();
+  window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;
   biometricAwaitingAcceptance?: boolean;

--- a/common/src/models/domain/windowState.ts
+++ b/common/src/models/domain/windowState.ts
@@ -1,0 +1,10 @@
+export class WindowState {
+  width?: number;
+  height?: number;
+  isMaximized?: boolean;
+  // TODO: displayBounds is an Electron.Rectangle.
+  // We need to establish some kind of client-specific global state, similiar to the way we already extend a base Account.
+  displayBounds: any;
+  x?: number;
+  y?: number;
+}

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -36,6 +36,7 @@ import { BehaviorSubject } from "rxjs";
 
 import { StateMigrationService } from "../abstractions/stateMigration.service";
 import { EnvironmentUrls } from "../models/domain/environmentUrls";
+import { WindowState } from "../models/domain/windowState";
 
 const keys = {
   global: "global",
@@ -2066,14 +2067,14 @@ export class StateService<TAccount extends Account = Account>
     await this.saveGlobals(globals, await this.defaultOnDiskOptions());
   }
 
-  async getWindow(): Promise<Map<string, any>> {
+  async getWindow(): Promise<WindowState> {
     const globals = await this.getGlobals(await this.defaultOnDiskOptions());
     return globals?.window != null && Object.keys(globals.window).length > 0
       ? globals.window
-      : new Map<string, any>();
+      : new WindowState();
   }
 
-  async setWindow(value: Map<string, any>, options?: StorageOptions): Promise<void> {
+  async setWindow(value: WindowState, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );

--- a/electron/src/window.main.ts
+++ b/electron/src/window.main.ts
@@ -99,7 +99,6 @@ export class WindowMain {
 
   async createWindow(): Promise<void> {
     this.windowStates[mainWindowSizeKey] = await this.getWindowState(
-      mainWindowSizeKey,
       this.defaultWidth,
       this.defaultHeight
     );
@@ -214,7 +213,7 @@ export class WindowMain {
       const bounds = win.getBounds();
 
       if (this.windowStates[configKey] == null) {
-        this.windowStates[configKey] = (await this.stateService.getWindow()).get(configKey);
+        this.windowStates[configKey] = await this.stateService.getWindow();
         if (this.windowStates[configKey] == null) {
           this.windowStates[configKey] = {};
         }
@@ -230,25 +229,20 @@ export class WindowMain {
         this.windowStates[configKey].height = bounds.height;
       }
 
-      const cachedWindow = (await this.stateService.getWindow()) ?? new Map<string, any>();
-      cachedWindow.set(configKey, this.windowStates[configKey]);
-      await this.stateService.setWindow(cachedWindow);
+      await this.stateService.setWindow(this.windowStates[configKey]);
     } catch (e) {
       this.logService.error(e);
     }
   }
 
-  private async getWindowState(configKey: string, defaultWidth: number, defaultHeight: number) {
-    const windowState = (await this.stateService.getWindow()) ?? new Map<string, any>();
-    let state = windowState.has(configKey) ? windowState.get(configKey) : null;
+  private async getWindowState(defaultWidth: number, defaultHeight: number) {
+    const state = await this.stateService.getWindow();
 
     const isValid = state != null && (this.stateHasBounds(state) || state.isMaximized);
     let displayBounds: Electron.Rectangle = null;
     if (!isValid) {
-      state = {
-        width: defaultWidth,
-        height: defaultHeight,
-      };
+      state.width = defaultWidth;
+      state.height = defaultHeight;
 
       displayBounds = screen.getPrimaryDisplay().bounds;
     } else if (this.stateHasBounds(state) && state.displayBounds) {


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201724590570903

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Bug
Electron windows do not spawn on second launch of Bitwarden. They open fine the first time, because we haven't migrated window information yet, but a bug in the window management logic causes second launches to not spawn a window.

## Code changes
1. Properly define what we store for persistent window management in the form of WindowState(), and make that the type used for getters/setters for Window in StateService()
2. Stop searching for a configKey in Window when we get it in window.main. This is where the break happens: because the key we are looking for doesn't exist in the Window object - it IS the window object. Simply using this value without checking for a key corrects window spawning behavior. 

## Testing requirements
I tested this by building mac universal apps locally, we will need to check Testflight once a build is available there. 

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
