### PR TITLE
[bug] Store everBeenUnlocked in memory

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1468,20 +1468,17 @@ export class StateService<
 
   async getEverBeenUnlocked(options?: StorageOptions): Promise<boolean> {
     return (
-      (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.profile?.everBeenUnlocked ?? false
+      (await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions)))?.profile
+        ?.everBeenUnlocked ?? false
     );
   }
 
   async setEverBeenUnlocked(value: boolean, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+      this.reconcileOptions(options, this.defaultInMemoryOptions)
     );
     account.profile.everBeenUnlocked = value;
-    await this.saveAccount(
-      account,
-      this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    );
+    await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
   }
 
   async getForcePasswordReset(options?: StorageOptions): Promise<boolean> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
`everBeenUnlocked` is not meant to be stored long term. [Previously](https://github.com/bitwarden/jslib/blob/b4f475251aa6817403117b71fb5a8836cdae9c75/common/src/services/vaultTimeout.service.ts#L23), it was tracked using a service variable. The storage refactor incorrectly began saving this value to disk, creating issues with never lock situations. If a user:

1. Previously installed Bitwarden (is migrating)
2. Updates (migrates, everBeenUnlocked set to null)
3. Logs in (everBeenUnlocked is set to true)
4. Changes to Never Lock
5. Closes the browser
6. Reopens it

You can observe that the vault is locked, because everBeenUnlocked returns true [here](https://github.com/bitwarden/jslib/blob/5fad7c666f0fa301a180ec1a72794b1fd6088a5e/common/src/services/vaultTimeout.service.ts#L56), causing us to return that the vault is locked.

## Code changes
* Return everBeenUnlocked to an in memory variable

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
