### PR TITLE
Cache state service account blob from disk reads

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2194,7 +2194,7 @@ export class StateService<
       return null;
     }
 
-    var cachedAccount = this.accountDiskCache.get(options.userId);
+    const cachedAccount = this.accountDiskCache.get(options.userId);
     if (cachedAccount != null) {
       return cachedAccount;
     }

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -69,13 +69,17 @@ export class StateService<
 
   private hasBeenInited: boolean = false;
 
+  private accountDiskCache: Map<string, TAccount>;
+
   constructor(
     protected storageService: StorageService,
     protected secureStorageService: StorageService,
     protected logService: LogService,
     protected stateMigrationService: StateMigrationService,
     protected stateFactory: StateFactory<TGlobalState, TAccount>
-  ) {}
+  ) {
+    this.accountDiskCache = new Map<string, TAccount>();
+  }
 
   async init(): Promise<void> {
     if (this.hasBeenInited) {
@@ -2190,6 +2194,11 @@ export class StateService<
       return null;
     }
 
+    var cachedAccount = this.accountDiskCache.get(options.userId);
+    if (cachedAccount != null) {
+      return cachedAccount;
+    }
+
     const account = options?.useSecureStorage
       ? (await this.secureStorageService.get<TAccount>(options.userId, options)) ??
         (await this.storageService.get<TAccount>(
@@ -2198,6 +2207,7 @@ export class StateService<
         ))
       : await this.storageService.get<TAccount>(options.userId, options);
 
+    this.accountDiskCache.set(options.userId, account);
     return account;
   }
 
@@ -2227,6 +2237,7 @@ export class StateService<
       : this.storageService;
 
     await storageLocation.save(`${options.userId}`, account, options);
+    this.accountDiskCache.delete(options.userId);
   }
 
   protected async saveAccountToMemory(account: TAccount): Promise<void> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Prevent so much disk i/o with the new large account object being read so much.

## Code changes

Adds an account cache in memory to buffer the disk reads.

## Testing requirements

Regression

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
