### PR TITLE
Generator cleanup

### DIFF
--- a/angular/src/components/generator.component.ts
+++ b/angular/src/components/generator.component.ts
@@ -10,8 +10,8 @@ import { UsernameGenerationService } from "jslib-common/abstractions/usernameGen
 import { PasswordGeneratorPolicyOptions } from "jslib-common/models/domain/passwordGeneratorPolicyOptions";
 
 @Directive()
-export class PasswordGeneratorComponent implements OnInit {
-  @Input() showSelect = false;
+export class GeneratorComponent implements OnInit {
+  @Input() comingFromAddEdit = false;
   @Input() type: string;
   @Output() onSelected = new EventEmitter<string>();
 

--- a/angular/src/components/generator.component.ts
+++ b/angular/src/components/generator.component.ts
@@ -27,7 +27,6 @@ export class GeneratorComponent implements OnInit {
   password = "-";
   showOptions = false;
   avoidAmbiguous = false;
-  showWebsiteOption = false;
   enforcedPasswordPolicyOptions: PasswordGeneratorPolicyOptions;
   usernameWebsite: string = null;
 
@@ -78,11 +77,6 @@ export class GeneratorComponent implements OnInit {
       this.passwordOptions.type =
         this.passwordOptions.type === "passphrase" ? "passphrase" : "password";
 
-      if (this.showWebsiteOption) {
-        const websiteOption = { name: this.i18nService.t("websiteName"), value: "website-name" };
-        this.subaddressOptions.push(websiteOption);
-        this.catchallOptions.push(websiteOption);
-      }
       this.usernameOptions = await this.usernameGenerationService.getOptions();
       if (this.usernameOptions.type == null) {
         this.usernameOptions.type = "word";
@@ -93,11 +87,13 @@ export class GeneratorComponent implements OnInit {
       ) {
         this.usernameOptions.subaddressEmail = await this.stateService.getEmail();
       }
-      if (!this.showWebsiteOption) {
+      if (this.usernameWebsite == null) {
         this.usernameOptions.subaddressType = this.usernameOptions.catchallType = "random";
-      }
-      if (this.usernameWebsite != null) {
+      } else {
         this.usernameOptions.website = this.usernameWebsite;
+        const websiteOption = { name: this.i18nService.t("websiteName"), value: "website-name" };
+        this.subaddressOptions.push(websiteOption);
+        this.catchallOptions.push(websiteOption);
       }
 
       if (this.type !== "username" && this.type !== "password") {

--- a/angular/src/components/generator.component.ts
+++ b/angular/src/components/generator.component.ts
@@ -101,11 +101,7 @@ export class GeneratorComponent implements OnInit {
           this.type = qParams.type;
         } else {
           const generatorOptions = await this.stateService.getGeneratorOptions();
-          if (generatorOptions != null && generatorOptions.type != null) {
-            this.type = generatorOptions.type;
-          } else {
-            this.type = "password";
-          }
+          this.type = generatorOptions?.type ?? "password";
         }
       }
       await this.regenerate();

--- a/angular/src/components/password-generator.component.ts
+++ b/angular/src/components/password-generator.component.ts
@@ -12,7 +12,7 @@ import { PasswordGeneratorPolicyOptions } from "jslib-common/models/domain/passw
 @Directive()
 export class PasswordGeneratorComponent implements OnInit {
   @Input() showSelect = false;
-  @Input() type = "password";
+  @Input() type: string;
   @Output() onSelected = new EventEmitter<string>();
 
   typeOptions: any[];
@@ -100,12 +100,16 @@ export class PasswordGeneratorComponent implements OnInit {
         this.usernameOptions.website = this.usernameWebsite;
       }
 
-      if (qParams.type === "username" || qParams.type === "password") {
-        this.type = qParams.type;
-      } else {
-        const generatorOptions = await this.stateService.getGeneratorOptions();
-        if (generatorOptions != null && generatorOptions.type != null) {
-          this.type = generatorOptions.type;
+      if (this.type !== "username" && this.type !== "password") {
+        if (qParams.type === "username" || qParams.type === "password") {
+          this.type = qParams.type;
+        } else {
+          const generatorOptions = await this.stateService.getGeneratorOptions();
+          if (generatorOptions != null && generatorOptions.type != null) {
+            this.type = generatorOptions.type;
+          } else {
+            this.type = "password";
+          }
         }
       }
       await this.regenerate();


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Following the addition of the username generator, the password generator component had a few outstanding cleanup items to attend to. This PR addresses them. Client repo PRs reacting to these changes will follow.

## Code changes

- Rename `PasswordGenerator` component to `Generator`.
- Rename `showSelect` property to `comingFromAddEdit` per feedback from @eliykat 
- Remove `showWebsiteOption` property since the same logic can be derived from `usernameWebsite`.
- Default `type` to null so that it can be properly set based on logic from `onInit` or passed in from child component.

## Testing requirements

Standard generator testing as defined in previous PRs for this feature.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
