### PR TITLE
Remove Dashlane json importer from the featured importer list

### DIFF
--- a/common/src/enums/importOptions.ts
+++ b/common/src/enums/importOptions.ts
@@ -8,7 +8,6 @@ export const featuredImportOptions = [
   { id: "bitwardencsv", name: "Bitwarden (csv)" },
   { id: "chromecsv", name: "Chrome (csv)" },
   { id: "dashlanecsv", name: "Dashlane (csv)" },
-  { id: "dashlanejson", name: "Dashlane (json)" },
   { id: "firefoxcsv", name: "Firefox (csv)" },
   { id: "keepass2xml", name: "KeePass 2 (xml)" },
   { id: "lastpasscsv", name: "LastPass (csv)" },
@@ -21,6 +20,7 @@ export const regularImportOptions = [
   { id: "1password1pif", name: "1Password (1pif)" },
   { id: "1passwordwincsv", name: "1Password 6 and 7 Windows (csv)" },
   { id: "1passwordmaccsv", name: "1Password 6 and 7 Mac (csv)" },
+  { id: "dashlanejson", name: "Dashlane (json)" },
   { id: "roboformcsv", name: "RoboForm (csv)" },
   { id: "keepercsv", name: "Keeper (csv)" },
   // Temporarily remove this option for the Feb release


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With https://github.com/bitwarden/jslib/pull/708 we added the new Dashlane csv importer. As Dashlane has removed support for the JSON format, the CSV importer should be on the featureList instead

## Code changes
- **common/src/enums/importOptions.ts:** Removed the Dashlane json importer from the featured importer list

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
