### PR TITLE
[Bug] Add validation for username and password on add new login item

### DIFF
--- a/angular/src/components/add-edit.component.ts
+++ b/angular/src/components/add-edit.component.ts
@@ -283,6 +283,36 @@ export class AddEditComponent implements OnInit {
 
     if (
       (!this.editMode || this.cloneMode) &&
+      this.cipher.type === CipherType.Login
+    ) {
+      if (
+        (
+          this.cipher.login.username == null ||
+          this.cipher.login.username === ""
+        ) &&
+        (
+          this.cipher.login.password == null ||
+          this.cipher.login.password === ""
+        )
+      ) {
+        this.platformUtilsService.showToast(
+          "error",
+          this.i18nService.t("errorOccurred"),
+          this.i18nService.t("usernamePasswordRequired")
+        );
+        return false;
+      }
+      if (
+        this.cipher.login.uris != null &&
+        this.cipher.login.uris.length === 1 &&
+        (this.cipher.login.uris[0].uri == null || this.cipher.login.uris[0].uri === "")
+      ) {
+        this.cipher.login.uris = null;
+      }
+    }
+
+    if (
+      (!this.editMode || this.cloneMode) &&
       this.cipher.type === CipherType.Login &&
       this.cipher.login.uris != null &&
       this.cipher.login.uris.length === 1 &&


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When a new Login type item is created, the form allows you to create an item with a completely empty username and password. This is why you must validate that at least one of these two fields (username or password) must be filled.

Asana task: https://app.asana.com/0/1200885895476554/1201824409517085/f
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **add-edit.component.ts:** A new condition was added inside the `submit` function, to evaluate that at least the username or password is not empty.

## Testing requirements
It must be proven that the creation or editing of a login type item can be performed correctly if and only if at least the username or password is provided and the other previously existing conditions are passed successfully.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
