### PR TITLE
[bug] Make activity a top level storage key

### DIFF
--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -94,7 +94,6 @@ export class AccountProfile {
   everBeenUnlocked?: boolean;
   forcePasswordReset?: boolean;
   hasPremiumPersonally?: boolean;
-  lastActive?: number;
   lastSync?: string;
   userId?: string;
   usesKeyConnector?: boolean;

--- a/common/src/models/domain/state.ts
+++ b/common/src/models/domain/state.ts
@@ -9,6 +9,7 @@ export class State<
   globals: TGlobalState;
   activeUserId: string;
   authenticatedAccounts: string[] = [];
+  accountActivity: { [userId: string]: number } = {};
 
   constructor(globals: TGlobalState) {
     this.globals = globals;

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -413,7 +413,9 @@ export class StateMigrationService<
     await this.set(keys.authenticatedAccounts, [userId]);
     await this.set(keys.activeUserId, userId);
 
-    const accountActivity: { [userId: string]: number } = {};
+    const accountActivity: { [userId: string]: number } = {
+      [userId]: await this.get<number>(v1Keys.lastActive),
+    };
     accountActivity[userId] = await this.get<number>(v1Keys.lastActive);
     await this.set(keys.accountActivity, accountActivity);
 

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -413,9 +413,8 @@ export class StateMigrationService<
     await this.set(keys.authenticatedAccounts, [userId]);
     await this.set(keys.activeUserId, userId);
 
-    const accountActivity: { [userId: string]: number } = {
-      userId: await this.get<number>(v1Keys.lastActive),
-    };
+    const accountActivity: { [userId: string]: number } = {};
+    accountActivity[userId] = await this.get<number>(v1Keys.lastActive);
     await this.set(keys.accountActivity, accountActivity);
 
     await clearV1Keys(userId);

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -122,6 +122,7 @@ const keys = {
   authenticatedAccounts: "authenticatedAccounts",
   activeUserId: "activeUserId",
   tempAccountSettings: "tempAccountSettings", // used to hold account specific settings (i.e clear clipboard) between initial migration and first account authentication
+  accountActivity: "accountActivity",
 };
 
 const partialKeys = {
@@ -396,7 +397,6 @@ export class StateMigrationService<
         kdfIterations: await this.get<number>(v1Keys.kdfIterations),
         kdfType: await this.get<KdfType>(v1Keys.kdf),
         keyHash: await this.get<string>(v1Keys.keyHash),
-        lastActive: await this.get<number>(v1Keys.lastActive),
         lastSync: null,
         userId: userId,
         usesKeyConnector: null,
@@ -412,6 +412,12 @@ export class StateMigrationService<
 
     await this.set(keys.authenticatedAccounts, [userId]);
     await this.set(keys.activeUserId, userId);
+
+    const accountActivity: { [userId: string]: number } = {
+      userId: await this.get<number>(v1Keys.lastActive),
+    };
+    await this.set(keys.accountActivity, accountActivity);
+
     await clearV1Keys(userId);
 
     if (await this.secureStorageService.has(v1Keys.key, { keySuffix: "biometric" })) {


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201771028067731

This will need to be cherry-picked to all clients.

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
During the storage data model refactor we have frequently seen issues where the frequency at which we record activity sometimes creates a race condition with other operations that create unexpected behavior. 

This happens because activity tracking runs outside of normal client processes, and runs a lot (on every click, for example), but access the same Account storage key as other operations (like saving vault timeout settings). This creates a race condition where:

1. The vaultTimeout.valueChange methods starts modifying state to save the updated setting
2. At the same time (from the same click) activity tracking starts its process to record activity
3. Both operations, running at the same time, access the storage key used for the Account they are modifying
4. Explosions begin as the operations save over each other with bad data

## Code changes
To stop this from happening I've moved account activity to its own top level storage key, outside of the Account model that represents settings, vaults, etc. This way these processes access different keys and don't step on each others toes.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
