### PR TITLE
Save localData to local storage instead of in memory

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -1613,16 +1613,19 @@ export class StateService<
   }
 
   async getLocalData(options?: StorageOptions): Promise<any> {
-    return (await this.getAccount(this.reconcileOptions(options, this.defaultInMemoryOptions)))
-      ?.data?.localData;
+    return (
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.data?.localData;
   }
-
   async setLocalData(value: string, options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
-      this.reconcileOptions(options, this.defaultInMemoryOptions)
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
     account.data.localData = value;
-    await this.saveAccount(account, this.reconcileOptions(options, this.defaultInMemoryOptions));
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
   }
 
   async getLocale(options?: StorageOptions): Promise<string> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When a user has multiple logins for the same site, the list is sorted by the lastUsedDate on the localData state object.
This was formerly saved to local storage, so it was persisted across browser restarts. With the state service refactor, this was moved to memory storage, which is wiped when the browser is restarted.

I checked to see what other items are save to the localData object so I don't break anything with this change, and it appears that lastUsedDate and lastLaunched are the only data items saved to it so I think we are fine here.

## Code changes

- **common/src/services/state.service.ts:** Get and save localData to local storage instead of in memory

## Testing requirements

Use autofill for a site that the account has multiple logins for, then quit the browser. Open the browser again and verify that the last item autofilled is the login used to autofill the login form.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
