### PR TITLE
[Icons] Fix sass deprecation warnings

### DIFF
--- a/angular/src/scss/bwicons/styles/style.scss
+++ b/angular/src/scss/bwicons/styles/style.scss
@@ -31,7 +31,7 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 
 // Fixed Width Icons
 .bwi-fw {
-  width: (18em / 14);
+  width: math.div(18em, 14);
   text-align: center;
 }
 
@@ -41,8 +41,8 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 }
 
 .bwi-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: math.div(4em, 3);
+  line-height: math.div(3em, 4);
   vertical-align: -15%;
 }
 
@@ -75,7 +75,7 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 // List Icons
 .bwi-ul {
   padding-left: 0;
-  margin-left: (30em / 14);
+  margin-left: math.div(30em, 14);
   list-style-type: none;
   > li {
     position: relative;
@@ -84,12 +84,12 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 
 .bwi-li {
   position: absolute;
-  left: -(30em / 14);
-  width: (30em / 14);
-  top: (2em / 14);
+  left: math.div(30em, 14) * -1;
+  width: math.div(30em, 14);
+  top: math.div(2em, 14);
   text-align: center;
   &.bwi-lg {
-    left: -(30em / 14) + (4em / 14);
+    left: (math.div(30em, 14) * -1) + math.div(4em, 14);
   }
 }
 
@@ -245,11 +245,5 @@ $icons: (
 @each $name, $glyph in $icons {
   .bwi-#{$name}:before {
     content: $glyph;
-  }
-}
-
-:export {
-  @each $name, $glyph in $icons {
-    #{$name}: $glyph;
   }
 }

--- a/angular/src/scss/bwicons/styles/style.scss
+++ b/angular/src/scss/bwicons/styles/style.scss
@@ -31,7 +31,7 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 
 // Fixed Width Icons
 .bwi-fw {
-  width: math.div(18em, 14);
+  width: calc(18em / 14);
   text-align: center;
 }
 
@@ -41,8 +41,8 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 }
 
 .bwi-lg {
-  font-size: math.div(4em, 3);
-  line-height: math.div(3em, 4);
+  font-size: calc(4em / 3);
+  line-height: calc(3em / 4);
   vertical-align: -15%;
 }
 
@@ -75,7 +75,7 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 // List Icons
 .bwi-ul {
   padding-left: 0;
-  margin-left: math.div(30em, 14);
+  margin-left: calc(30em / 14);
   list-style-type: none;
   > li {
     position: relative;
@@ -84,12 +84,12 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 
 .bwi-li {
   position: absolute;
-  left: math.div(30em, 14) * -1;
-  width: math.div(30em, 14);
-  top: math.div(2em, 14);
+  left: calc(30em / 14) * -1;
+  width: calc(30em / 14);
+  top: calc(2em / 14);
   text-align: center;
   &.bwi-lg {
-    left: (math.div(30em, 14) * -1) + math.div(4em, 14);
+    left: (calc(30em / 14) * -1) + calc(4em / 14);
   }
 }
 

--- a/angular/src/scss/bwicons/styles/style.scss
+++ b/angular/src/scss/bwicons/styles/style.scss
@@ -84,12 +84,12 @@ $icomoon-font-path: "~@bitwarden/jslib-angular/src/scss/bwicons/fonts/" !default
 
 .bwi-li {
   position: absolute;
-  left: calc(30em / 14) * -1;
+  left: calc(-30em / 14);
   width: calc(30em / 14);
   top: calc(2em / 14);
   text-align: center;
   &.bwi-lg {
-    left: (calc(30em / 14) * -1) + calc(4em / 14);
+    left: calc(-30em / 14) + calc(4em / 14);
   }
 }
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Cleanup the new `bwicons -> styles.scss` file that has deprecation warnings revolving around the use of `/` for division.  Use the `calc()` function since the `math.div` function is not available in our current version of `sass`

## Code changes
- **styles.scss:** Surrounded all division math with the `calc()` function. Removed unused `export` call

## Testing requirements
- Make sure icons using either `bwi-fw, bwi-lg, bwi-ul, bwi-li, or bwi-li & bwi-lg` still appear the same throughout the client applications (once the updated `jslib` has been applied)

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
