### PR TITLE
Individually await saving of orgs and providers

### DIFF
--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -328,10 +328,8 @@ export class SyncService implements SyncServiceAbstraction {
       }
     });
 
-    await Promise.all([
-      this.organizationService.save(organizations),
-      this.providerService.save(providers),
-    ]);
+    await this.organizationService.save(organizations);
+    await this.providerService.save(providers);
 
     if (await this.keyConnectorService.userNeedsMigration()) {
       await this.keyConnectorService.setConvertAccountRequired(true);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Now that organizations and providers are saved to the same state object, we need to save them individually instead of at the same time because they were causing shenanigans and overwriting each other. 

## Code changes

- **common/src/services/sync.service.ts:** Await saving of organizations and providers individually

## Testing requirements

Ensure both organizations and providers show up as expected on the vault page.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
