### PR TITLE
[bug] Fix logout timeout action for inactive accounts

### DIFF
--- a/angular/src/services/jslib-services.module.ts
+++ b/angular/src/services/jslib-services.module.ts
@@ -313,7 +313,8 @@ import { StateFactory } from "jslib-common/factories/stateFactory";
           keyConnectorService,
           stateService,
           null,
-          async () => messagingService.send("logout", { expired: false })
+          async (userId?: string) =>
+            messagingService.send("logout", { expired: false, userId: userId })
         ),
       deps: [
         CipherServiceAbstraction,

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -121,6 +121,7 @@ export class StateService<
     await this.storageService.save(keys.authenticatedAccounts, this.state.authenticatedAccounts);
     this.state.accounts[account.profile.userId] = account;
     await this.scaffoldNewAccountStorage(account);
+    await this.setLastActive(new Date().getTime(), { userId: account.profile.userId });
     await this.setActiveUser(account.profile.userId);
     this.activeAccount.next(account.profile.userId);
   }
@@ -2437,6 +2438,7 @@ export class StateService<
 
   protected async deAuthenticateAccount(userId: string) {
     await this.setAccessToken(null, { userId: userId });
+    await this.setLastActive(null, { userId: userId });
     const index = this.state.authenticatedAccounts.indexOf(userId);
     if (index > -1) {
       this.state.authenticatedAccounts.splice(index, 1);

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -87,7 +87,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
         (pinSet[0] && (await this.stateService.getDecryptedPinProtected()) != null) || pinSet[1];
 
       if (!pinLock && !(await this.isBiometricLockSet())) {
-        await this.logOut();
+        await this.logOut(userId);
       }
     }
 

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -29,7 +29,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     private policyService: PolicyService,
     private keyConnectorService: KeyConnectorService,
     private stateService: StateService,
-    private lockedCallback: () => Promise<void> = null,
+    private lockedCallback: (userId?: string) => Promise<void> = null,
     private loggedOutCallback: (userId?: string) => Promise<void> = null
   ) {}
 
@@ -110,7 +110,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     this.messagingService.send("locked", { userId: userId });
 
     if (this.lockedCallback != null) {
-      await this.lockedCallback();
+      await this.lockedCallback(userId);
     }
   }
 

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -198,6 +198,6 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
 
   private async executeTimeoutAction(userId: string): Promise<void> {
     const timeoutAction = await this.stateService.getVaultTimeoutAction({ userId: userId });
-    timeoutAction === "logOut" ? await this.logOut() : await this.lock(true, userId);
+    timeoutAction === "logOut" ? await this.logOut(userId) : await this.lock(true, userId);
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/inbox/1183359552741416/1201787020823690/1201782081866250

This will need to be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When an account has the Vault Timeout Action set to Logout, the other authenticated accounts incorrectly get logged out

## Code changes
* Pass userId in to the logout callback parameter to the vaultTimeoutService. The message handle in desktop already expects this.
* Set lastActive on account login, and null it on account deauthentication. This prevents an issue where newly logged in accounts immediately time out due to inactivity.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
