### PR TITLE
[bug] Set proper default for autoConfirmFingerprint

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -213,7 +213,7 @@ export class StateService<
   async getAutoConfirmFingerPrints(options?: StorageOptions): Promise<boolean> {
     return (
       (await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskOptions())))
-        ?.settings?.autoConfirmFingerPrints ?? true
+        ?.settings?.autoConfirmFingerPrints ?? false
     );
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Bug
Organization fingerprint confirmation dialogues are not appearing.

## Code changes
Use the correct default, `false`, for `autoConfirmFingerprint`. The value should only be true if manually set that way by a user.

## Screenshots
https://user-images.githubusercontent.com/15897251/156610109-bf910854-8d2c-4b38-9645-05a39ef5b7a7.mov

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
