### PR TITLE
[feature] Implement scope warning for exports

### DIFF
--- a/angular/src/components/export-scope-callout.component.html
+++ b/angular/src/components/export-scope-callout.component.html
@@ -1,0 +1,5 @@
+<ng-container *ngIf="show">
+  <app-callout type="info" title="{{ scopeConfig.title | i18n }}">
+    {{ scopeConfig.description | i18n: scopeConfig.scopeIdentifier }}
+  </app-callout>
+</ng-container>

--- a/angular/src/components/export-scope-callout.component.ts
+++ b/angular/src/components/export-scope-callout.component.ts
@@ -26,7 +26,6 @@ export class ExportScopeCalloutComponent implements OnInit {
     if (!(await this.organizationService.hasOrganizations())) {
       return;
     }
-    this.show = true;
     this.scopeConfig =
       this.organizationId != null
         ? {
@@ -39,5 +38,6 @@ export class ExportScopeCalloutComponent implements OnInit {
             description: "exportingPersonalVaultDescription",
             scopeIdentifier: await this.stateService.getEmail(),
           };
+    this.show = true;
   }
 }

--- a/angular/src/components/export-scope-callout.component.ts
+++ b/angular/src/components/export-scope-callout.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnInit } from "@angular/core";
+
+import { OrganizationService } from "jslib-common/abstractions/organization.service";
+import { StateService } from "jslib-common/abstractions/state.service";
+
+@Component({
+  selector: "app-export-scope-callout",
+  templateUrl: "export-scope-callout.component.html",
+})
+export class ExportScopeCalloutComponent implements OnInit {
+  @Input() organizationId: string = null;
+
+  show: boolean = false;
+  scopeConfig: {
+    title: string;
+    description: string;
+    scopeIdentifier: string;
+  };
+
+  constructor(
+    protected organizationService: OrganizationService,
+    protected stateService: StateService
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+    if (!(await this.organizationService.hasOrganizations())) {
+      return;
+    }
+    this.show = true;
+    this.scopeConfig =
+      this.organizationId != null
+        ? {
+            title: "exportingOrganizationVaultTitle",
+            description: "exportingOrganizationVaultDescription",
+            scopeIdentifier: (await this.organizationService.get(this.organizationId)).name,
+          }
+        : {
+            title: "exportingPersonalVaultTitle",
+            description: "exportingPersonalVaultDescription",
+            scopeIdentifier: await this.stateService.getEmail(),
+          };
+  }
+}

--- a/common/src/abstractions/organization.service.ts
+++ b/common/src/abstractions/organization.service.ts
@@ -8,4 +8,5 @@ export abstract class OrganizationService {
   getAll: (userId?: string) => Promise<Organization[]>;
   save: (orgs: { [id: string]: OrganizationData }) => Promise<any>;
   canManageSponsorships: () => Promise<boolean>;
+  hasOrganizations: (userId?: string) => Promise<boolean>;
 }

--- a/common/src/services/organization.service.ts
+++ b/common/src/services/organization.service.ts
@@ -47,4 +47,9 @@ export class OrganizationService implements OrganizationServiceAbstraction {
       (o) => o.familySponsorshipAvailable || o.familySponsorshipFriendlyName !== null
     );
   }
+
+  async hasOrganizations(userId?: string): Promise<boolean> {
+    const organizations = await this.getAll(userId);
+    return organizations.length > 0;
+  }
 }


### PR DESCRIPTION
https://app.asana.com/0/1183359552741420/1200074829339233

## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Exports are often confusing to users in organizations because there is no indication on screen that a personal export won't include organization items and vice versa. We should add an information panel to this screen noting what exactly is being exported.

## Code changes
- **organization.service:** Added a `hasOrganizations()` method.
- **export-scope-callout.component:** Created this component to be used in client `export.component` templates.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
