### PR TITLE
Move providers to profile and save to disk

### DIFF
--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -57,6 +57,7 @@ export class AccountData {
   collapsedGroupings?: Set<string>;
   eventCollection?: EventData[];
   organizations?: { [id: string]: OrganizationData };
+  providers?: { [id: string]: ProviderData };
 }
 
 export class AccountKeys {
@@ -99,7 +100,6 @@ export class AccountProfile {
   keyHash?: string;
   kdfIterations?: number;
   kdfType?: KdfType;
-  providers?: { [id: string]: ProviderData };
 }
 
 export class AccountSettings {

--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -57,7 +57,6 @@ export class AccountData {
   collapsedGroupings?: Set<string>;
   eventCollection?: EventData[];
   organizations?: { [id: string]: OrganizationData };
-  providers?: { [id: string]: ProviderData };
 }
 
 export class AccountKeys {
@@ -100,6 +99,7 @@ export class AccountProfile {
   keyHash?: string;
   kdfIterations?: number;
   kdfType?: KdfType;
+  providers?: { [id: string]: ProviderData };
 }
 
 export class AccountSettings {

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1848,7 +1848,7 @@ export class StateService<
   async getProviders(options?: StorageOptions): Promise<{ [id: string]: ProviderData }> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
-    )?.profile?.providers;
+    )?.data?.providers;
   }
 
   async setProviders(
@@ -1858,7 +1858,7 @@ export class StateService<
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.profile.providers = value;
+    account.data.providers = value;
     await this.saveAccount(
       account,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1846,8 +1846,9 @@ export class StateService<
   }
 
   async getProviders(options?: StorageOptions): Promise<{ [id: string]: ProviderData }> {
-    return (await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions)))
-      ?.data?.providers;
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions()))
+    )?.profile?.providers;
   }
 
   async setProviders(
@@ -1855,10 +1856,13 @@ export class StateService<
     options?: StorageOptions
   ): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, this.defaultInMemoryOptions)
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
     );
-    account.data.providers = value;
-    await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
+    account.profile.providers = value;
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    );
   }
 
   async getPublicKey(options?: StorageOptions): Promise<ArrayBuffer> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix providers portal links being removed on vault refresh and unlock.
[Ticket](https://app.asana.com/0/1169444489336079/1201797137809540)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **common/src/services/state.service.ts:** Save providers to 'disk' so that they are persisted after page refresh and vault unlock. They only get set from the syncAll() api call, so we can't rely on them being reset in memory on page refresh.

## Testing requirements

Ensure that Providers links are present after vault is refreshed and locked.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
