### PR TITLE
Clean up the cached account

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2425,6 +2425,7 @@ export class StateService<
 
   protected removeAccountFromMemory(userId: string = this.state.activeUserId): void {
     delete this.state.accounts[userId];
+    this.accountDiskCache.delete(userId);
   }
 
   protected async pruneInMemoryAccounts() {
@@ -2432,6 +2433,7 @@ export class StateService<
     for (const userId in this.state.accounts) {
       if (!(await this.getIsAuthenticated({ userId: userId }))) {
         delete this.state.accounts[userId];
+        this.accountDiskCache.delete(userId);
       }
     }
   }

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2432,8 +2432,7 @@ export class StateService<
     // We preserve settings for logged out accounts, but we don't want to consider them when thinking about active account state
     for (const userId in this.state.accounts) {
       if (!(await this.getIsAuthenticated({ userId: userId }))) {
-        delete this.state.accounts[userId];
-        this.accountDiskCache.delete(userId);
+        this.removeAccountFromMemory(userId);
       }
     }
   }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With https://github.com/bitwarden/jslib/pull/668 we introduced an account cache which results in good performance but had some issues when logging out and back in again.

## Code changes
- **common/src/services/state.service.ts:** Make sure the account cache is cleared when logging out

## Testing requirements
Testing will be done on the clients with logging out of accounts and back in again. Also with timeoutAction == logout

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
