### PR TITLE
Use Identity server routes

### DIFF
--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -310,7 +310,9 @@ export class ApiService implements ApiServiceAbstraction {
       request,
       false,
       true,
-      this.environmentService.getIdentityUrl()
+      this.platformUtilsService.isDev()
+        ? this.environmentService.getIdentityUrl()
+        : this.environmentService.getApiUrl()
     );
     return new PreloginResponse(r);
   }
@@ -359,7 +361,9 @@ export class ApiService implements ApiServiceAbstraction {
       request,
       false,
       false,
-      this.environmentService.getIdentityUrl()
+      this.platformUtilsService.isDev()
+        ? this.environmentService.getIdentityUrl()
+        : this.environmentService.getApiUrl()
     );
   }
 

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -304,7 +304,14 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   async postPrelogin(request: PreloginRequest): Promise<PreloginResponse> {
-    const r = await this.send("POST", "/accounts/prelogin", request, false, true);
+    const r = await this.send(
+      "POST",
+      "/accounts/prelogin",
+      request,
+      false,
+      true,
+      this.environmentService.getIdentityUrl()
+    );
     return new PreloginResponse(r);
   }
 
@@ -346,7 +353,14 @@ export class ApiService implements ApiServiceAbstraction {
   }
 
   postRegister(request: RegisterRequest): Promise<any> {
-    return this.send("POST", "/accounts/register", request, false, false);
+    return this.send(
+      "POST",
+      "/accounts/register",
+      request,
+      false,
+      false,
+      this.environmentService.getIdentityUrl()
+    );
   }
 
   async postPremium(data: FormData): Promise<PaymentResponse> {


### PR DESCRIPTION
We've moved `prelogin` and `register` endpoints to the Indentity project
Reflecting that change here

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Related to https://github.com/bitwarden/server/pull/1837. https://github.com/bitwarden/server/pull/1807 moved endpoints into identity, but we did not update this project at the time to point to the new location, but the obsolete API location. This PR updates to the newer path.

## Code changes
* **api.service**: override api url with identity url for calls moved to that project.

## Testing requirements

Validate registration and login still work as expected

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
