### PR TITLE
Fix autoFillOnPageLoadDefault default value

### DIFF
--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -100,7 +100,7 @@ export class AccountProfile {
 
 export class AccountSettings {
   autoConfirmFingerPrints?: boolean;
-  autoFillOnPageLoadDefault?: boolean;
+  autoFillOnPageLoadDefault?: boolean = true;
   biometricLocked?: boolean;
   biometricUnlock?: boolean;
   clearClipboard?: number;
@@ -116,7 +116,7 @@ export class AccountSettings {
   dontShowCardsCurrentTab?: boolean;
   dontShowIdentitiesCurrentTab?: boolean;
   enableAlwaysOnTop?: boolean;
-  enableAutoFillOnPageLoad?: boolean;
+  enableAutoFillOnPageLoad?: boolean = false;
   enableBiometric?: boolean;
   enableFullWidth?: boolean;
   enableGravitars?: boolean;

--- a/common/src/models/domain/account.ts
+++ b/common/src/models/domain/account.ts
@@ -100,7 +100,7 @@ export class AccountProfile {
 
 export class AccountSettings {
   autoConfirmFingerPrints?: boolean;
-  autoFillOnPageLoadDefault?: boolean = true;
+  autoFillOnPageLoadDefault?: boolean;
   biometricLocked?: boolean;
   biometricUnlock?: boolean;
   clearClipboard?: number;
@@ -116,7 +116,7 @@ export class AccountSettings {
   dontShowCardsCurrentTab?: boolean;
   dontShowIdentitiesCurrentTab?: boolean;
   enableAlwaysOnTop?: boolean;
-  enableAutoFillOnPageLoad?: boolean = false;
+  enableAutoFillOnPageLoad?: boolean;
   enableBiometric?: boolean;
   enableFullWidth?: boolean;
   enableGravitars?: boolean;

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -231,7 +231,7 @@ export class StateService<
   async getAutoFillOnPageLoadDefault(options?: StorageOptions): Promise<boolean> {
     return (
       (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.autoFillOnPageLoadDefault ?? false
+        ?.settings?.autoFillOnPageLoadDefault ?? true
     );
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix https://github.com/bitwarden/browser/issues/2400.

`autoFillOnPageLoadDefault` should default to true if it's not explicitly set. Note that this is the default per-item autofill setting - it still won't do anything unless `enableAutoFillOnPageLoad` is true (to enable the feature in general).

The intention was always to replicate the previous behaviour, where once Autofill On Page Load was enabled, all items would autofill by default unless configured otherwise.

Luckily this does not appear to be a migration issue as such, any saved value should still have been migrated, we just need to handle the `null` case.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Change default value if null.

## Testing requirements

* use browser client on a fresh install (no saved data)
* log in
* confirm that Settings > Options are:
  * Enable Auto-Fill On Page Load: `false`
  * Default autofill setting for login items: `Auto-fill on page load`
* brief regression test to make sure the actual autofill behaviour follows these settings

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
