### PR TITLE
Check runtime name vs mangled name

### DIFF
--- a/angular/src/directives/api-action.directive.ts
+++ b/angular/src/directives/api-action.directive.ts
@@ -32,7 +32,7 @@ export class ApiActionDirective implements OnChanges {
         this.el.nativeElement.loading = false;
 
         if (
-          (e instanceof ErrorResponse || e.constructor.name === "ErrorResponse") &&
+          (e instanceof ErrorResponse || e.constructor.name === ErrorResponse.name) &&
           (e as ErrorResponse).captchaRequired
         ) {
           this.logService.error("Captcha required error response: " + e.getSingleMessage());

--- a/common/src/services/cipher.service.ts
+++ b/common/src/services/cipher.service.ts
@@ -1029,7 +1029,7 @@ export class CipherService implements CipherServiceAbstraction {
       ciphers[c.id].revisionDate = c.revisionDate;
     };
 
-    if (cipher.constructor.name === "Array") {
+    if (cipher.constructor.name === Array.name) {
       (cipher as { id: string; revisionDate: string }[]).forEach(clearDeletedDate);
     } else {
       clearDeletedDate(cipher as { id: string; revisionDate: string });

--- a/node/src/cli/commands/login.command.ts
+++ b/node/src/cli/commands/login.command.ts
@@ -467,7 +467,7 @@ export class LoginCommand {
     } catch (e) {
       if (
         e instanceof ErrorResponse ||
-        (e.constructor.name === "ErrorResponse" &&
+        (e.constructor.name === ErrorResponse.name &&
           (e as ErrorResponse).message.includes("Captcha is invalid"))
       ) {
         return badCaptcha;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

After minification was added to browser last release, we started mangling constructor names. This breaks our runtime type checking.

This PR fixes the issue by determining the appropriate constructor name at runtime as well.

Fixes https://app.asana.com/0/1169444489336079/1201956221046192/f

This will be cherry picked to `rc`

## Testing requirements
Validate that linked issue is resolved.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
