### PR TITLE
[authService refactor] Fix browser by not using instanceof

### DIFF
--- a/common/src/enums/authenticationType.ts
+++ b/common/src/enums/authenticationType.ts
@@ -1,0 +1,5 @@
+export enum AuthenticationType {
+  Password = 0,
+  Sso = 1,
+  Api = 2,
+}

--- a/common/src/models/domain/logInCredentials.ts
+++ b/common/src/models/domain/logInCredentials.ts
@@ -1,6 +1,9 @@
+import { AuthenticationType } from "../../enums/authenticationType";
 import { TokenRequestTwoFactor } from "../request/identityToken/tokenRequest";
 
 export class PasswordLogInCredentials {
+  readonly type = AuthenticationType.Password;
+
   constructor(
     public email: string,
     public masterPassword: string,
@@ -10,6 +13,8 @@ export class PasswordLogInCredentials {
 }
 
 export class SsoLogInCredentials {
+  readonly type = AuthenticationType.Sso;
+
   constructor(
     public code: string,
     public codeVerifier: string,
@@ -20,5 +25,7 @@ export class SsoLogInCredentials {
 }
 
 export class ApiLogInCredentials {
+  readonly type = AuthenticationType.Api;
+
   constructor(public clientId: string, public clientSecret: string) {}
 }

--- a/common/src/models/domain/logInCredentials.ts
+++ b/common/src/models/domain/logInCredentials.ts
@@ -1,4 +1,5 @@
 import { AuthenticationType } from "../../enums/authenticationType";
+
 import { TokenRequestTwoFactor } from "../request/identityToken/tokenRequest";
 
 export class PasswordLogInCredentials {

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -28,6 +28,8 @@ import { StateService } from "../abstractions/state.service";
 import { TokenService } from "../abstractions/token.service";
 import { TwoFactorService } from "../abstractions/twoFactor.service";
 
+import { AuthenticationType } from "../enums/authenticationType";
+
 export class AuthService implements AuthServiceAbstraction {
   get email(): string {
     return this.logInStrategy instanceof PasswordLogInStrategy ? this.logInStrategy.email : null;
@@ -60,10 +62,9 @@ export class AuthService implements AuthServiceAbstraction {
   ): Promise<AuthResult> {
     this.clearState();
 
-    let result: AuthResult;
     let strategy: ApiLogInStrategy | PasswordLogInStrategy | SsoLogInStrategy;
 
-    if (credentials instanceof PasswordLogInCredentials) {
+    if (credentials.type === AuthenticationType.Password) {
       strategy = new PasswordLogInStrategy(
         this.cryptoService,
         this.apiService,
@@ -76,8 +77,8 @@ export class AuthService implements AuthServiceAbstraction {
         this.twoFactorService,
         this
       );
-      result = await strategy.logIn(credentials);
-    } else if (credentials instanceof SsoLogInCredentials) {
+      credentials;
+    } else if (credentials.type === AuthenticationType.Sso) {
       strategy = new SsoLogInStrategy(
         this.cryptoService,
         this.apiService,
@@ -90,8 +91,7 @@ export class AuthService implements AuthServiceAbstraction {
         this.twoFactorService,
         this.keyConnectorService
       );
-      result = await strategy.logIn(credentials);
-    } else if (credentials instanceof ApiLogInCredentials) {
+    } else if (credentials.type === AuthenticationType.Api) {
       strategy = new ApiLogInStrategy(
         this.cryptoService,
         this.apiService,
@@ -105,8 +105,9 @@ export class AuthService implements AuthServiceAbstraction {
         this.environmentService,
         this.keyConnectorService
       );
-      result = await strategy.logIn(credentials);
     }
+
+    const result = await strategy.logIn(credentials as any);
 
     if (result?.requiresTwoFactor) {
       this.saveState(strategy);

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -77,7 +77,6 @@ export class AuthService implements AuthServiceAbstraction {
         this.twoFactorService,
         this
       );
-      credentials;
     } else if (credentials.type === AuthenticationType.Sso) {
       strategy = new SsoLogInStrategy(
         this.cryptoService,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The authService refactor was broken on browser. `authService.logIn` identifies the `credentials` subclass by using `instanceof`. However, browser has different webpack bundles for the background page and the popup, so a `credentials` object constructed in the popup and passed to the background page is not an `instanceof` the same class as it exists in the background.

Now, we just switch based on an enum identifying the authentication type which the credentials are used for.

Note: client PRs are on hold until this is merged.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Covered under the authService refactor ticket.
## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
