### PR TITLE
Remove the VerifyMasterPasswordComponent from jslib module

### DIFF
--- a/angular/src/jslib.module.ts
+++ b/angular/src/jslib.module.ts
@@ -89,7 +89,6 @@ import { UserNamePipe } from "./pipes/user-name.pipe";
     UserNamePipe,
     CalloutComponent,
     IconComponent,
-    VerifyMasterPasswordComponent,
     ExportScopeCalloutComponent,
   ],
   providers: [UserNamePipe, SearchPipe, I18nPipe, DatePipe],

--- a/angular/src/jslib.module.ts
+++ b/angular/src/jslib.module.ts
@@ -7,7 +7,6 @@ import { CalloutComponent } from "./components/callout.component";
 import { ExportScopeCalloutComponent } from "./components/export-scope-callout.component";
 import { IconComponent } from "./components/icon.component";
 import { BitwardenToastModule } from "./components/toastr.component";
-import { VerifyMasterPasswordComponent } from "./components/verify-master-password.component";
 import { A11yInvalidDirective } from "./directives/a11y-invalid.directive";
 import { A11yTitleDirective } from "./directives/a11y-title.directive";
 import { ApiActionDirective } from "./directives/api-action.directive";
@@ -62,7 +61,6 @@ import { UserNamePipe } from "./pipes/user-name.pipe";
     UserNamePipe,
     CalloutComponent,
     IconComponent,
-    VerifyMasterPasswordComponent,
     ExportScopeCalloutComponent,
   ],
   exports: [


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We override the verify master password component in the client projects, which does not seem possible when the module is already defined.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
