### PR TITLE
fix infinite recursion on getEncKey

### DIFF
--- a/common/src/services/crypto.service.ts
+++ b/common/src/services/crypto.service.ts
@@ -158,41 +158,8 @@ export class CryptoService implements CryptoServiceAbstraction {
   }
 
   @sequentialize(() => "getEncKey")
-  async getEncKey(key: SymmetricCryptoKey = null): Promise<SymmetricCryptoKey> {
-    const inMemoryKey = await this.stateService.getDecryptedCryptoSymmetricKey();
-    if (inMemoryKey != null) {
-      return inMemoryKey;
-    }
-
-    const encKey = await this.stateService.getEncryptedCryptoSymmetricKey();
-    if (encKey == null) {
-      return null;
-    }
-
-    if (key == null) {
-      key = await this.getKey();
-    }
-    if (key == null) {
-      return null;
-    }
-
-    let decEncKey: ArrayBuffer;
-    const encKeyCipher = new EncString(encKey);
-    if (encKeyCipher.encryptionType === EncryptionType.AesCbc256_B64) {
-      decEncKey = await this.decryptToBytes(encKeyCipher, key);
-    } else if (encKeyCipher.encryptionType === EncryptionType.AesCbc256_HmacSha256_B64) {
-      const newKey = await this.stretchKey(key);
-      decEncKey = await this.decryptToBytes(encKeyCipher, newKey);
-    } else {
-      throw new Error("Unsupported encKey type.");
-    }
-
-    if (decEncKey == null) {
-      return null;
-    }
-    const symmetricCryptoKey = new SymmetricCryptoKey(decEncKey);
-    await this.stateService.setDecryptedCryptoSymmetricKey(symmetricCryptoKey);
-    return symmetricCryptoKey;
+  getEncKey(key: SymmetricCryptoKey = null): Promise<SymmetricCryptoKey> {
+    return this.getEncKeyHelper(key);
   }
 
   async getPublicKey(): Promise<ArrayBuffer> {
@@ -747,7 +714,7 @@ export class CryptoService implements CryptoServiceAbstraction {
   async validateKey(key: SymmetricCryptoKey) {
     try {
       const encPrivateKey = await this.stateService.getEncryptedPrivateKey();
-      const encKey = await this.getEncKey(key);
+      const encKey = await this.getEncKeyHelper(key);
       if (encPrivateKey == null || encKey == null) {
         return false;
       }
@@ -966,5 +933,41 @@ export class CryptoService implements CryptoServiceAbstraction {
   private async clearSecretKeyStore(userId?: string): Promise<void> {
     await this.stateService.setCryptoMasterKeyAuto(null, { userId: userId });
     await this.stateService.setCryptoMasterKeyBiometric(null, { userId: userId });
+  }
+
+  private async getEncKeyHelper(key: SymmetricCryptoKey = null): Promise<SymmetricCryptoKey> {
+    const inMemoryKey = await this.stateService.getDecryptedCryptoSymmetricKey();
+    if (inMemoryKey != null) {
+      return inMemoryKey;
+    }
+
+    const encKey = await this.stateService.getEncryptedCryptoSymmetricKey();
+    if (encKey == null) {
+      return null;
+    }
+
+    if (key == null) {
+      key = await this.getKey();
+    }
+    if (key == null) {
+      return null;
+    }
+
+    let decEncKey: ArrayBuffer;
+    const encKeyCipher = new EncString(encKey);
+    if (encKeyCipher.encryptionType === EncryptionType.AesCbc256_B64) {
+      decEncKey = await this.decryptToBytes(encKeyCipher, key);
+    } else if (encKeyCipher.encryptionType === EncryptionType.AesCbc256_HmacSha256_B64) {
+      const newKey = await this.stretchKey(key);
+      decEncKey = await this.decryptToBytes(encKeyCipher, newKey);
+    } else {
+      throw new Error("Unsupported encKey type.");
+    }
+    if (decEncKey == null) {
+      return null;
+    }
+    const symmetricCryptoKey = new SymmetricCryptoKey(decEncKey);
+    await this.stateService.setDecryptedCryptoSymmetricKey(symmetricCryptoKey);
+    return symmetricCryptoKey;
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Allow new `bw serve` command to work without getting stuck in an infinite recursion loop.

It's still not clear to be with this only happens when running the new `bw serve` CLI command. Perhaps because all other clients are preceded by an unlock function of some sort.

## Code changes

Moved `getEncKey()` functionality out to a private helper so that the `sequentialize()` decorator does not try to parallelize the call when coming from other internal functions such as `validateKey()`.

## Testing requirements

No behavior to test here other than ensure we do not lose the performance boost of  `getEncKey()` being sequentialized in other areas of the code, such as vault decryption.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
