### PR TITLE
[bug] Store collapsedGroupings in accountSettings

### DIFF
--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -51,7 +51,6 @@ export class AccountData {
     GeneratedPasswordHistory[]
   > = new EncryptionPair<GeneratedPasswordHistory[], GeneratedPasswordHistory[]>();
   addEditCipherInfo?: any;
-  collapsedGroupings?: string[];
   eventCollection?: EventData[];
   organizations?: { [id: string]: OrganizationData };
   providers?: { [id: string]: ProviderData };
@@ -105,6 +104,7 @@ export class AccountSettings {
   biometricLocked?: boolean;
   biometricUnlock?: boolean;
   clearClipboard?: number;
+  collapsedGroupings?: string[];
   defaultUriMatch?: UriMatchType;
   disableAddLoginNotification?: boolean;
   disableAutoBiometricsPrompt?: boolean;

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -383,14 +383,14 @@ export class StateService<
   async getCollapsedGroupings(options?: StorageOptions): Promise<string[]> {
     return (
       await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.data?.collapsedGroupings;
+    )?.settings?.collapsedGroupings;
   }
 
   async setCollapsedGroupings(value: string[], options?: StorageOptions): Promise<void> {
     const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
-    account.data.collapsedGroupings = value;
+    account.settings.collapsedGroupings = value;
     await this.saveAccount(
       account,
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())


### PR DESCRIPTION
https://app.asana.com/0/1169444489336079/1201880324649413

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Move collapsedGroupings to accountSettings, which is not cleared on logout or during login scaffolding. 

## Code changes
* Move collapsedGroupings to accountSettings in the Account model and reference it correctly in StateService get/set functions.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
