### PR TITLE
Fix import path for safari importer

### DIFF
--- a/spec/common/importers/safariCsvImporter.spec.ts
+++ b/spec/common/importers/safariCsvImporter.spec.ts
@@ -1,4 +1,4 @@
-import { SafariCsvImporter as Importer } from "jslib-common/importers/SafariCsvImporter";
+import { SafariCsvImporter as Importer } from "jslib-common/importers/safariCsvImporter";
 import { CipherView } from "jslib-common/models/view/cipherView";
 import { LoginUriView } from "jslib-common/models/view/loginUriView";
 import { LoginView } from "jslib-common/models/view/loginView";


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Happily merged https://github.com/bitwarden/jslib/pull/730 and realized the import path for the safariCsvImporter was wrong and thus the build failed.

## Code changes
- **spec/common/importers/safariCsvImporter.spec.ts:** Fix the import path of the SafarCsvImporter

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
