### PR TITLE
WIP Restore zoom factor on start bitwarden/desktop#540

### DIFF
--- a/electron/src/window.main.ts
+++ b/electron/src/window.main.ts
@@ -125,6 +125,7 @@ export class WindowMain {
         nodeIntegration: true,
         backgroundThrottling: false,
         contextIsolation: false,
+        zoomFactor: this.windowStates[mainWindowSizeKey].zoomFactor || "1",
       },
     });
 
@@ -229,6 +230,7 @@ export class WindowMain {
         this.windowStates[configKey].y = bounds.y;
         this.windowStates[configKey].width = bounds.width;
         this.windowStates[configKey].height = bounds.height;
+        this.windowStates[configKey].zoomFactor = this.win.webContents.getZoomFactor();
       }
 
       await this.stateService.setWindow(this.windowStates[configKey]);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix bitwarden/desktop#540

## Code changes

- **electron/src/window.main.ts:** Get the zoom factor when the app is closing and restore it before reopening it by putting it into BrowserWindow properties

## Testing requirements

- Test using Windows
- Test using a Linux distribution

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
