### PR TITLE
Temporarily remove keeper json import for the Feb release

### DIFF
--- a/common/src/services/import.service.ts
+++ b/common/src/services/import.service.ts
@@ -101,7 +101,8 @@ export class ImportService implements ImportServiceAbstraction {
     { id: "1passwordmaccsv", name: "1Password 6 and 7 Mac (csv)" },
     { id: "roboformcsv", name: "RoboForm (csv)" },
     { id: "keepercsv", name: "Keeper (csv)" },
-    { id: "keeperjson", name: "Keeper (json)" },
+    // Temporarily remove this option for the Feb release
+    // { id: "keeperjson", name: "Keeper (json)" },
     { id: "enpasscsv", name: "Enpass (csv)" },
     { id: "enpassjson", name: "Enpass (json)" },
     { id: "safeincloudxml", name: "SafeInCloud (xml)" },


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
I recently added an importer for the Keeper json format https://github.com/bitwarden/jslib/pull/608. During testing we found some issues and room for improvement to support additional item types. 

This PR is gonna hide the option from the WebVault import dropdown/cli import

Asana task: https://app.asana.com/0/1200804338582616/1201763333842566/f

This will need cherry picking 🍒 ⛏️  to `rc`

## Code changes
- **common/src/services/import.service.ts:** Comment out the keeperJson import / Hide it from the dropdown

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
