### PR TITLE
Add ellipsis pipe

### DIFF
--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'ellipsis'
+})
+export class EllipsisPipe implements PipeTransform {
+  transform(value: string, limit = 25, completeWords = false, ellipsis = '...') {
+    if (completeWords) {
+      limit = value.substring(0, limit).lastIndexOf(' ');
+    }
+    return value.length > limit ? value.substring(0, limit) + ellipsis : value;
+  }
+}

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -5,9 +5,10 @@ import { Pipe, PipeTransform } from "@angular/core";
 })
 export class EllipsisPipe implements PipeTransform {
   transform(value: string, limit = 25, completeWords = false, ellipsis = "...") {
+    limit -= ellipsis.length;
     if (completeWords) {
       limit = value.substring(0, limit).lastIndexOf(" ");
     }
-    return value.length > limit ? value.substring(0, limit - ellipsis.length) + ellipsis : value;
+    return value.length > limit ? value.substring(0, limit) + ellipsis : value;
   }
 }

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -12,7 +12,6 @@ export class EllipsisPipe implements PipeTransform {
     if (completeWords && value.length > limit && value.indexOf(" ") > 0) {
       limit = value.substring(0, limit).lastIndexOf(" ");
     }
-    console.log(value.length, limit);
     return value.substring(0, limit) + ellipsis;
   }
 }

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -1,12 +1,12 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform } from "@angular/core";
 
 @Pipe({
-  name: 'ellipsis'
+  name: "ellipsis",
 })
 export class EllipsisPipe implements PipeTransform {
-  transform(value: string, limit = 25, completeWords = false, ellipsis = '...') {
+  transform(value: string, limit = 25, completeWords = false, ellipsis = "...") {
     if (completeWords) {
-      limit = value.substring(0, limit).lastIndexOf(' ');
+      limit = value.substring(0, limit).lastIndexOf(" ");
     }
     return value.length > limit ? value.substring(0, limit) + ellipsis : value;
   }

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -5,12 +5,15 @@ import { Pipe, PipeTransform } from "@angular/core";
 })
 export class EllipsisPipe implements PipeTransform {
   transform(value: string, limit = 25, completeWords = false, ellipsis = "...") {
+    if (value.length <= limit) {
+      return value;
+    }
     limit -= ellipsis.length;
     if (completeWords && value.length > limit) {
       if (value.indexOf(" ") > 0) {
         limit = value.substring(0, limit).lastIndexOf(" ");
       }
     }
-    return value.length > limit ? value.substring(0, limit) + ellipsis : value;
+    return value.substring(0, limit) + ellipsis;
   }
 }

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -6,7 +6,7 @@ import { Pipe, PipeTransform } from "@angular/core";
 export class EllipsisPipe implements PipeTransform {
   transform(value: string, limit = 25, completeWords = false, ellipsis = "...") {
     limit -= ellipsis.length;
-    if (completeWords) {
+    if (completeWords && value.length > limit) {
       limit = value.substring(0, limit).lastIndexOf(" ");
     }
     return value.length > limit ? value.substring(0, limit) + ellipsis : value;

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -8,6 +8,6 @@ export class EllipsisPipe implements PipeTransform {
     if (completeWords) {
       limit = value.substring(0, limit).lastIndexOf(" ");
     }
-    return value.length > limit ? value.substring(0, limit) + ellipsis : value;
+    return value.length > limit ? value.substring(0, limit - ellipsis.length) + ellipsis : value;
   }
 }

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -9,11 +9,10 @@ export class EllipsisPipe implements PipeTransform {
       return value;
     }
     limit -= ellipsis.length;
-    if (completeWords && value.length > limit) {
-      if (value.indexOf(" ") > 0) {
-        limit = value.substring(0, limit).lastIndexOf(" ");
-      }
+    if (completeWords && value.length > limit && value.indexOf(" ") > 0) {
+      limit = value.substring(0, limit).lastIndexOf(" ");
     }
+    console.log(value.length, limit);
     return value.substring(0, limit) + ellipsis;
   }
 }

--- a/angular/src/pipes/ellipsis.pipe.ts
+++ b/angular/src/pipes/ellipsis.pipe.ts
@@ -7,7 +7,9 @@ export class EllipsisPipe implements PipeTransform {
   transform(value: string, limit = 25, completeWords = false, ellipsis = "...") {
     limit -= ellipsis.length;
     if (completeWords && value.length > limit) {
-      limit = value.substring(0, limit).lastIndexOf(" ");
+      if (value.indexOf(" ") > 0) {
+        limit = value.substring(0, limit).lastIndexOf(" ");
+      }
     }
     return value.length > limit ? value.substring(0, limit) + ellipsis : value;
   }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

I noticed that we don't have a nice way to truncate large text (such as organization names) while working on the end user vault refresh work for browser, so I added this ellipsis pipe to do just that 🙂  

The default limit is 25 characters, but you can pass the amount you want to add the ellipsis on. You can also pass a flag to break on complete words and to also change what the ellipsis is.

## Code changes

- **angular/src/pipes/ellipsis.pipe.ts:** Add ellipsis pipe

## Testing requirements

None, until it is used in one of our clients.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
