### PR TITLE
Resolve hasKeyStored returning true when no biometric key is stored

### DIFF
--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -349,9 +349,9 @@ export class CryptoService implements CryptoServiceAbstraction {
   async hasKeyStored(keySuffix: KeySuffixOptions, userId?: string): Promise<boolean> {
     switch (keySuffix) {
       case KeySuffixOptions.Auto:
-        return await this.stateService.getCryptoMasterKeyAuto({ userId: userId }) != null;
+        return (await this.stateService.getCryptoMasterKeyAuto({ userId: userId })) != null;
       case KeySuffixOptions.Biometric:
-        return await this.stateService.hasCryptoMasterKeyBiometric({ userId: userId }) === true;
+        return (await this.stateService.hasCryptoMasterKeyBiometric({ userId: userId })) === true;
       default:
         return false;
     }

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -350,7 +350,7 @@ export class CryptoService implements CryptoServiceAbstraction {
     const key =
       keySuffix === KeySuffixOptions.Auto
         ? await this.stateService.getCryptoMasterKeyAuto({ userId: userId })
-        : await this.stateService.hasCryptoMasterKeyBiometric({ userId: userId });
+        : await this.stateService.getCryptoMasterKeyBiometric({ userId: userId });
 
     return key != null;
   }

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -351,7 +351,7 @@ export class CryptoService implements CryptoServiceAbstraction {
       case KeySuffixOptions.Auto:
         return await this.stateService.getCryptoMasterKeyAuto({ userId: userId }) != null;
       case KeySuffixOptions.Biometric:
-        return await this.stateService.hasCryptoMasterKeyBiometric({ userId: userId }) == true;
+        return await this.stateService.hasCryptoMasterKeyBiometric({ userId: userId }) === true;
       default:
         return false;
     }

--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -347,12 +347,14 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   async hasKeyStored(keySuffix: KeySuffixOptions, userId?: string): Promise<boolean> {
-    const key =
-      keySuffix === KeySuffixOptions.Auto
-        ? await this.stateService.getCryptoMasterKeyAuto({ userId: userId })
-        : await this.stateService.getCryptoMasterKeyBiometric({ userId: userId });
-
-    return key != null;
+    switch (keySuffix) {
+      case KeySuffixOptions.Auto:
+        return await this.stateService.getCryptoMasterKeyAuto({ userId: userId }) != null;
+      case KeySuffixOptions.Biometric:
+        return await this.stateService.hasCryptoMasterKeyBiometric({ userId: userId }) == true;
+      default:
+        return false;
+    }
   }
 
   async hasEncKey(): Promise<boolean> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

It seems `hasKeyStored` returned true when checking for biometric keys since `hasCryptoMasterKeyBiometric` returns a boolean which should never be null.

Should resolve https://github.com/bitwarden/browser/issues/2334

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

I've tested this in browser, but we probably need to investigate if this has sideeffects in the other clients.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
