### PR TITLE
[bug] Fix Safari CSV importer for URL and Notes

### DIFF
--- a/common/src/importers/safariCsvImporter.ts
+++ b/common/src/importers/safariCsvImporter.ts
@@ -17,8 +17,9 @@ export class SafariCsvImporter extends BaseImporter implements Importer {
       cipher.name = this.getValueOrDefault(value.Title, "--");
       cipher.login.username = this.getValueOrDefault(value.Username);
       cipher.login.password = this.getValueOrDefault(value.Password);
-      cipher.login.uris = this.makeUriArray(value.Url);
+      cipher.login.uris = this.makeUriArray(value.Url ?? value.URL);
       cipher.login.totp = this.getValueOrDefault(value.OTPAuth);
+      cipher.notes = this.getValueOrDefault(value.Notes);
       this.cleanupCipher(cipher);
       result.ciphers.push(cipher);
     });

--- a/spec/common/importers/safariCsvImporter.spec.ts
+++ b/spec/common/importers/safariCsvImporter.spec.ts
@@ -1,0 +1,74 @@
+import { SafariCsvImporter as Importer } from "jslib-common/importers/SafariCsvImporter";
+import { CipherView } from "jslib-common/models/view/cipherView";
+import { LoginUriView } from "jslib-common/models/view/loginUriView";
+import { LoginView } from "jslib-common/models/view/loginView";
+
+import { data as oldSimplePasswordData } from "./testData/safariCsv/oldSimplePasswordData.csv";
+import { data as simplePasswordData } from "./testData/safariCsv/simplePasswordData.csv";
+
+const CipherData = [
+  {
+    title: "should parse URLs in new CSV format",
+    csv: simplePasswordData,
+    expected: Object.assign(new CipherView(), {
+      id: null,
+      organizationId: null,
+      folderId: null,
+      name: "example.com (example_user)",
+      login: Object.assign(new LoginView(), {
+        username: "example_user",
+        password: "example_p@ssword",
+        uris: [
+          Object.assign(new LoginUriView(), {
+            uri: "https://example.com",
+          }),
+        ],
+        totp: "otpauth://totp/test?secret=examplesecret",
+      }),
+      notes: "Example note\nMore notes on new line",
+      type: 1,
+    }),
+  },
+  {
+    title: "should parse URLs in old CSV format",
+    csv: oldSimplePasswordData,
+    expected: Object.assign(new CipherView(), {
+      id: null,
+      organizationId: null,
+      folderId: null,
+      name: "example.com (example_user)",
+      login: Object.assign(new LoginView(), {
+        username: "example_user",
+        password: "example_p@ssword",
+        uris: [
+          Object.assign(new LoginUriView(), {
+            uri: "https://example.com",
+          }),
+        ],
+      }),
+      type: 1,
+    }),
+  },
+];
+
+describe("Safari CSV Importer", () => {
+  CipherData.forEach((data) => {
+    it(data.title, async () => {
+      const importer = new Importer();
+      const result = await importer.parse(data.csv);
+      expect(result != null).toBe(true);
+      expect(result.ciphers.length).toBeGreaterThan(0);
+
+      const cipher = result.ciphers.shift();
+      let property: keyof typeof data.expected;
+      for (property in data.expected) {
+        // eslint-disable-next-line
+        if (data.expected.hasOwnProperty(property)) {
+          // eslint-disable-next-line
+          expect(cipher.hasOwnProperty(property)).toBe(true);
+          expect(cipher[property]).toEqual(data.expected[property]);
+        }
+      }
+    });
+  });
+});

--- a/spec/common/importers/testData/safariCsv/oldSimplePasswordData.csv.ts
+++ b/spec/common/importers/testData/safariCsv/oldSimplePasswordData.csv.ts
@@ -1,0 +1,2 @@
+export const data = `Title,Url,Username,Password
+example.com (example_user),https://example.com,example_user,example_p@ssword`;

--- a/spec/common/importers/testData/safariCsv/simplePasswordData.csv.ts
+++ b/spec/common/importers/testData/safariCsv/simplePasswordData.csv.ts
@@ -1,0 +1,3 @@
+export const data = `Title,URL,Username,Password,Notes,OTPAuth
+example.com (example_user),https://example.com,example_user,example_p@ssword,"Example note
+More notes on new line",otpauth://totp/test?secret=examplesecret`;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently, the Safari CSV importer does not handle the modern Safari/macOS export format where the header includes an upper case `URL` field. Also, notes within the Passwords.csv file were ignored.

See the format used below as of macOS 12.3 and Safari 15.4.
<img width="685" alt="image" src="https://user-images.githubusercontent.com/42774874/158917355-33990e86-dde2-4df5-a0d6-f5ac81d7c03e.png">


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **safariCsvImporter.ts:** Updated login `URL` and `Notes` field parsing
- Unit tests for both formats were also added

## Testing requirements

- Importing password exports from Safari/macOS works for different CSV header formats
- Notes and URLs from Safari/macOS password exports are included in Bitwarden items


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
