### PR TITLE
[bug] Delete stored keys if passed in value is null

### DIFF
--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -446,7 +446,7 @@ export class StateService<
     if (options?.userId == null) {
       return;
     }
-    await this.secureStorageService.save(`${options.userId}${partialKeys.autoKey}`, value, options);
+    await this.saveSecureStorageKey(partialKeys.autoKey, value, options);
   }
 
   async getCryptoMasterKeyB64(options?: StorageOptions): Promise<string> {
@@ -465,11 +465,7 @@ export class StateService<
     if (options?.userId == null) {
       return;
     }
-    await this.secureStorageService.save(
-      `${options.userId}${partialKeys.masterKey}`,
-      value,
-      options
-    );
+    await this.saveSecureStorageKey(partialKeys.masterKey, value, options);
   }
 
   async getCryptoMasterKeyBiometric(options?: StorageOptions): Promise<string> {
@@ -508,11 +504,7 @@ export class StateService<
     if (options?.userId == null) {
       return;
     }
-    await this.secureStorageService.save(
-      `${options.userId}${partialKeys.biometricKey}`,
-      value,
-      options
-    );
+    await this.saveSecureStorageKey(partialKeys.biometricKey, value, options);
   }
 
   async getDecodedToken(options?: StorageOptions): Promise<any> {
@@ -2501,5 +2493,11 @@ export class StateService<
         ? this.defaultInMemoryOptions
         : await this.defaultOnDiskOptions();
     return this.reconcileOptions(options, defaultOptions);
+  }
+
+  private async saveSecureStorageKey(key: string, value: string, options?: StorageOptions) {
+    return value == null
+      ? await this.secureStorageService.remove(`${options.userId}${key}`, options)
+      : await this.secureStorageService.save(`${options.userId}${key}`, value, options);
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We aren't completely removing keytar keys right now, and instead are just nulling out values. We should be completely cleaning up those keys if they are set to null, like on logout..

## Code changes
To achieve this I checked for a null value on any secure storage set operations and used the `remove` method instead of `save` if the passed in value is null.

## Screenshots

https://user-images.githubusercontent.com/15897251/156616575-2409e877-056a-497f-bc77-930cb9e24026.mov



## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
