### PR TITLE
[bug] Remove Global default for theme

### DIFF
--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -13,7 +13,7 @@ export class GlobalState {
   ssoOrganizationIdentifier?: string;
   ssoState?: string;
   rememberedEmail?: string;
-  theme?: ThemeType = ThemeType.Light;
+  theme?: ThemeType;
   window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We are sending a default theme on all client to Light theme, but this is inaccurate since Desktop and Browser default to the system theme. 

## Code changes
* Remove the default theme value from GlobalState and depend on clients to set this value

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
