### PR TITLE
Run addAccount storage scaffolding calls through saveAccount

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2246,11 +2246,7 @@ export class StateService<
       account.profile.apiKeyClientId = null;
       account.keys.apiKeyClientSecret = null;
     }
-    await this.storageService.save(
-      account.profile.userId,
-      account,
-      await this.defaultOnDiskLocalOptions()
-    );
+    await this.saveAccount(account, await this.defaultOnDiskLocalOptions());
   }
 
   protected async scaffoldNewAccountMemoryStorage(account: TAccount): Promise<void> {
@@ -2262,11 +2258,7 @@ export class StateService<
       storedAccount.settings.environmentUrls = account.settings.environmentUrls;
       account.settings = storedAccount.settings;
     }
-    await this.storageService.save(
-      account.profile.userId,
-      account,
-      await this.defaultOnDiskMemoryOptions()
-    );
+    await this.saveAccount(account, await this.defaultOnDiskLocalOptions());
   }
 
   protected async scaffoldNewAccountSessionStorage(account: TAccount): Promise<void> {
@@ -2278,11 +2270,7 @@ export class StateService<
       storedAccount.settings.environmentUrls = account.settings.environmentUrls;
       account.settings = storedAccount.settings;
     }
-    await this.storageService.save(
-      account.profile.userId,
-      account,
-      await this.defaultOnDiskOptions()
-    );
+    await this.saveAccount(account, await this.defaultOnDiskLocalOptions());
   }
   //
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We aren't running the account scaffolding methods that happen during login through saveAccount, and so they aren't being cached. This is creating a confusing state for applications and authenticating them inappropriately. 

## Code changes
* Call saveAccount from the scaffolding methods. Only one of these is relevant, since the other two are web specific and don't cache, but we should still be pushing all account saving logic through saveAccount.

## Screenshots

https://user-images.githubusercontent.com/15897251/153625545-c1347382-3ad8-4523-8c13-4dfa2eed5b07.mov


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
