### PR TITLE
[bug] Toggle tokens appropriatly based on timeout action

### DIFF
--- a/common/src/abstractions/token.service.ts
+++ b/common/src/abstractions/token.service.ts
@@ -14,7 +14,6 @@ export abstract class TokenService {
   getClientId: () => Promise<string>;
   setClientSecret: (clientSecret: string) => Promise<any>;
   getClientSecret: () => Promise<string>;
-  toggleTokens: () => Promise<any>;
   setTwoFactorToken: (tokenResponse: IdentityTokenResponse) => Promise<any>;
   getTwoFactorToken: () => Promise<string>;
   clearTwoFactorToken: () => Promise<any>;

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -147,20 +147,23 @@ export class StateService<
   }
 
   async getAccessToken(options?: StorageOptions): Promise<string> {
-    return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
-    )?.tokens?.accessToken;
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    return (await this.getAccount(options))?.tokens?.accessToken;
   }
 
   async setAccessToken(value: string, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    const account = await this.getAccount(options);
     account.tokens.accessToken = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    await this.saveAccount(account, options);
   }
 
   async getAddEditCipherInfo(options?: StorageOptions): Promise<any> {
@@ -195,37 +198,43 @@ export class StateService<
   }
 
   async getApiKeyClientId(options?: StorageOptions): Promise<string> {
-    return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
-    )?.profile?.apiKeyClientId;
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    return (await this.getAccount(options))?.profile?.apiKeyClientId;
   }
 
   async setApiKeyClientId(value: string, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    const account = await this.getAccount(options);
     account.profile.apiKeyClientId = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    await this.saveAccount(account, options);
   }
 
   async getApiKeyClientSecret(options?: StorageOptions): Promise<string> {
-    return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
-    )?.keys?.apiKeyClientSecret;
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    return (await this.getAccount(options))?.keys?.apiKeyClientSecret;
   }
 
   async setApiKeyClientSecret(value: string, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    const account = await this.getAccount(options);
     account.keys.apiKeyClientSecret = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    await this.saveAccount(account, options);
   }
 
   async getAutoConfirmFingerPrints(options?: StorageOptions): Promise<boolean> {
@@ -1866,20 +1875,23 @@ export class StateService<
   }
 
   async getRefreshToken(options?: StorageOptions): Promise<string> {
-    return (
-      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
-    )?.tokens?.refreshToken;
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    return (await this.getAccount(options))?.tokens?.refreshToken;
   }
 
   async setRefreshToken(value: string, options?: StorageOptions): Promise<void> {
-    const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    const defaultOptions =
+      (await this.getVaultTimeoutAction({ userId: options?.userId })) === "logOut"
+        ? this.defaultInMemoryOptions
+        : await this.defaultOnDiskOptions();
+    options = this.reconcileOptions(options, defaultOptions);
+    const account = await this.getAccount(options);
     account.tokens.refreshToken = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    await this.saveAccount(account, options);
   }
 
   async getRememberedEmail(options?: StorageOptions): Promise<string> {
@@ -2225,9 +2237,11 @@ export class StateService<
   }
 
   protected async scaffoldNewAccountStorage(account: TAccount): Promise<void> {
-    await this.scaffoldNewAccountLocalStorage(account);
-    await this.scaffoldNewAccountSessionStorage(account);
-    await this.scaffoldNewAccountMemoryStorage(account);
+    // We don't want to manipulate the referenced in memory account
+    const deepClone = JSON.parse(JSON.stringify(account));
+    await this.scaffoldNewAccountLocalStorage(deepClone);
+    await this.scaffoldNewAccountSessionStorage(deepClone);
+    await this.scaffoldNewAccountMemoryStorage(deepClone);
   }
 
   // TODO: There is a tech debt item for splitting up these methods - only Web uses multiple storage locations in its storageService.
@@ -2246,6 +2260,12 @@ export class StateService<
       await this.storageService.remove(keys.tempAccountSettings);
     }
     account.settings.environmentUrls = environmentUrls;
+    if (account.settings.vaultTimeoutAction === "logOut") {
+      account.tokens.accessToken = null;
+      account.tokens.refreshToken = null;
+      account.profile.apiKeyClientId = null;
+      account.keys.apiKeyClientSecret = null;
+    }
     await this.storageService.save(
       account.profile.userId,
       account,
@@ -2422,7 +2442,7 @@ export class StateService<
 
   protected clearDecryptedDataForActiveUser() {
     const userId = this.state.activeUserId;
-    if (userId == null) {
+    if (userId == null || this.state?.accounts[userId]?.data == null) {
       return;
     }
     this.state.accounts[userId].data = new AccountData();

--- a/common/src/services/token.service.ts
+++ b/common/src/services/token.service.ts
@@ -22,9 +22,6 @@ export class TokenService implements TokenServiceAbstraction {
   }
 
   async setClientId(clientId: string): Promise<any> {
-    if ((await this.skipTokenStorage()) || clientId == null) {
-      return;
-    }
     return await this.stateService.setApiKeyClientId(clientId);
   }
 
@@ -33,9 +30,6 @@ export class TokenService implements TokenServiceAbstraction {
   }
 
   async setClientSecret(clientSecret: string): Promise<any> {
-    if ((await this.skipTokenStorage()) || clientSecret == null) {
-      return;
-    }
     return await this.stateService.setApiKeyClientSecret(clientSecret);
   }
 
@@ -52,33 +46,11 @@ export class TokenService implements TokenServiceAbstraction {
   }
 
   async setRefreshToken(refreshToken: string): Promise<any> {
-    if (await this.skipTokenStorage()) {
-      return;
-    }
     return await this.stateService.setRefreshToken(refreshToken);
   }
 
   async getRefreshToken(): Promise<string> {
     return await this.stateService.getRefreshToken();
-  }
-
-  async toggleTokens(): Promise<any> {
-    const token = await this.getToken();
-    const refreshToken = await this.getRefreshToken();
-    const clientId = await this.getClientId();
-    const clientSecret = await this.getClientSecret();
-    const timeout = await this.stateService.getVaultTimeout();
-    const action = await this.stateService.getVaultTimeoutAction();
-
-    if ((timeout != null || timeout === 0) && action === "logOut") {
-      // if we have a vault timeout and the action is log out, reset tokens
-      await this.clearToken();
-    }
-
-    await this.setToken(token);
-    await this.setRefreshToken(refreshToken);
-    await this.setClientId(clientId);
-    await this.setClientSecret(clientSecret);
   }
 
   async setTwoFactorToken(tokenResponse: IdentityTokenResponse): Promise<any> {
@@ -213,11 +185,5 @@ export class TokenService implements TokenServiceAbstraction {
     const decoded = await this.decodeToken();
 
     return Array.isArray(decoded.amr) && decoded.amr.includes("external");
-  }
-
-  private async skipTokenStorage(): Promise<boolean> {
-    const timeout = await this.stateService.getVaultTimeout();
-    const action = await this.stateService.getVaultTimeoutAction();
-    return timeout != null && action === "logOut";
   }
 }

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -131,7 +131,7 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     const clientSecret = await this.tokenService.getClientSecret();
 
     const currentAction = await this.stateService.getVaultTimeoutAction();
-    if ((timeout != null || timeout === 0) && action === "logOut" && action != currentAction) {
+    if ((timeout != null || timeout === 0) && action === "logOut" && action !== currentAction) {
       // if we have a vault timeout and the action is log out, reset tokens
       await this.tokenService.clearToken();
     }

--- a/common/src/services/vaultTimeout.service.ts
+++ b/common/src/services/vaultTimeout.service.ts
@@ -130,7 +130,8 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     const clientId = await this.tokenService.getClientId();
     const clientSecret = await this.tokenService.getClientSecret();
 
-    if ((timeout != null || timeout === 0) && action === "logOut") {
+    const currentAction = await this.stateService.getVaultTimeoutAction();
+    if ((timeout != null || timeout === 0) && action === "logOut" && action != currentAction) {
       // if we have a vault timeout and the action is log out, reset tokens
       await this.tokenService.clearToken();
     }


### PR DESCRIPTION
https://app.asana.com/0/inbox/1183359552741416/1201787020823699/1201795621278997

This will need to be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
In production we store tokens in different locations based on timeout action. If the timeout action is set to "lock", we save tokens to memory for normal use and to disk in order to maintain authenticated sessions on startup. If the timeout action is set to "log out" we only store tokens in memory, so when the app is closed it takes authenticated sessions with it. In production most of this switch happens in [`toggleTokens()`](https://github.com/bitwarden/jslib/blob/f4c66b2c8c243935bf25f689b16afaa5d6345f1b/common/src/services/token.service.ts#L92-L113).

With the state refactor I misunderstood this and broke it, only ever saving tokens to disk. As far as I know this only has one negative consequence: "On Restart Logout" vault timeouts not working for desktop. The lock screen is presented instead, because an access token still exists so the session is still authenticated.

Unfortunately, this is a little messy to get working again. We need to be able to pick up the tokens and save them to the right place without disrupting the rest of the application state, or clearing the token completely and deauthenticating the session. 

## Code changes
To achieve this I have:

1. Added conditions to getters/setters for token values in the StateService that are dependent on vault timeout action for their storage location. 
2. Ensured we don't save tokens to disk when scaffolding new login storage if we already have a logged out timeout action saved
3. Removed all "skipStorage" logic from the token service, since we always save tokens somewhere and now the StateService always knows where to put them.
4. Removed `toggleTokens()` and split that logic in half. We gather tokens, and clear them, before actually setting the timeout action, then reset the tokens after changing the timeout action so the StateService knows where to put them back to.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
