### PR TITLE
Clear active user if state has no users

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2381,10 +2381,7 @@ export class StateService<
     );
     await this.saveAccount(
       this.resetAccount(storedAccount),
-      this.reconcileOptions(
-        { userId: userId },
-        await this.defaultOnDiskLocalOptions()
-      )
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskLocalOptions())
     );
   }
 
@@ -2396,10 +2393,7 @@ export class StateService<
     );
     await this.saveAccount(
       this.resetAccount(storedAccount),
-      this.reconcileOptions(
-        { userId: userId },
-        await this.defaultOnDiskOptions()
-      )
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskOptions())
     );
   }
 

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2382,7 +2382,7 @@ export class StateService<
     await this.saveAccount(
       this.resetAccount(storedAccount),
       this.reconcileOptions(
-        { userId: storedAccount.profile.userId },
+        { userId: userId },
         await this.defaultOnDiskLocalOptions()
       )
     );
@@ -2397,7 +2397,7 @@ export class StateService<
     await this.saveAccount(
       this.resetAccount(storedAccount),
       this.reconcileOptions(
-        { userId: storedAccount.profile.userId },
+        { userId: userId },
         await this.defaultOnDiskOptions()
       )
     );

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2376,26 +2376,30 @@ export class StateService<
   protected async removeAccountFromLocalStorage(
     userId: string = this.state.activeUserId
   ): Promise<void> {
-    const storedAccount = await this.storageService.get<TAccount>(userId, {
-      htmlStorageLocation: HtmlStorageLocation.Local,
-    });
-    await this.storageService.save(
-      userId,
+    const storedAccount = await this.getAccount(
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskLocalOptions())
+    );
+    await this.saveAccount(
       this.resetAccount(storedAccount),
-      await this.defaultOnDiskLocalOptions()
+      this.reconcileOptions(
+        { userId: storedAccount.profile.userId },
+        await this.defaultOnDiskLocalOptions()
+      )
     );
   }
 
   protected async removeAccountFromSessionStorage(
     userId: string = this.state.activeUserId
   ): Promise<void> {
-    const storedAccount = await this.storageService.get<TAccount>(userId, {
-      htmlStorageLocation: HtmlStorageLocation.Session,
-    });
-    await this.storageService.save(
-      userId,
+    const storedAccount = await this.getAccount(
+      this.reconcileOptions({ userId: userId }, await this.defaultOnDiskOptions())
+    );
+    await this.saveAccount(
       this.resetAccount(storedAccount),
-      await this.defaultOnDiskOptions()
+      this.reconcileOptions(
+        { userId: storedAccount.profile.userId },
+        await this.defaultOnDiskOptions()
+      )
     );
   }
 
@@ -2470,6 +2474,10 @@ export class StateService<
   }
 
   protected async dynamicallySetActiveUser() {
+    if (Object.keys(this.state.accounts).length < 1) {
+      await this.setActiveUser(null);
+      return;
+    }
     for (const userId in this.state.accounts) {
       if (userId == null) {
         continue;

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -2468,7 +2468,7 @@ export class StateService<
   }
 
   protected async dynamicallySetActiveUser() {
-    if (Object.keys(this.state.accounts).length < 1) {
+    if (this.state.accounts == null || Object.keys(this.state.accounts).length < 1) {
       await this.setActiveUser(null);
       return;
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Logging out in some clients is crashing because the active user is being set back to the user that was just logged out.

I'm not entirely sure when/how this started, but a simple length check on state and setting the active user to null if we don't have any options does the job of logging out successfully. 

## Code changes
* Set active userId to null if state doesn't have any users
* Use getAccount/saveAccount for account teardown functions. I don't think this has any effect on the bug, but we should be using those methods for all account access, especially with the cache addition. 


## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
