### PR TITLE
[bug] Allow for GlobalState to be extended and modified in clients

### DIFF
--- a/angular/src/services/jslib-services.module.ts
+++ b/angular/src/services/jslib-services.module.ts
@@ -76,7 +76,11 @@ import { PasswordRepromptService } from "./passwordReprompt.service";
 import { UnauthGuardService } from "./unauth-guard.service";
 import { ValidationService } from "./validation.service";
 
-import { Account, AccountFactory } from "jslib-common/models/domain/account";
+import { Account } from "jslib-common/models/domain/account";
+import { GlobalState } from "jslib-common/models/domain/globalState";
+
+import { GlobalStateFactory } from "jslib-common/factories/globalStateFactory";
+import { StateFactory } from "jslib-common/factories/stateFactory";
 
 @NgModule({
   declarations: [],
@@ -338,7 +342,7 @@ import { Account, AccountFactory } from "jslib-common/models/domain/account";
           secureStorageService,
           logService,
           stateMigrationService,
-          new AccountFactory(Account)
+          new StateFactory(GlobalState, Account)
         ),
       deps: [
         StorageServiceAbstraction,
@@ -349,7 +353,15 @@ import { Account, AccountFactory } from "jslib-common/models/domain/account";
     },
     {
       provide: StateMigrationServiceAbstraction,
-      useClass: StateMigrationService,
+      useFactory: (
+        storageService: StorageServiceAbstraction,
+        secureStorageService: StorageServiceAbstraction
+      ) =>
+        new StateMigrationService(
+          storageService,
+          secureStorageService,
+          new GlobalStateFactory(GlobalState)
+        ),
       deps: [StorageServiceAbstraction, "SECURE_STORAGE"],
     },
     {

--- a/common/src/factories/accountFactory.ts
+++ b/common/src/factories/accountFactory.ts
@@ -1,0 +1,13 @@
+import { Account } from "../models/domain/account";
+
+export class AccountFactory<T extends Account = Account> {
+  private accountConstructor: new (init: Partial<T>) => T;
+
+  constructor(accountConstructor: new (init: Partial<T>) => T) {
+    this.accountConstructor = accountConstructor;
+  }
+
+  create(args: Partial<T>) {
+    return new this.accountConstructor(args);
+  }
+}

--- a/common/src/factories/globalStateFactory.ts
+++ b/common/src/factories/globalStateFactory.ts
@@ -1,0 +1,13 @@
+import { GlobalState } from "../models/domain/globalState";
+
+export class GlobalStateFactory<T extends GlobalState = GlobalState> {
+  private globalStateConstructor: new (init: Partial<T>) => T;
+
+  constructor(globalStateConstructor: new (init: Partial<T>) => T) {
+    this.globalStateConstructor = globalStateConstructor;
+  }
+
+  create(args?: Partial<T>) {
+    return new this.globalStateConstructor(args);
+  }
+}

--- a/common/src/factories/stateFactory.ts
+++ b/common/src/factories/stateFactory.ts
@@ -1,0 +1,25 @@
+import { Account } from "../models/domain/account";
+import { GlobalState } from "../models/domain/globalState";
+import { AccountFactory } from "./accountFactory";
+import { GlobalStateFactory } from "./globalStateFactory";
+
+export class StateFactory<TAccount extends Account, TGlobal extends GlobalState> {
+  private globalStateFactory: GlobalStateFactory<TGlobal>;
+  private accountFactory: AccountFactory<TAccount>;
+
+  constructor(
+    globalStateConstructor: new (init: Partial<TGlobal>) => TGlobal,
+    accountConstructor: new (init: Partial<TAccount>) => TAccount
+  ) {
+    this.globalStateFactory = new GlobalStateFactory(globalStateConstructor);
+    this.accountFactory = new AccountFactory(accountConstructor);
+  }
+
+  createGlobal(args: Partial<TGlobal>): TGlobal {
+    return this.globalStateFactory.create(args);
+  }
+
+  createAccount(args: Partial<TAccount>): TAccount {
+    return this.accountFactory.create(args);
+  }
+}

--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -175,15 +175,3 @@ export class Account {
     });
   }
 }
-
-export class AccountFactory<T extends Account = Account> {
-  private accountConstructor: new (init: Partial<T>) => T;
-
-  constructor(accountConstructor: new (init: Partial<T>) => T) {
-    this.accountConstructor = accountConstructor;
-  }
-
-  create(args: Partial<T>) {
-    return new this.accountConstructor(args);
-  }
-}

--- a/common/src/models/domain/globalState.ts
+++ b/common/src/models/domain/globalState.ts
@@ -13,7 +13,7 @@ export class GlobalState {
   ssoOrganizationIdentifier?: string;
   ssoState?: string;
   rememberedEmail?: string;
-  theme?: ThemeType = ThemeType.Light;
+  theme?: ThemeType = ThemeType.System;
   window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;

--- a/common/src/models/domain/state.ts
+++ b/common/src/models/domain/state.ts
@@ -1,9 +1,16 @@
 import { Account } from "./account";
 import { GlobalState } from "./globalState";
 
-export class State<TAccount extends Account = Account> {
+export class State<
+  TAccount extends Account = Account,
+  TGlobalState extends GlobalState = GlobalState
+> {
   accounts: { [userId: string]: TAccount } = {};
-  globals: GlobalState = new GlobalState();
+  globals: TGlobalState;
   activeUserId: string;
   authenticatedAccounts: string[] = [];
+
+  constructor(globals: TGlobalState) {
+    this.globals = globals;
+  }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some clients have unique global setting defaults (and unique global settings)
For example: the web vault defaults to light theme, but most clients with theme support default to system theme.

The current way we handle `GlobalState` is buried in jslib and not easily extendible in clients.

To fix this, we need to treat `GlobalState` as a generic in the `StateService` and `StateMigration` service and allow for its extension in those methods and anywhere `GlobalState` is inited. We already use this pattern for extending the `Account` object into clients.

## Code changes
* Set the default `ThemeType` to `System`, since that is the standard among clients.
* Move `AccountFactory` into a folder dedicated to factories
* Add a `GlobalStateFactory`, and a `StateFactory` that combines the combines the two for one easy parameter to `StateService`.
* Make `GlobalState` on the `State` model generic, and pass in default values through a constructor since we can't new up generics in typescript.
* Make `GlobalState` on the `StateService` generic, and replace any initializers with calls to the `StateFactory`
* Add `GlobalState` as a type argument to the `StateMigrationService` so when we init the object we use the correct one. 

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
