### PR TITLE
Avoid duplicate fullSync api calls

### DIFF
--- a/common/src/abstractions/sync.service.ts
+++ b/common/src/abstractions/sync.service.ts
@@ -10,6 +10,7 @@ export abstract class SyncService {
   getLastSync: () => Promise<Date>;
   setLastSync: (date: Date, userId?: string) => Promise<any>;
   fullSync: (forceSync: boolean, allowThrowOnError?: boolean) => Promise<boolean>;
+  ensureFirstSync: () => Promise<boolean>;
   syncUpsertFolder: (notification: SyncFolderNotification, isEdit: boolean) => Promise<boolean>;
   syncDeleteFolder: (notification: SyncFolderNotification) => Promise<boolean>;
   syncUpsertCipher: (notification: SyncCipherNotification, isEdit: boolean) => Promise<boolean>;

--- a/common/src/abstractions/sync.service.ts
+++ b/common/src/abstractions/sync.service.ts
@@ -10,7 +10,6 @@ export abstract class SyncService {
   getLastSync: () => Promise<Date>;
   setLastSync: (date: Date, userId?: string) => Promise<any>;
   fullSync: (forceSync: boolean, allowThrowOnError?: boolean) => Promise<boolean>;
-  ensureFirstSync: () => Promise<boolean>;
   syncUpsertFolder: (notification: SyncFolderNotification, isEdit: boolean) => Promise<boolean>;
   syncDeleteFolder: (notification: SyncFolderNotification) => Promise<boolean>;
   syncUpsertCipher: (notification: SyncCipherNotification, isEdit: boolean) => Promise<boolean>;

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -13,7 +13,7 @@ import { SendService } from "../abstractions/send.service";
 import { SettingsService } from "../abstractions/settings.service";
 import { StateService } from "../abstractions/state.service";
 import { SyncService as SyncServiceAbstraction } from "../abstractions/sync.service";
-import { sequentialize } from '../misc/sequentialize';
+import { sequentialize } from "../misc/sequentialize";
 import { CipherData } from "../models/data/cipherData";
 import { CollectionData } from "../models/data/collectionData";
 import { FolderData } from "../models/data/folderData";

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -262,10 +262,10 @@ export class SyncService implements SyncServiceAbstraction {
     return this.syncCompleted(false);
   }
 
-  async doFirstSync() {
+  async ensureFirstSync() {
     return this.needsFirstSync()
       ? false
-      : this.fullSync(false);
+      : this.fullSync(true);
   }
 
   // Helpers
@@ -283,7 +283,7 @@ export class SyncService implements SyncServiceAbstraction {
 
   private async needsFirstSync() {
     const lastSync = await this.getLastSync();
-    return lastSync != null && lastSync.getTime() !== 0;
+    return lastSync == null || lastSync.getTime() === 0;
   }
 
   private async needsSyncing(forceSync: boolean) {
@@ -291,7 +291,7 @@ export class SyncService implements SyncServiceAbstraction {
       return true;
     }
 
-    if (!this.needsFirstSync()) {
+    if (this.needsFirstSync()) {
       return true;
     }
 

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -262,12 +262,6 @@ export class SyncService implements SyncServiceAbstraction {
     return this.syncCompleted(false);
   }
 
-  async ensureFirstSync() {
-    return this.needsFirstSync()
-      ? false
-      : this.fullSync(true);
-  }
-
   // Helpers
 
   private syncStarted() {
@@ -281,22 +275,17 @@ export class SyncService implements SyncServiceAbstraction {
     return successfully;
   }
 
-  private async needsFirstSync() {
-    const lastSync = await this.getLastSync();
-    return lastSync == null || lastSync.getTime() === 0;
-  }
-
   private async needsSyncing(forceSync: boolean) {
     if (forceSync) {
       return true;
     }
 
-    if (this.needsFirstSync()) {
+    const lastSync = await this.getLastSync();
+    if (lastSync == null || lastSync.getTime() === 0) {
       return true;
     }
 
     const response = await this.apiService.getAccountRevisionDate();
-    const lastSync = await this.getLastSync();
     if (new Date(response) <= lastSync) {
       return false;
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix https://github.com/bitwarden/web/issues/1324.

I came across this code in the web navbar component which is likely causing duplicate fullSyncs: https://github.com/bitwarden/web/blob/master/src/app/layouts/navbar.component.ts#L38

That code is not unreasonable though, sometimes we need to ensure a full sync has been done. Better to handle duplicate calls in syncService so that callers don't need to worry about it.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Add sequentialize decorator to `syncService.fullSync`.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
