### PR TITLE
[refactor] Use ThemeType enum instead of string

### DIFF
--- a/common/src/abstractions/state.service.ts
+++ b/common/src/abstractions/state.service.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject } from "rxjs";
 
 import { KdfType } from "../enums/kdfType";
+import { ThemeType } from "../enums/themeType";
 import { UriMatchType } from "../enums/uriMatchType";
 
 import { CipherData } from "../models/data/cipherData";
@@ -287,8 +288,8 @@ export abstract class StateService<T extends Account = Account> {
   setSsoOrganizationIdentifier: (value: string, options?: StorageOptions) => Promise<void>;
   getSsoState: (options?: StorageOptions) => Promise<string>;
   setSsoState: (value: string, options?: StorageOptions) => Promise<void>;
-  getTheme: (options?: StorageOptions) => Promise<string>;
-  setTheme: (value: string, options?: StorageOptions) => Promise<void>;
+  getTheme: (options?: StorageOptions) => Promise<ThemeType>;
+  setTheme: (value: ThemeType, options?: StorageOptions) => Promise<void>;
   getTwoFactorToken: (options?: StorageOptions) => Promise<string>;
   setTwoFactorToken: (value: string, options?: StorageOptions) => Promise<void>;
   getUserId: (options?: StorageOptions) => Promise<string>;

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -1,4 +1,6 @@
 import { StateVersion } from "../../enums/stateVersion";
+import { ThemeType } from "../../enums/themeType";
+
 import { EnvironmentUrls } from "./environmentUrls";
 import { WindowState } from "./windowState";
 
@@ -11,7 +13,7 @@ export class GlobalState {
   ssoOrganizationIdentifier?: string;
   ssoState?: string;
   rememberedEmail?: string;
-  theme?: string = "light";
+  theme?: ThemeType = ThemeType.Light;
   window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -8,6 +8,7 @@ import { StorageService } from "../abstractions/storage.service";
 import { HtmlStorageLocation } from "../enums/htmlStorageLocation";
 import { KdfType } from "../enums/kdfType";
 import { StorageLocation } from "../enums/storageLocation";
+import { ThemeType } from "../enums/themeType";
 import { UriMatchType } from "../enums/uriMatchType";
 
 import { CipherView } from "../models/view/cipherView";
@@ -1961,13 +1962,13 @@ export class StateService<TAccount extends Account = Account>
     );
   }
 
-  async getTheme(options?: StorageOptions): Promise<string> {
+  async getTheme(options?: StorageOptions): Promise<ThemeType> {
     return (
       await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
     )?.theme;
   }
 
-  async setTheme(value: string, options?: StorageOptions): Promise<void> {
+  async setTheme(value: ThemeType, options?: StorageOptions): Promise<void> {
     const globals = await this.getGlobals(
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -16,6 +16,7 @@ import { SendData } from "../models/data/sendData";
 import { HtmlStorageLocation } from "../enums/htmlStorageLocation";
 import { KdfType } from "../enums/kdfType";
 import { StateVersion } from "../enums/stateVersion";
+import { ThemeType } from "../enums/themeType";
 
 import { EnvironmentUrls } from "../models/domain/environmentUrls";
 
@@ -191,7 +192,7 @@ export class StateMigrationService {
     globals.ssoState = (await this.get<any>(v1Keys.ssoState)) ?? globals.ssoState;
     globals.rememberedEmail =
       (await this.get<string>(v1Keys.rememberedEmail)) ?? globals.rememberedEmail;
-    globals.theme = (await this.get<string>(v1Keys.theme)) ?? globals.theme;
+    globals.theme = (await this.get<ThemeType>(v1Keys.theme)) ?? globals.theme;
     globals.vaultTimeout = (await this.get<number>(v1Keys.vaultTimeout)) ?? globals.vaultTimeout;
     globals.vaultTimeoutAction =
       (await this.get<string>(v1Keys.vaultTimeoutAction)) ?? globals.vaultTimeoutAction;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
A good refactor point was made that we can use the ThemeType enum instead of strings when managing theme in state. 

## Code changes
Convert type used for theme in the state model, service, and migration

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
