### PR TITLE
Roll back organizationId and collectionId's if ciphers fail to be moved

### DIFF
--- a/common/src/services/cipher.service.ts
+++ b/common/src/services/cipher.service.ts
@@ -657,7 +657,15 @@ export class CipherService implements CipherServiceAbstraction {
     }
     await Promise.all(promises);
     const request = new CipherBulkShareRequest(encCiphers, collectionIds);
-    await this.apiService.putShareCiphers(request);
+    try {
+      await this.apiService.putShareCiphers(request);
+    } catch (e) {
+      for (const cipher of ciphers) {
+        cipher.organizationId = null;
+        cipher.collectionIds = null;
+      }
+      throw e;
+    }
     const userId = await this.stateService.getUserId();
     await this.upsert(encCiphers.map((c) => c.toCipherData(userId)));
   }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
While working on [this](https://github.com/bitwarden/server/pull/1890), I noticed that if a bulk share action fails, the items in the cipher view are updated to show that they transferred to the organization even though they were not. 

The items in the vault that were attempted to be shared are then in this state until a sync is performed or the vault is refreshed.

## Code changes

- **common/src/services/cipher.service.ts:** Add try catch that reverts setting of items `organizationId` and `collectionIds` properties if the api call fails.

## Testing requirements

Make sure that if an item fails to share to an organization (e.g. has attachments and is sent to a free org)

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
