### PR TITLE
Remove error Response type check

### DIFF
--- a/angular/src/directives/api-action.directive.ts
+++ b/angular/src/directives/api-action.directive.ts
@@ -15,7 +15,7 @@ export class ApiActionDirective implements OnChanges {
     private el: ElementRef,
     private validationService: ValidationService,
     private logService: LogService
-  ) { }
+  ) {}
 
   ngOnChanges(changes: any) {
     if (this.appApiAction == null || this.appApiAction.then == null) {

--- a/angular/src/directives/api-action.directive.ts
+++ b/angular/src/directives/api-action.directive.ts
@@ -15,7 +15,7 @@ export class ApiActionDirective implements OnChanges {
     private el: ElementRef,
     private validationService: ValidationService,
     private logService: LogService
-  ) {}
+  ) { }
 
   ngOnChanges(changes: any) {
     if (this.appApiAction == null || this.appApiAction.then == null) {
@@ -31,10 +31,7 @@ export class ApiActionDirective implements OnChanges {
       (e: any) => {
         this.el.nativeElement.loading = false;
 
-        if (
-          (e instanceof ErrorResponse || e.constructor.name === ErrorResponse.name) &&
-          (e as ErrorResponse).captchaRequired
-        ) {
+        if ((e as ErrorResponse).captchaRequired) {
           this.logService.error("Captcha required error response: " + e.getSingleMessage());
           return;
         }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Minimization is impacting type checking in a non-consistent way. The previous type check works locally, but not from build artifacts :shrug:. We only set `captchaRequired` on our errors when we want a resubmit with captcha included, so we're safe keying off that

## Code changes
Remove ErrorResponse type requirement from api-action.directive checking

## Testing requirements
Will be tested in clients. related to https://app.asana.com/0/1169444489336079/1201956221046192/f

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
