### PR TITLE
Fix v1 migration of providerKeys and orgKeys

### DIFF
--- a/common/src/services/stateMigration.service.ts
+++ b/common/src/services/stateMigration.service.ts
@@ -373,7 +373,7 @@ export class StateMigrationService<
         legacyEtmKey: null,
         organizationKeys: {
           decrypted: null,
-          encrypted: await this.get<any>(v1Keys.encOrgKeys + userId),
+          encrypted: await this.get<any>(v1Keys.encOrgKeys),
         },
         privateKey: {
           decrypted: null,
@@ -381,7 +381,7 @@ export class StateMigrationService<
         },
         providerKeys: {
           decrypted: null,
-          encrypted: await this.get<any>(v1Keys.encProviderKeys + userId),
+          encrypted: await this.get<any>(v1Keys.encProviderKeys),
         },
         publicKey: null,
       },


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix https://github.com/bitwarden/cli/issues/490.

`encOrgKeys` are never migrated properly because `stateMigrationService` does not reference the correct storage key - it incorrectly appends the `userId` to the storage key. This means that org items cannot be decrypted in CLI after an upgrade. I assume that other clients hid this issue by syncing to get account keys, whereas CLI is less automatic in this respect.

For reference, here's the `setOrgKeys` method immediately before account switching was merged. Note the lack of userId suffix: https://github.com/bitwarden/jslib/blob/8fc3cf50d2967212ffbbf0d57cac71d0774aa2a8/common/src/services/crypto.service.ts#L97

The migration of provider enc keys also follow this pattern, and I also note that the pre-account switching logic doesn't have this suffix (although I haven't tested this one): https://github.com/bitwarden/jslib/blob/8fc3cf50d2967212ffbbf0d57cac71d0774aa2a8/common/src/services/crypto.service.ts#L107

This will not help users who have already upgraded (I believe the migration clears the old v0 data, so it's gone), but will fix the issue for any late upgraders.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Remove userId suffixes when fetching v0 org and provider keys.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
1. Use an account with access to organization items
2. Follow the upgrade path from pre-account switching to post-account switching. 
3. Confirm that all org items are available after the upgrade. Especially for CLI where this bug was first reported.

Repeat the above as a provider user who only has access to an org via their provider.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
