### PR TITLE
support for username gen website setting

### DIFF
--- a/angular/src/components/password-generator.component.ts
+++ b/angular/src/components/password-generator.component.ts
@@ -29,6 +29,7 @@ export class PasswordGeneratorComponent implements OnInit {
   avoidAmbiguous = false;
   showWebsiteOption = false;
   enforcedPasswordPolicyOptions: PasswordGeneratorPolicyOptions;
+  usernameWebsite: string = null;
 
   constructor(
     protected passwordGenerationService: PasswordGenerationService,
@@ -94,6 +95,9 @@ export class PasswordGeneratorComponent implements OnInit {
       }
       if (!this.showWebsiteOption) {
         this.usernameOptions.subaddressType = this.usernameOptions.catchallType = "random";
+      }
+      if (this.usernameWebsite != null) {
+        this.usernameOptions.website = this.usernameWebsite;
       }
 
       if (qParams.type === "username" || qParams.type === "password") {

--- a/angular/src/services/jslib-services.module.ts
+++ b/angular/src/services/jslib-services.module.ts
@@ -36,6 +36,7 @@ import { TokenService as TokenServiceAbstraction } from "jslib-common/abstractio
 import { TotpService as TotpServiceAbstraction } from "jslib-common/abstractions/totp.service";
 import { TwoFactorService as TwoFactorServiceAbstraction } from "jslib-common/abstractions/twoFactor.service";
 import { UserVerificationService as UserVerificationServiceAbstraction } from "jslib-common/abstractions/userVerification.service";
+import { UsernameGenerationService as UsernameGenerationServiceAbstraction } from "jslib-common/abstractions/usernameGeneration.service";
 import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "jslib-common/abstractions/vaultTimeout.service";
 import { StateFactory } from "jslib-common/factories/stateFactory";
 import { Account } from "jslib-common/models/domain/account";
@@ -69,6 +70,7 @@ import { TokenService } from "jslib-common/services/token.service";
 import { TotpService } from "jslib-common/services/totp.service";
 import { TwoFactorService } from "jslib-common/services/twoFactor.service";
 import { UserVerificationService } from "jslib-common/services/userVerification.service";
+import { UsernameGenerationService } from "jslib-common/services/usernameGeneration.service";
 import { VaultTimeoutService } from "jslib-common/services/vaultTimeout.service";
 import { WebCryptoFunctionService } from "jslib-common/services/webCryptoFunction.service";
 
@@ -197,6 +199,11 @@ import { ValidationService } from "./validation.service";
       provide: PasswordGenerationServiceAbstraction,
       useClass: PasswordGenerationService,
       deps: [CryptoServiceAbstraction, PolicyServiceAbstraction, StateServiceAbstraction],
+    },
+    {
+      provide: UsernameGenerationServiceAbstraction,
+      useClass: UsernameGenerationService,
+      deps: [CryptoServiceAbstraction, StateServiceAbstraction],
     },
     {
       provide: ApiServiceAbstraction,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add ability to pass username website to base component so that it can be property set inside the scope of 
 `route.queryParams.pipe` subscription. This is used for passing in the context of the item website being edited so that it can be used in the generator.

Also added username generator service to angular DI service module in jslib.

## Code changes

password-generator.component.ts - Added websiteUsername property to override username options.

jslib-services.module.ts - resolve username gen service

## Testing requirements

n/a

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
