### PR TITLE
[bug] Always save environmentUrls passed to setUrls

### DIFF
--- a/common/src/abstractions/environment.service.ts
+++ b/common/src/abstractions/environment.service.ts
@@ -29,6 +29,6 @@ export abstract class EnvironmentService {
   getEventsUrl: () => string;
   getKeyConnectorUrl: () => string;
   setUrlsFromStorage: () => Promise<void>;
-  setUrls: (urls: any, saveSettings?: boolean) => Promise<Urls>;
+  setUrls: (urls: any) => Promise<Urls>;
   getUrls: () => Urls;
 }

--- a/common/src/abstractions/environment.service.ts
+++ b/common/src/abstractions/environment.service.ts
@@ -29,6 +29,6 @@ export abstract class EnvironmentService {
   getEventsUrl: () => string;
   getKeyConnectorUrl: () => string;
   setUrlsFromStorage: () => Promise<void>;
-  setUrls: (urls: any) => Promise<Urls>;
+  setUrls: (urls: Urls) => Promise<Urls>;
   getUrls: () => Urls;
 }

--- a/common/src/services/environment.service.ts
+++ b/common/src/services/environment.service.ts
@@ -126,7 +126,7 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     this.keyConnectorUrl = urls.keyConnector;
   }
 
-  async setUrls(urls: Urls, saveSettings: boolean = true): Promise<any> {
+  async setUrls(urls: Urls): Promise<any> {
     urls.base = this.formatUrl(urls.base);
     urls.webVault = this.formatUrl(urls.webVault);
     urls.api = this.formatUrl(urls.api);
@@ -136,18 +136,16 @@ export class EnvironmentService implements EnvironmentServiceAbstraction {
     urls.events = this.formatUrl(urls.events);
     urls.keyConnector = this.formatUrl(urls.keyConnector);
 
-    if (saveSettings) {
-      await this.stateService.setEnvironmentUrls({
-        base: urls.base,
-        api: urls.api,
-        identity: urls.identity,
-        webVault: urls.webVault,
-        icons: urls.icons,
-        notifications: urls.notifications,
-        events: urls.events,
-        keyConnector: urls.keyConnector,
-      });
-    }
+    await this.stateService.setEnvironmentUrls({
+      base: urls.base,
+      api: urls.api,
+      identity: urls.identity,
+      webVault: urls.webVault,
+      icons: urls.icons,
+      notifications: urls.notifications,
+      events: urls.events,
+      keyConnector: urls.keyConnector,
+    });
 
     this.baseUrl = urls.base;
     this.webVaultUrl = urls.webVault;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With the change to our state model to have a concept of an "account" we started saving global environmentUrls to a temporary location in storage to be fetched and added to any newly authed accounts

This isn't compatible with the option to not save envUrls passed to setUrls to storage, since we need that storage value to handle urls for authed accounts. This is only applicable to web.

There was some discussion around maybe extending the environmentService in web to skip the temporary storage route, since web isn't planned to ever offer account switching, but that would also require a distinction in web specifically that environmentUrls aren't an account level data point, which isn't really true. Ultimately I think just removing this option is the clearest way to make this work.

## Code changes
* Remove the flag from setUrls that allowed for skipping saving urls to storage

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
