### PR TITLE
Load component on init, then watch

### DIFF
--- a/angular/src/components/lock.component.ts
+++ b/angular/src/components/lock.component.ts
@@ -59,6 +59,8 @@ export class LockComponent implements OnInit {
   ) {}
 
   async ngOnInit() {
+    // Load the first and observe updates
+    await this.load();
     this.stateService.activeAccount.subscribe(async (_userId) => {
       await this.load();
     });


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes a minor regression bug where the autoprompt for biometric is never shown on desktop. This is due to not awaiting the first `load` call prior to watching the observable.

## Code changes

## Testing requirements

Biometric is shown immediately upon opening the desktop app to unlock

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
