### PR TITLE
[bug] Default the state version check function to 1

### DIFF
--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -461,6 +461,6 @@ export class StateMigrationService<
   }
 
   protected async getCurrentStateVersion(): Promise<StateVersion> {
-    return (await this.getGlobals())?.stateVersion;
+    return (await this.getGlobals())?.stateVersion ?? StateVersion.One;
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201780415937173

This will need to be cherry picked to all clients

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some clients, like desktop, will create and save to storage before migrations can run and will always have a StateVersion to check when migrations do run.

Other clients, like browser, don't do this, and then the migration service doesn't have a version to check - resulting in migrations not running.

## Code changes
* Ensure no state version = StateVersion.One to the mgirator

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
