### PR TITLE
Clear stale everBeenUnlocked value from onDisk storage

### DIFF
--- a/common/src/enums/stateVersion.ts
+++ b/common/src/enums/stateVersion.ts
@@ -2,5 +2,6 @@ export enum StateVersion {
   One = 1, // Original flat key/value pair store
   Two = 2, // Move to a typed State object
   Three = 3, // Fix migration of users' premium status
-  Latest = Three,
+  Four = 4, // Fix 'Never Lock' option by removing stale data
+  Latest = Four,
 }

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -158,6 +158,9 @@ export class StateMigrationService<
         case StateVersion.Two:
           await this.migrateStateFrom2To3();
           break;
+        case StateVersion.Three:
+          await this.migrateStateFrom3To4();
+          break;
       }
 
       currentStateVersion += 1;
@@ -471,6 +474,22 @@ export class StateMigrationService<
 
     const globals = await this.getGlobals();
     globals.stateVersion = StateVersion.Three;
+    await this.set(keys.global, globals);
+  }
+
+  protected async migrateStateFrom3To4(): Promise<void> {
+    const authenticatedUserIds = await this.get<string[]>(keys.authenticatedAccounts);
+    await Promise.all(
+      authenticatedUserIds.map(async (userId) => {
+        const account = await this.get<TAccount>(userId);
+        if (account?.profile?.everBeenUnlocked != null) {
+          return this.set("everBeenUnlocked", null);
+        }
+      })
+    );
+
+    const globals = await this.getGlobals();
+    globals.stateVersion = StateVersion.Four;
     await this.set(keys.global, globals);
   }
 

--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -483,7 +483,8 @@ export class StateMigrationService<
       authenticatedUserIds.map(async (userId) => {
         const account = await this.get<TAccount>(userId);
         if (account?.profile?.everBeenUnlocked != null) {
-          return this.set("everBeenUnlocked", null);
+          delete account.profile.everBeenUnlocked;
+          return this.set(userId, account);
         }
       })
     );

--- a/spec/common/services/stateMigration.service.ts
+++ b/spec/common/services/stateMigration.service.ts
@@ -1,0 +1,86 @@
+import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
+
+import { StorageService } from "jslib-common/abstractions/storage.service";
+import { StateFactory } from "jslib-common/factories/stateFactory";
+
+import { StateMigrationService } from "jslib-common/services/stateMigration.service";
+
+import { Account, AccountProfile } from "jslib-common/models/domain/account";
+import { GlobalState } from "jslib-common/models/domain/globalState";
+import { StateVersion } from "jslib-common/enums/stateVersion";
+
+const userId = "USER_ID";
+
+describe("State Migration Service", () => {
+  let storageService: SubstituteOf<StorageService>;
+  let secureStorageService: SubstituteOf<StorageService>;
+  let stateFactory: SubstituteOf<StateFactory>;
+
+  let stateMigrationService: StateMigrationService;
+
+  beforeEach(() => {
+    storageService = Substitute.for<StorageService>();
+    secureStorageService = Substitute.for<StorageService>();
+    stateFactory = Substitute.for<StateFactory>();
+
+    stateMigrationService = new StateMigrationService(
+      storageService,
+      secureStorageService,
+      stateFactory
+    );
+  });
+
+  describe("StateVersion 3 to 4 migration", async () => {
+    beforeEach(() => {
+      const globalVersion3: Partial<GlobalState> = {
+        stateVersion: StateVersion.Three,
+      };
+
+      storageService.get("global", Arg.any()).resolves(globalVersion3);
+      storageService.get("authenticatedAccounts", Arg.any()).resolves([userId]);
+    });
+
+    it("clears everBeenUnlocked", async () => {
+      const accountVersion3: Account = {
+        profile: {
+          apiKeyClientId: null,
+          convertAccountToKeyConnector: null,
+          email: "EMAIL",
+          emailVerified: true,
+          everBeenUnlocked: true,
+          hasPremiumPersonally: false,
+          kdfIterations: 100000,
+          kdfType: 0,
+          keyHash: "KEY_HASH",
+          lastSync: "LAST_SYNC",
+          userId: userId,
+          usesKeyConnector: false,
+          forcePasswordReset: false,
+        },
+      };
+
+      const expectedAccountVersion4: Account = {
+        profile: {
+          ...accountVersion3.profile,
+        },
+      };
+      delete expectedAccountVersion4.profile.everBeenUnlocked;
+
+      storageService.get(userId, Arg.any()).resolves(accountVersion3);
+
+      await stateMigrationService.migrate();
+
+      storageService.received(1).save(userId, expectedAccountVersion4, Arg.any());
+    });
+
+    it("updates StateVersion number", async () => {
+      await stateMigrationService.migrate();
+
+      storageService.received(1).save(
+        "global",
+        Arg.is((globals: GlobalState) => globals.stateVersion === StateVersion.Four),
+        Arg.any()
+      );
+    });
+  });
+});

--- a/spec/common/services/stateMigration.service.ts
+++ b/spec/common/services/stateMigration.service.ts
@@ -1,12 +1,14 @@
 import { Arg, Substitute, SubstituteOf } from "@fluffy-spoon/substitute";
 
 import { StorageService } from "jslib-common/abstractions/storage.service";
-import { StateFactory } from "jslib-common/factories/stateFactory";
 
 import { StateMigrationService } from "jslib-common/services/stateMigration.service";
 
-import { Account, AccountProfile } from "jslib-common/models/domain/account";
+import { StateFactory } from "jslib-common/factories/stateFactory";
+
+import { Account } from "jslib-common/models/domain/account";
 import { GlobalState } from "jslib-common/models/domain/globalState";
+
 import { StateVersion } from "jslib-common/enums/stateVersion";
 
 const userId = "USER_ID";


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix bitwarden/browser#2337, for real this time.

The previous fix (https://github.com/bitwarden/jslib/pull/667) moved the `everBeenUnlocked` key from onDisk to inMemory storage.

However, `stateService.init()` loads the onDisk values into memory on startup. If the old onDisk value is left behind, it'll be loaded into memory, and that will continue to be used as the `everBeenUnlocked` value. The defect persists until users clear local storage.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Add another `StateVersion` migration, following a similar pattern as #666.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
