### PR TITLE
Fixes and improvements to MykiCsvImporter

### DIFF
--- a/common/src/importers/mykiCsvImporter.ts
+++ b/common/src/importers/mykiCsvImporter.ts
@@ -58,7 +58,6 @@ export class MykiCsvImporter extends BaseImporter implements Importer {
         cipher.secureNote = new SecureNoteView();
         cipher.type = CipherType.SecureNote;
         cipher.secureNote.type = SecureNoteType.Generic;
-        cipher.name = this.getValueOrDefault(value.title, "--");
         cipher.notes = this.getValueOrDefault(value.content);
       } else {
         return;

--- a/common/src/importers/mykiCsvImporter.ts
+++ b/common/src/importers/mykiCsvImporter.ts
@@ -32,6 +32,7 @@ const _mappedIdentityColumns = new Set(
   ])
 );
 
+const _mappedIdCardColumns = new Set(mappedBaseColumns.concat(["idName", "idNumber", "idCountry"]));
 const _mappedTwoFaColumns = new Set(mappedBaseColumns.concat(["authToken"]));
 
 const _mappedUserNoteColumns = new Set(mappedBaseColumns.concat(["content"]));
@@ -92,6 +93,18 @@ export class MykiCsvImporter extends BaseImporter implements Importer {
         cipher.identity.postalCode = this.getValueOrDefault(value.zipCode);
 
         this.importUnmappedFields(cipher, value, _mappedIdentityColumns);
+      } else if (value.idType !== undefined) {
+        // IdCards
+        cipher.identity = new IdentityView();
+        cipher.type = CipherType.Identity;
+        this.processFullName(cipher, value.idName);
+
+        // TODO set number depending on idType (licenseNumber, ssn, passportNumber)
+        cipher.identity.licenseNumber = value.idNumber;
+
+        cipher.identity.country = this.getValueOrDefault(value.idCountry);
+
+        this.importUnmappedFields(cipher, value, _mappedIdCardColumns);
       } else if (value.content !== undefined) {
         // Notes
         cipher.secureNote = new SecureNoteView();

--- a/common/src/importers/mykiCsvImporter.ts
+++ b/common/src/importers/mykiCsvImporter.ts
@@ -28,6 +28,9 @@ export class MykiCsvImporter extends BaseImporter implements Importer {
         cipher.login.username = this.getValueOrDefault(value.username);
         cipher.login.password = this.getValueOrDefault(value.password);
         cipher.login.totp = this.getValueOrDefault(value.twofaSecret);
+      } else if (value.authToken !== undefined) {
+        // TwoFA
+        cipher.login.totp = this.getValueOrDefault(value.authToken);
       } else if (value.cardNumber !== undefined) {
         // Cards
         cipher.card = new CardView();

--- a/common/src/importers/mykiCsvImporter.ts
+++ b/common/src/importers/mykiCsvImporter.ts
@@ -33,6 +33,7 @@ const _mappedIdentityColumns = new Set(
 );
 
 const _mappedIdCardColumns = new Set(mappedBaseColumns.concat(["idName", "idNumber", "idCountry"]));
+
 const _mappedTwoFaColumns = new Set(mappedBaseColumns.concat(["authToken"]));
 
 const _mappedUserNoteColumns = new Set(mappedBaseColumns.concat(["content"]));
@@ -95,14 +96,35 @@ export class MykiCsvImporter extends BaseImporter implements Importer {
         this.importUnmappedFields(cipher, value, _mappedIdentityColumns);
       } else if (value.idType !== undefined) {
         // IdCards
+
         cipher.identity = new IdentityView();
         cipher.type = CipherType.Identity;
         this.processFullName(cipher, value.idName);
-
-        // TODO set number depending on idType (licenseNumber, ssn, passportNumber)
-        cipher.identity.licenseNumber = value.idNumber;
-
         cipher.identity.country = this.getValueOrDefault(value.idCountry);
+
+        switch (value.idType) {
+          // case "Driver's License":
+          // case "ID Card":
+          // case "Outdoor License":
+          // case "Software License":
+          // case "Tax Number":
+          // case "Bank Account":
+          // case "Insurance Card":
+          // case "Health Card":
+          // case "Membership":
+          // case "Database":
+          // case "Reward Program":
+          // case "Tour Visa":
+          case "Passport":
+            cipher.identity.passportNumber = value.idNumber;
+            break;
+          case "Social Security":
+            cipher.identity.ssn = value.idNumber;
+            break;
+          default:
+            cipher.identity.licenseNumber = value.idNumber;
+            break;
+        }
 
         this.importUnmappedFields(cipher, value, _mappedIdCardColumns);
       } else if (value.content !== undefined) {

--- a/common/src/importers/mykiCsvImporter.ts
+++ b/common/src/importers/mykiCsvImporter.ts
@@ -27,7 +27,7 @@ export class MykiCsvImporter extends BaseImporter implements Importer {
         cipher.login.uris = this.makeUriArray(value.url);
         cipher.login.username = this.getValueOrDefault(value.username);
         cipher.login.password = this.getValueOrDefault(value.password);
-        cipher.login.totp = this.getValueOrDefault(value.twoFactAuthToken);
+        cipher.login.totp = this.getValueOrDefault(value.twofaSecret);
       } else if (value.cardNumber !== undefined) {
         // Cards
         cipher.card = new CardView();

--- a/spec/common/importers/mykiCsvImporter.spec.ts
+++ b/spec/common/importers/mykiCsvImporter.spec.ts
@@ -1,0 +1,87 @@
+import { CipherType } from "jslib-common/enums/cipherType";
+import { MykiCsvImporter as Importer } from "jslib-common/importers/MykiCsvImporter";
+
+import { userAccountData } from "./testData/mykiCsv/UserAccount.csv";
+import { userCreditCardData } from "./testData/mykiCsv/UserCreditCard.csv";
+import { userIdentityData } from "./testData/mykiCsv/UserIdentity.csv";
+import { userNoteData } from "./testData/mykiCsv/UserNote.csv";
+
+describe("Myki CSV Importer", () => {
+  let importer: Importer;
+  beforeEach(() => {
+    importer = new Importer();
+  });
+
+  it("should parse userAccount records", async () => {
+    const result = await importer.parse(userAccountData);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+
+    expect(cipher.name).toEqual("PasswordNickname");
+    expect(cipher.login.username).toEqual("user.name@email.com");
+    expect(cipher.login.password).toEqual("abc123");
+    expect(cipher.login.totp).toEqual("someTOTPSeed");
+    expect(cipher.login.uris.length).toEqual(1);
+    const uriView = cipher.login.uris.shift();
+    expect(uriView.uri).toEqual("http://www.google.com");
+    expect(cipher.notes).toEqual("This is the additional information text.");
+  });
+
+  it("should parse creditCard records", async () => {
+    const result = await importer.parse(userCreditCardData);
+
+    expect(result).not.toBeNull();
+    expect(result.success).toBe(true);
+    expect(result.ciphers.length).toBe(1);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.type).toBe(CipherType.Card);
+    expect(cipher.name).toBe("Visa test card");
+    expect(cipher.card.brand).toBe("Visa");
+    expect(cipher.card.cardholderName).toBe("Joe User");
+    expect(cipher.card.number).toBe("4111111111111111");
+    expect(cipher.card.code).toBe("222");
+    expect(cipher.card.expMonth).toBe("04");
+    expect(cipher.card.expYear).toBe("24");
+
+    expect(cipher.notes).toBe("This is the additional information field");
+  });
+
+  it("should parse identity records", async () => {
+    const result = await importer.parse(userIdentityData);
+
+    expect(result).not.toBeNull();
+    expect(result.success).toBe(true);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.type).toBe(CipherType.Identity);
+    expect(cipher.name).toBe("Joe User's nickname");
+    expect(cipher.identity.fullName).toBe("Mr Joe M User");
+    expect(cipher.identity.title).toBe("Mr");
+    expect(cipher.identity.firstName).toBe("Joe");
+    expect(cipher.identity.middleName).toBe("M");
+    expect(cipher.identity.lastName).toBe("User");
+    expect(cipher.identity.email).toBe("joe.user@email.com");
+
+    expect(cipher.identity.address1).toBe("1 Example House");
+    expect(cipher.identity.address2).toBe("Suite 300");
+
+    expect(cipher.identity.city).toBe("Portland");
+    expect(cipher.identity.postalCode).toBe("04101");
+    expect(cipher.identity.country).toBe("United States");
+  });
+
+  it("should parse secureNote records", async () => {
+    const result = await importer.parse(userNoteData);
+
+    expect(result).not.toBeNull();
+    expect(result.success).toBe(true);
+    expect(result.ciphers.length).toBe(1);
+
+    const cipher = result.ciphers.shift();
+    expect(cipher.type).toBe(CipherType.SecureNote);
+    expect(cipher.name).toBe("The title of a secure note");
+    expect(cipher.notes).toBe("The content of a secure note. Lorem ipsum, etc.");
+  });
+});

--- a/spec/common/importers/mykiCsvImporter.spec.ts
+++ b/spec/common/importers/mykiCsvImporter.spec.ts
@@ -1,5 +1,6 @@
 import { CipherType } from "jslib-common/enums/cipherType";
 import { MykiCsvImporter as Importer } from "jslib-common/importers/mykiCsvImporter";
+import { CipherView } from "jslib-common/models/view/cipherView";
 
 import { userAccountData } from "./testData/mykiCsv/UserAccount.csv";
 import { userCreditCardData } from "./testData/mykiCsv/UserCreditCard.csv";
@@ -7,6 +8,428 @@ import { userIdCardData } from "./testData/mykiCsv/UserIdCard.csv";
 import { userIdentityData } from "./testData/mykiCsv/UserIdentity.csv";
 import { userNoteData } from "./testData/mykiCsv/UserNote.csv";
 import { userTwoFaData } from "./testData/mykiCsv/UserTwofa.csv";
+
+function expectDriversLicense(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Joe User's nickname");
+  expect(cipher.notes).toBe("Additional information");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("123456");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Driver's License");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("02/02/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("02/02/2024");
+}
+
+function expectPassport(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Passport ID card");
+  expect(cipher.notes).toBe("Additional information field");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.passportNumber).toBe("1234567");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Passport");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectSocialSecurity(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Social Security ID card");
+  expect(cipher.notes).toBe("Additional information field text");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.ssn).toBe("123455678");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Social Security");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectIdCard(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("ID card type ID card");
+  expect(cipher.notes).toBe("Additional Information field text");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("1234566");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("ID Card");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectTaxNumber(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Tax number ID card");
+  expect(cipher.notes).toBe("Additinoal information text field");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("12345678");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Tax Number");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectBankAccount(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Bank account ID card");
+  expect(cipher.notes).toBe("Additional text information here");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("12344556677");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Bank Account");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectInsuranceCard(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Insurance card ID card");
+  expect(cipher.notes).toBe("Additional information text goes here");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("123456677");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Insurance Card");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2022");
+}
+
+function expectHealthCard(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Health card Id card");
+  expect(cipher.notes).toBe("More info");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("1234670");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Health Card");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectMembershipCard(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Membership ID card");
+  expect(cipher.notes).toBe("Add'l info");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("12345709");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Membership");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectDatabase(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Database ID card");
+  expect(cipher.notes).toBe("Addin't info");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("12345089u");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Database");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectOutdoorLicense(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Outdoor license ID card");
+  expect(cipher.notes).toBe("Additional info");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("123890090");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Outdoor License");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectRewardProgram(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Reward program Id card");
+  expect(cipher.notes).toBe("1234890");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("12345890b");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Reward Program");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectSoftwareLicense(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Software license ID card");
+  expect(cipher.notes).toBe(
+    "It seems like the fields don't change, which makes it pretty useless that they have so many ID card types."
+  );
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("1234567c");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Software License");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
+
+function expectTourVisa(cipher: CipherView) {
+  expect(cipher.type).toBe(CipherType.Identity);
+  expect(cipher.name).toBe("Tour visa ID card");
+  expect(cipher.notes).toBe("Additional Informaion text");
+
+  expect(cipher.identity.fullName).toBe("Joe M User");
+  expect(cipher.identity.firstName).toBe("Joe");
+  expect(cipher.identity.middleName).toBe("M");
+  expect(cipher.identity.lastName).toBe("User");
+  expect(cipher.identity.licenseNumber).toBe("123456lkhj");
+  expect(cipher.identity.country).toBe("United States");
+
+  expect(cipher.fields.length).toBe(5);
+
+  expect(cipher.fields[0].name).toEqual("status");
+  expect(cipher.fields[0].value).toEqual("active");
+
+  expect(cipher.fields[1].name).toEqual("tags");
+  expect(cipher.fields[1].value).toEqual("someTag");
+
+  expect(cipher.fields[2].name).toEqual("idType");
+  expect(cipher.fields[2].value).toEqual("Tour Visa");
+
+  expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+  expect(cipher.fields[3].value).toEqual("03/07/2022");
+
+  expect(cipher.fields[4].name).toEqual("idExpirationDate");
+  expect(cipher.fields[4].value).toEqual("03/07/2028");
+}
 
 describe("Myki CSV Importer", () => {
   let importer: Importer;
@@ -125,43 +548,6 @@ describe("Myki CSV Importer", () => {
     expect(cipher.fields[3].value).toEqual("2223334444");
   });
 
-  it("should parse idCard records", async () => {
-    const result = await importer.parse(userIdCardData);
-
-    expect(result).not.toBeNull();
-    expect(result.success).toBe(true);
-
-    // TODO: idType field means multiple types
-    const cipher = result.ciphers.shift();
-    expect(cipher.type).toBe(CipherType.Identity);
-    expect(cipher.name).toBe("Joe User's nickname");
-    expect(cipher.notes).toBe("Additional information");
-
-    expect(cipher.identity.fullName).toBe("Joe M User");
-    expect(cipher.identity.firstName).toBe("Joe");
-    expect(cipher.identity.middleName).toBe("M");
-    expect(cipher.identity.lastName).toBe("User");
-    expect(cipher.identity.licenseNumber).toBe("123456");
-    expect(cipher.identity.country).toBe("United States");
-
-    expect(cipher.fields.length).toBe(5);
-
-    expect(cipher.fields[0].name).toEqual("status");
-    expect(cipher.fields[0].value).toEqual("active");
-
-    expect(cipher.fields[1].name).toEqual("tags");
-    expect(cipher.fields[1].value).toEqual("someTag");
-
-    expect(cipher.fields[2].name).toEqual("idType");
-    expect(cipher.fields[2].value).toEqual("Driver's License");
-
-    expect(cipher.fields[3].name).toEqual("idIssuanceDate");
-    expect(cipher.fields[3].value).toEqual("02/02/2022");
-
-    expect(cipher.fields[4].name).toEqual("idExpirationDate");
-    expect(cipher.fields[4].value).toEqual("02/02/2024");
-  });
-
   it("should parse secureNote records", async () => {
     const result = await importer.parse(userNoteData);
 
@@ -178,5 +564,70 @@ describe("Myki CSV Importer", () => {
 
     expect(cipher.fields[0].name).toBe("status");
     expect(cipher.fields[0].value).toBe("active");
+  });
+
+  it("should parse idCard records", async () => {
+    const result = await importer.parse(userIdCardData);
+
+    expect(result).not.toBeNull();
+    expect(result.success).toBe(true);
+
+    expect(result.ciphers.length).toBe(14);
+
+    // Driver's license
+    const cipher = result.ciphers.shift();
+    expectDriversLicense(cipher);
+
+    // Passport
+    const cipher2 = result.ciphers.shift();
+    expectPassport(cipher2);
+
+    // Social Security
+    const cipher3 = result.ciphers.shift();
+    expectSocialSecurity(cipher3);
+
+    // Id Card
+    const cipher4 = result.ciphers.shift();
+    expectIdCard(cipher4);
+
+    // Tax Number
+    const cipher5 = result.ciphers.shift();
+    expectTaxNumber(cipher5);
+
+    // Bank Account
+    const cipher6 = result.ciphers.shift();
+    expectBankAccount(cipher6);
+
+    // Insurance card
+    const cipher7 = result.ciphers.shift();
+    expectInsuranceCard(cipher7);
+
+    // Health card
+    const cipher8 = result.ciphers.shift();
+    expectHealthCard(cipher8);
+
+    // Membership card
+    const cipher9 = result.ciphers.shift();
+    expectMembershipCard(cipher9);
+
+    // Database card
+    const cipher10 = result.ciphers.shift();
+    expectDatabase(cipher10);
+
+    // Outdoor license
+    const cipher11 = result.ciphers.shift();
+    expectOutdoorLicense(cipher11);
+
+    // Reward program
+    const cipher12 = result.ciphers.shift();
+    expectRewardProgram(cipher12);
+
+    // Software license
+    const cipher13 = result.ciphers.shift();
+    expectSoftwareLicense(cipher13);
+
+    // Tour visa
+    const cipher14 = result.ciphers.shift();
+    expectTourVisa(cipher14);
   });
 });

--- a/spec/common/importers/mykiCsvImporter.spec.ts
+++ b/spec/common/importers/mykiCsvImporter.spec.ts
@@ -27,6 +27,14 @@ describe("Myki CSV Importer", () => {
     const uriView = cipher.login.uris.shift();
     expect(uriView.uri).toEqual("http://www.google.com");
     expect(cipher.notes).toEqual("This is the additional information text.");
+
+    expect(cipher.fields.length).toBe(2);
+
+    expect(cipher.fields[0].name).toBe("status");
+    expect(cipher.fields[0].value).toBe("active");
+
+    expect(cipher.fields[1].name).toBe("tags");
+    expect(cipher.fields[1].value).toBe("someTag");
   });
 
   it("should parse userTwoFa records", async () => {
@@ -40,6 +48,14 @@ describe("Myki CSV Importer", () => {
     expect(cipher.login.password).toBeNull();
     expect(cipher.login.totp).toBe("someTOTPSeed");
     expect(cipher.notes).toEqual("Additional information field content.");
+
+    expect(cipher.fields.length).toBe(2);
+
+    expect(cipher.fields[0].name).toBe("status");
+    expect(cipher.fields[0].value).toBe("active");
+
+    expect(cipher.fields[1].name).toBe("tags");
+    expect(cipher.fields[1].value).toBe("someTag");
   });
 
   it("should parse creditCard records", async () => {
@@ -60,6 +76,14 @@ describe("Myki CSV Importer", () => {
     expect(cipher.card.expYear).toBe("24");
 
     expect(cipher.notes).toBe("This is the additional information field");
+
+    expect(cipher.fields.length).toBe(2);
+
+    expect(cipher.fields[0].name).toBe("status");
+    expect(cipher.fields[0].value).toBe("active");
+
+    expect(cipher.fields[1].name).toBe("tags");
+    expect(cipher.fields[1].value).toBe("someTag");
   });
 
   it("should parse identity records", async () => {
@@ -84,6 +108,20 @@ describe("Myki CSV Importer", () => {
     expect(cipher.identity.city).toBe("Portland");
     expect(cipher.identity.postalCode).toBe("04101");
     expect(cipher.identity.country).toBe("United States");
+
+    expect(cipher.fields.length).toBe(4);
+
+    expect(cipher.fields[0].name).toEqual("status");
+    expect(cipher.fields[0].value).toEqual("active");
+
+    expect(cipher.fields[1].name).toBe("tags");
+    expect(cipher.fields[1].value).toBe("someTag");
+
+    expect(cipher.fields[2].name).toEqual("gender");
+    expect(cipher.fields[2].value).toEqual("Male");
+
+    expect(cipher.fields[3].name).toEqual("number");
+    expect(cipher.fields[3].value).toEqual("2223334444");
   });
 
   it("should parse secureNote records", async () => {
@@ -97,5 +135,10 @@ describe("Myki CSV Importer", () => {
     expect(cipher.type).toBe(CipherType.SecureNote);
     expect(cipher.name).toBe("The title of a secure note");
     expect(cipher.notes).toBe("The content of a secure note. Lorem ipsum, etc.");
+
+    expect(cipher.fields.length).toBe(1);
+
+    expect(cipher.fields[0].name).toBe("status");
+    expect(cipher.fields[0].value).toBe("active");
   });
 });

--- a/spec/common/importers/mykiCsvImporter.spec.ts
+++ b/spec/common/importers/mykiCsvImporter.spec.ts
@@ -5,6 +5,7 @@ import { userAccountData } from "./testData/mykiCsv/UserAccount.csv";
 import { userCreditCardData } from "./testData/mykiCsv/UserCreditCard.csv";
 import { userIdentityData } from "./testData/mykiCsv/UserIdentity.csv";
 import { userNoteData } from "./testData/mykiCsv/UserNote.csv";
+import { userTwoFaData } from "./testData/mykiCsv/UserTwofa.csv";
 
 describe("Myki CSV Importer", () => {
   let importer: Importer;
@@ -26,6 +27,19 @@ describe("Myki CSV Importer", () => {
     const uriView = cipher.login.uris.shift();
     expect(uriView.uri).toEqual("http://www.google.com");
     expect(cipher.notes).toEqual("This is the additional information text.");
+  });
+
+  it("should parse userTwoFa records", async () => {
+    const result = await importer.parse(userTwoFaData);
+    expect(result != null).toBe(true);
+
+    const cipher = result.ciphers.shift();
+
+    expect(cipher.name).toEqual("2FA nickname");
+    expect(cipher.login.username).toBeNull();
+    expect(cipher.login.password).toBeNull();
+    expect(cipher.login.totp).toBe("someTOTPSeed");
+    expect(cipher.notes).toEqual("Additional information field content.");
   });
 
   it("should parse creditCard records", async () => {

--- a/spec/common/importers/mykiCsvImporter.spec.ts
+++ b/spec/common/importers/mykiCsvImporter.spec.ts
@@ -3,6 +3,7 @@ import { MykiCsvImporter as Importer } from "jslib-common/importers/mykiCsvImpor
 
 import { userAccountData } from "./testData/mykiCsv/UserAccount.csv";
 import { userCreditCardData } from "./testData/mykiCsv/UserCreditCard.csv";
+import { userIdCardData } from "./testData/mykiCsv/UserIdCard.csv";
 import { userIdentityData } from "./testData/mykiCsv/UserIdentity.csv";
 import { userNoteData } from "./testData/mykiCsv/UserNote.csv";
 import { userTwoFaData } from "./testData/mykiCsv/UserTwofa.csv";
@@ -122,6 +123,43 @@ describe("Myki CSV Importer", () => {
 
     expect(cipher.fields[3].name).toEqual("number");
     expect(cipher.fields[3].value).toEqual("2223334444");
+  });
+
+  it("should parse idCard records", async () => {
+    const result = await importer.parse(userIdCardData);
+
+    expect(result).not.toBeNull();
+    expect(result.success).toBe(true);
+
+    // TODO: idType field means multiple types
+    const cipher = result.ciphers.shift();
+    expect(cipher.type).toBe(CipherType.Identity);
+    expect(cipher.name).toBe("Joe User's nickname");
+    expect(cipher.notes).toBe("Additional information");
+
+    expect(cipher.identity.fullName).toBe("Joe M User");
+    expect(cipher.identity.firstName).toBe("Joe");
+    expect(cipher.identity.middleName).toBe("M");
+    expect(cipher.identity.lastName).toBe("User");
+    expect(cipher.identity.licenseNumber).toBe("123456");
+    expect(cipher.identity.country).toBe("United States");
+
+    expect(cipher.fields.length).toBe(5);
+
+    expect(cipher.fields[0].name).toEqual("status");
+    expect(cipher.fields[0].value).toEqual("active");
+
+    expect(cipher.fields[1].name).toEqual("tags");
+    expect(cipher.fields[1].value).toEqual("someTag");
+
+    expect(cipher.fields[2].name).toEqual("idType");
+    expect(cipher.fields[2].value).toEqual("Driver's License");
+
+    expect(cipher.fields[3].name).toEqual("idIssuanceDate");
+    expect(cipher.fields[3].value).toEqual("02/02/2022");
+
+    expect(cipher.fields[4].name).toEqual("idExpirationDate");
+    expect(cipher.fields[4].value).toEqual("02/02/2024");
   });
 
   it("should parse secureNote records", async () => {

--- a/spec/common/importers/mykiCsvImporter.spec.ts
+++ b/spec/common/importers/mykiCsvImporter.spec.ts
@@ -1,5 +1,5 @@
 import { CipherType } from "jslib-common/enums/cipherType";
-import { MykiCsvImporter as Importer } from "jslib-common/importers/MykiCsvImporter";
+import { MykiCsvImporter as Importer } from "jslib-common/importers/mykiCsvImporter";
 
 import { userAccountData } from "./testData/mykiCsv/UserAccount.csv";
 import { userCreditCardData } from "./testData/mykiCsv/UserCreditCard.csv";

--- a/spec/common/importers/testData/mykiCsv/UserAccount.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserAccount.csv.ts
@@ -1,3 +1,3 @@
 /* eslint-disable */
 export const userAccountData = `nickname,url,username,password,additionalInfo,twofaSecret,status,tags
-PasswordNickname,www.google.com,user.name@email.com,abc123,This is the additional information text.,someTOTPSeed,active,`;
+PasswordNickname,www.google.com,user.name@email.com,abc123,This is the additional information text.,someTOTPSeed,active,someTag`;

--- a/spec/common/importers/testData/mykiCsv/UserAccount.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserAccount.csv.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export const userAccountData = `nickname,url,username,password,additionalInfo,twofaSecret,status,tags
+PasswordNickname,www.google.com,user.name@email.com,abc123,This is the additional information text.,someTOTPSeed,active,`;

--- a/spec/common/importers/testData/mykiCsv/UserCreditCard.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserCreditCard.csv.ts
@@ -1,3 +1,3 @@
 /* eslint-disable */
 export const userCreditCardData = `nickname,status,tags,cardNumber,cardName,exp_month,exp_year,cvv,additionalInfo
-Visa test card,active,,4111111111111111,Joe User,04,24,222,This is the additional information field`;
+Visa test card,active,someTag,4111111111111111,Joe User,04,24,222,This is the additional information field`;

--- a/spec/common/importers/testData/mykiCsv/UserCreditCard.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserCreditCard.csv.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export const userCreditCardData = `nickname,status,tags,cardNumber,cardName,exp_month,exp_year,cvv,additionalInfo
+Visa test card,active,,4111111111111111,Joe User,04,24,222,This is the additional information field`;

--- a/spec/common/importers/testData/mykiCsv/UserIdCard.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserIdCard.csv.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export const userIdCardData = `nickname,status,tags,idType,idNumber,idName,idIssuanceDate,idExpirationDate,idCountry,additionalInfo
+Joe User's nickname,active,someTag,Driver's License,123456,Joe M User,02/02/2022,02/02/2024,United States,Additional information`;

--- a/spec/common/importers/testData/mykiCsv/UserIdCard.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserIdCard.csv.ts
@@ -1,3 +1,16 @@
 /* eslint-disable */
 export const userIdCardData = `nickname,status,tags,idType,idNumber,idName,idIssuanceDate,idExpirationDate,idCountry,additionalInfo
-Joe User's nickname,active,someTag,Driver's License,123456,Joe M User,02/02/2022,02/02/2024,United States,Additional information`;
+Joe User's nickname,active,someTag,Driver's License,123456,Joe M User,02/02/2022,02/02/2024,United States,Additional information
+Passport ID card,active,someTag,Passport,1234567,Joe M User,03/07/2022,03/07/2028,United States,Additional information field
+Social Security ID card,active,someTag,Social Security,123455678,Joe M User,03/07/2022,03/07/2028,United States,Additional information field text
+ID card type ID card,active,someTag,ID Card,1234566,Joe M User,03/07/2022,03/07/2028,United States,Additional Information field text
+Tax number ID card,active,someTag,Tax Number,12345678,Joe M User,03/07/2022,03/07/2028,United States,Additinoal information text field
+Bank account ID card,active,someTag,Bank Account,12344556677,Joe M User,03/07/2022,03/07/2028,United States,Additional text information here
+Insurance card ID card,active,someTag,Insurance Card,123456677,Joe M User,03/07/2022,03/07/2022,United States,Additional information text goes here
+Health card Id card,active,someTag,Health Card,1234670,Joe M User,03/07/2022,03/07/2028,United States,More info
+Membership ID card,active,someTag,Membership,12345709,Joe M User,03/07/2022,03/07/2028,United States,Add'l info
+Database ID card,active,someTag,Database,12345089u,Joe M User,03/07/2022,03/07/2028,United States,Addin't info
+Outdoor license ID card,active,someTag,Outdoor License,123890090,Joe M User,03/07/2022,03/07/2028,United States,Additional info
+Reward program Id card,active,someTag,Reward Program,12345890b,Joe M User,03/07/2022,03/07/2028,United States,1234890
+Software license ID card,active,someTag,Software License,1234567c,Joe M User,03/07/2022,03/07/2028,United States,"It seems like the fields don't change, which makes it pretty useless that they have so many ID card types."
+Tour visa ID card,active,someTag,Tour Visa,123456lkhj,Joe M User,03/07/2022,03/07/2028,United States,Additional Informaion text`;

--- a/spec/common/importers/testData/mykiCsv/UserIdentity.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserIdentity.csv.ts
@@ -1,3 +1,3 @@
 /* eslint-disable */
 export const userIdentityData = `nickname,status,tags,firstName,middleName,lastName,email,firstAddressLine,secondAddressLine,title,gender,number,city,country,zipCode,additionalInfo
-Joe User's nickname,active,,Joe,M,User,joe.user@email.com,1 Example House,Suite 300,Mr,Male,2223334444,Portland,United States,04101,Additional information field`;
+Joe User's nickname,active,someTag,Joe,M,User,joe.user@email.com,1 Example House,Suite 300,Mr,Male,2223334444,Portland,United States,04101,Additional information field`;

--- a/spec/common/importers/testData/mykiCsv/UserIdentity.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserIdentity.csv.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export const userIdentityData = `nickname,status,tags,firstName,middleName,lastName,email,firstAddressLine,secondAddressLine,title,gender,number,city,country,zipCode,additionalInfo
+Joe User's nickname,active,,Joe,M,User,joe.user@email.com,1 Example House,Suite 300,Mr,Male,2223334444,Portland,United States,04101,Additional information field`;

--- a/spec/common/importers/testData/mykiCsv/UserNote.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserNote.csv.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export const userNoteData = `nickname,status,content
+The title of a secure note,active,"The content of a secure note. Lorem ipsum, etc."`;

--- a/spec/common/importers/testData/mykiCsv/UserTwofa.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserTwofa.csv.ts
@@ -1,3 +1,3 @@
 /* eslint-disable */
 export const userTwoFaData = `nickname,status,tags,authToken,additionalInfo
-2FA nickname,active,,someTOTPSeed,"Additional information field content. "`;
+2FA nickname,active,someTag,someTOTPSeed,"Additional information field content. "`;

--- a/spec/common/importers/testData/mykiCsv/UserTwofa.csv.ts
+++ b/spec/common/importers/testData/mykiCsv/UserTwofa.csv.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+export const userTwoFaData = `nickname,status,tags,authToken,additionalInfo
+2FA nickname,active,,someTOTPSeed,"Additional information field content. "`;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With the announcement of Myki discontinuing their existing products on April 10th, 2022, after being aquired by JumpCloud, it was time to revisit our Myki importer.

This PR fixes some minor issues and adds support for previously not imported exports types (`UserIdCard.csv` and `UserTwoFA.csv`).

Asana task: https://app.asana.com/0/1200578627114106/1201930330138516/f

**Rough overview of imported ciphers/fields:**
- Empty fields are skipped
- All unmapped columns are imported as custom fields (for example: status and tags)

- **Login items - `UserAccount.csv`**
  - Username
  - Password
  - TOTP
  - Notes
- **TwoFA - `UserTwoFa.csv`**
  - nickname -> CipherTitle
  - TOTP
  - Notes
- **CreditCard items - `UserCreditCard.csv`**
  - Cardholder
  - CC Number
  - CVV
  - Expiry date
  - Card brand is set using CC Number and only to our supported brands
  - Notes
- **Secure Notes- `UserNote.csv`**
  - Title
  - Content
- **Identity items - `UserIdentity.csv`**
  - Firstname
  - MiddleName
  - LastName
  - Email
  - Address
  - Notes
- **IdCard items - `UserIdCard.csv`**
  - All idCards are converted to Bitwarden identities.
  - FirstName
  - MiddleName
  - LastName
  - For Passport and Social Security the respective fields are used. All other types fill the LicenseNumber field
  - Notes

## Code changes
- **common/src/importers/mykiCsvImporter.ts:** 
   - Fixed 2fa seed not being copied on account records
   - Fixedx secure note title not being set
   - Added support for importing userIdCard.csv and userTwoFa.csv
   - Add importing of all unmapped columns into custom fields
- **spec/common/importers/mykiCsvImporter.spec.ts:** added test suite
- **spec/common/importers/testData/mykiCsv/*:** Example exports used for testing

## Testing requirements
Ensure that items are imported as described

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
