### PR TITLE
PS-91 make isMacAppStore return true/false

### DIFF
--- a/electron/src/utils.ts
+++ b/electron/src/utils.ts
@@ -34,7 +34,7 @@ export function isMac() {
 }
 
 export function isMacAppStore() {
-  return isMac() && (process.mas ?? false);
+  return isMac() && process.mas === true;
 }
 
 export function isWindowsStore() {

--- a/electron/src/utils.ts
+++ b/electron/src/utils.ts
@@ -34,7 +34,7 @@ export function isMac() {
 }
 
 export function isMacAppStore() {
-  return isMac() && process.mas && process.mas === true;
+  return isMac() && (process.mas ?? false);
 }
 
 export function isWindowsStore() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`isMacAppStore()` was returning undefined if on mac and not a MAS build. This fix forces the function to return true/false

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
`isMacAppStore` is called during the update function (to make sure the build is not a MAS build), while building the toolbar menus (some options like "Check for Update" is not available on MAS build) and while closing the window (to keep application alive in background until user quits it with Cmd-Q). These will need to be checked.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
