### PR TITLE
[Captcha] Failed login attempts

### DIFF
--- a/common/src/abstractions/auth.service.ts
+++ b/common/src/abstractions/auth.service.ts
@@ -13,7 +13,10 @@ export abstract class AuthService {
   logIn: (
     credentials: ApiLogInCredentials | PasswordLogInCredentials | SsoLogInCredentials
   ) => Promise<AuthResult>;
-  logInTwoFactor: (twoFactor: TokenRequestTwoFactor) => Promise<AuthResult>;
+  logInTwoFactor: (
+    twoFactor: TokenRequestTwoFactor,
+    captchaResponse: string
+  ) => Promise<AuthResult>;
   logOut: (callback: () => void) => void;
   makePreloginKey: (masterPassword: string, email: string) => Promise<SymmetricCryptoKey>;
   authingWithApiKey: () => boolean;

--- a/common/src/misc/logInStrategies/logIn.strategy.ts
+++ b/common/src/misc/logInStrategies/logIn.strategy.ts
@@ -27,7 +27,7 @@ import { IdentityTwoFactorResponse } from "../../models/response/identityTwoFact
 
 export abstract class LogInStrategy {
   protected abstract tokenRequest: ApiTokenRequest | PasswordTokenRequest | SsoTokenRequest;
-  protected bypassToken: string = null;
+  protected captchaBypassToken: string = null;
 
   constructor(
     protected cryptoService: CryptoService,
@@ -47,7 +47,7 @@ export abstract class LogInStrategy {
 
   async logInTwoFactor(
     twoFactor: TokenRequestTwoFactor,
-    captchaResponse: string
+    captchaResposne: string = null
   ): Promise<AuthResult> {
     this.tokenRequest.setTwoFactor(twoFactor);
     return this.startLogIn();
@@ -156,7 +156,7 @@ export abstract class LogInStrategy {
     const result = new AuthResult();
     result.twoFactorProviders = response.twoFactorProviders2;
     this.twoFactorService.setProviders(response);
-    this.bypassToken = response.captchaToken != null ? response.captchaToken : null;
+    this.captchaBypassToken = response.captchaToken ?? null;
     return result;
   }
 

--- a/common/src/misc/logInStrategies/logIn.strategy.ts
+++ b/common/src/misc/logInStrategies/logIn.strategy.ts
@@ -47,7 +47,7 @@ export abstract class LogInStrategy {
 
   async logInTwoFactor(
     twoFactor: TokenRequestTwoFactor,
-    captchaResposne: string = null
+    captchaResponse: string = null
   ): Promise<AuthResult> {
     this.tokenRequest.setTwoFactor(twoFactor);
     return this.startLogIn();

--- a/common/src/misc/logInStrategies/logIn.strategy.ts
+++ b/common/src/misc/logInStrategies/logIn.strategy.ts
@@ -27,6 +27,7 @@ import { IdentityTwoFactorResponse } from "../../models/response/identityTwoFact
 
 export abstract class LogInStrategy {
   protected abstract tokenRequest: ApiTokenRequest | PasswordTokenRequest | SsoTokenRequest;
+  protected bypassToken: string = null;
 
   constructor(
     protected cryptoService: CryptoService,
@@ -44,7 +45,10 @@ export abstract class LogInStrategy {
     credentials: ApiLogInCredentials | PasswordLogInCredentials | SsoLogInCredentials
   ): Promise<AuthResult>;
 
-  async logInTwoFactor(twoFactor: TokenRequestTwoFactor): Promise<AuthResult> {
+  async logInTwoFactor(
+    twoFactor: TokenRequestTwoFactor,
+    captchaResponse: string
+  ): Promise<AuthResult> {
     this.tokenRequest.setTwoFactor(twoFactor);
     return this.startLogIn();
   }
@@ -152,6 +156,7 @@ export abstract class LogInStrategy {
     const result = new AuthResult();
     result.twoFactorProviders = response.twoFactorProviders2;
     this.twoFactorService.setProviders(response);
+    this.bypassToken = response.captchaToken != null ? response.captchaToken : null;
     return result;
   }
 

--- a/common/src/misc/logInStrategies/passwordLogin.strategy.ts
+++ b/common/src/misc/logInStrategies/passwordLogin.strategy.ts
@@ -65,8 +65,8 @@ export class PasswordLogInStrategy extends LogInStrategy {
     twoFactor: TokenRequestTwoFactor,
     captchaResponse: string
   ): Promise<AuthResult> {
-    this.tokenRequest.captchaResponse = captchaResponse ?? this.bypassToken;
-    return super.logInTwoFactor(twoFactor, captchaResponse);
+    this.tokenRequest.captchaResponse = captchaResponse ?? this.captchaBypassToken;
+    return super.logInTwoFactor(twoFactor);
   }
 
   async logIn(credentials: PasswordLogInCredentials) {

--- a/common/src/misc/logInStrategies/passwordLogin.strategy.ts
+++ b/common/src/misc/logInStrategies/passwordLogin.strategy.ts
@@ -9,9 +9,11 @@ import { StateService } from "../../abstractions/state.service";
 import { TokenService } from "../../abstractions/token.service";
 import { TwoFactorService } from "../../abstractions/twoFactor.service";
 import { HashPurpose } from "../../enums/hashPurpose";
+import { AuthResult } from "../../models/domain/authResult";
 import { PasswordLogInCredentials } from "../../models/domain/logInCredentials";
 import { SymmetricCryptoKey } from "../../models/domain/symmetricCryptoKey";
 import { PasswordTokenRequest } from "../../models/request/identityToken/passwordTokenRequest";
+import { TokenRequestTwoFactor } from "../../models/request/identityToken/tokenRequest";
 
 import { LogInStrategy } from "./logIn.strategy";
 
@@ -57,6 +59,14 @@ export class PasswordLogInStrategy extends LogInStrategy {
   async onSuccessfulLogin() {
     await this.cryptoService.setKey(this.key);
     await this.cryptoService.setKeyHash(this.localHashedPassword);
+  }
+
+  async logInTwoFactor(
+    twoFactor: TokenRequestTwoFactor,
+    captchaResponse: string
+  ): Promise<AuthResult> {
+    this.tokenRequest.captchaResponse = captchaResponse ?? this.bypassToken;
+    return super.logInTwoFactor(twoFactor, captchaResponse);
   }
 
   async logIn(credentials: PasswordLogInCredentials) {

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -16,6 +16,7 @@ import { KdfType } from "../enums/kdfType";
 import { ApiLogInStrategy } from "../misc/logInStrategies/apiLogin.strategy";
 import { PasswordLogInStrategy } from "../misc/logInStrategies/passwordLogin.strategy";
 import { SsoLogInStrategy } from "../misc/logInStrategies/ssoLogin.strategy";
+import { Utils } from "../misc/utils";
 import { AuthResult } from "../models/domain/authResult";
 import {
   ApiLogInCredentials,
@@ -115,16 +116,19 @@ export class AuthService implements AuthServiceAbstraction {
     return result;
   }
 
-  async logInTwoFactor(twoFactor: TokenRequestTwoFactor): Promise<AuthResult> {
+  async logInTwoFactor(
+    twoFactor: TokenRequestTwoFactor,
+    captchaResponse: string
+  ): Promise<AuthResult> {
     if (this.logInStrategy == null) {
       throw new Error(this.i18nService.t("sessionTimeout"));
     }
 
     try {
-      const result = await this.logInStrategy.logInTwoFactor(twoFactor);
+      const result = await this.logInStrategy.logInTwoFactor(twoFactor, captchaResponse);
 
       // Only clear state if 2FA token has been accepted, otherwise we need to be able to try again
-      if (!result.requiresTwoFactor) {
+      if (!result.requiresTwoFactor && Utils.isNullOrWhitespace(result.captchaSiteKey)) {
         this.clearState();
       }
       return result;

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -16,7 +16,6 @@ import { KdfType } from "../enums/kdfType";
 import { ApiLogInStrategy } from "../misc/logInStrategies/apiLogin.strategy";
 import { PasswordLogInStrategy } from "../misc/logInStrategies/passwordLogin.strategy";
 import { SsoLogInStrategy } from "../misc/logInStrategies/ssoLogin.strategy";
-import { Utils } from "../misc/utils";
 import { AuthResult } from "../models/domain/authResult";
 import {
   ApiLogInCredentials,

--- a/common/src/services/auth.service.ts
+++ b/common/src/services/auth.service.ts
@@ -128,7 +128,7 @@ export class AuthService implements AuthServiceAbstraction {
       const result = await this.logInStrategy.logInTwoFactor(twoFactor, captchaResponse);
 
       // Only clear state if 2FA token has been accepted, otherwise we need to be able to try again
-      if (!result.requiresTwoFactor && Utils.isNullOrWhitespace(result.captchaSiteKey)) {
+      if (!result.requiresTwoFactor && !result.requiresCaptcha) {
         this.clearState();
       }
       return result;

--- a/spec/common/misc/logInStrategies/logIn.strategy.spec.ts
+++ b/spec/common/misc/logInStrategies/logIn.strategy.spec.ts
@@ -267,11 +267,14 @@ describe("LogInStrategy", () => {
 
       apiService.postIdentityToken(Arg.any()).resolves(identityTokenResponseFactory());
 
-      await passwordLogInStrategy.logInTwoFactor({
-        provider: twoFactorProviderType,
-        token: twoFactorToken,
-        remember: twoFactorRemember,
-      });
+      await passwordLogInStrategy.logInTwoFactor(
+        {
+          provider: twoFactorProviderType,
+          token: twoFactorToken,
+          remember: twoFactorRemember,
+        },
+        null
+      );
 
       apiService.received(1).postIdentityToken(
         Arg.is((actual) => {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix issue with captcha bypass token received on the `login` component being persisted during the 2fa flow
> Expand the current implementation to allow for captcha to be collected on the `two-factor` component and passed along to through the auth flow
> Update `cli - login.command` to handle captcha bypass and collection during the `2fa` flow

## Code changes
- **two-factor.component:** Extended `CaptchaProtectedComponent` and applied the setup, response handling, and passing of the `captchaResponse` into the the `logInTwoFactor` call
- **(abstraction/service)auth.service:** Updated `logInTwoFactor` method to take a passed in `captchaResponse`. Updated the state clearing to allow for captcha responses triggered from failed `2fa` attempts.
- **logInStrategy.ts**: Base class - extended the `logInTwoFactor` method to allow a passed in `captchaResponse`. Created a `bypassToken` variable that is set while processing the response of a `IdentityTwoFactorResponse` and is persisted through the `login -> 2fa` flow. The variable is contained within the strategy state and is cleared once a successful login occurs. This fixes the bug introduced from the `AuthService` refactor.
- **passwordLoginStrategy.ts**: Override the `logInTwoFactor` method in order to update the request token based on the presence of either 1) a passed in `captchaResponse` or 2) a persisted `bypassToken` that was received in a previous step.
- **cli/login.command.ts**: Added the functionality to handle a captcha response during the `2fa` flow. Restructured/organized all captcha handling code into one method that returns a `tuple` of data (in order to keep the exact same flow as is currently implemented). 

## Testing requirements
- Continual regression of all things related to the `AuthService` refactor (login, 2fa, sso login, api key login, captcha)
- Specific test case: Login -> Captcha Required -> Successful Captcha -> Complete login
- Specific test case: Login -> Captcha Required -> Successful Captcha -> 2fa (incorrect/correct 2fa tokens) -> Complete login
- Specific test case: Login -> 2fa required -> Captcha Required -> Successful Captcha -> Complete login

## Dependency
[Server - Captcha failed auth attempts ceiling](https://github.com/bitwarden/server/pull/1870)

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [X] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
