### PR TITLE
Fix avatar error when src is undefined

### DIFF
--- a/angular/src/components/avatar.component.ts
+++ b/angular/src/components/avatar.component.ts
@@ -9,7 +9,7 @@ import { Utils } from "jslib-common/misc/utils";
 @Component({
   selector: "app-avatar",
   template:
-    '<img [src]="sanitizer.bypassSecurityTrustResourceUrl(src)" title="{{data}}" ' +
+    '<img *ngIf="src" [src]="sanitizer.bypassSecurityTrustResourceUrl(src)" title="{{data}}" ' +
     "[ngClass]=\"{'rounded-circle': circle}\">",
 })
 export class AvatarComponent implements OnChanges, OnInit {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The avatar components generates an error message before the `src` component has had time to load. To resolve this I added a `*ngIf` check which triggers when `src` is null.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
