### PR TITLE
[bug] Fix default theme global setting

### DIFF
--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -13,7 +13,7 @@ export class GlobalState {
   ssoOrganizationIdentifier?: string;
   ssoState?: string;
   rememberedEmail?: string;
-  theme?: ThemeType = ThemeType.Light;
+  theme?: ThemeType = ThemeType.System;
   window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201735234799074

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
There is a discrepancy between clients on what the default theme is. Most clients with theme support default to using the system theme, but web defaults to light. This has created a bug in the storage refactor, since we set the default setting for all clients to light.

Luckily, it was determined that we should be using system theme in web too, and are moving in that direction. This PR simply updates the default theme to ThemeType.System.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
