### PR TITLE
[bug] CL - fix default button display and callout header class

### DIFF
--- a/components/src/button/button.component.spec.ts
+++ b/components/src/button/button.component.spec.ts
@@ -1,10 +1,15 @@
-import { Component } from "@angular/core";
-import { TestBed, waitForAsync } from "@angular/core/testing";
+import { Component, DebugElement } from "@angular/core";
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
 import { ButtonModule } from "./index";
 
 describe("Button", () => {
+  let fixture: ComponentFixture<TestApp>;
+  let testAppComponent: TestApp;
+  let buttonDebugElement: DebugElement;
+  let linkDebugElement: DebugElement;
+
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
@@ -13,16 +18,14 @@ describe("Button", () => {
       });
 
       TestBed.compileComponents();
+      fixture = TestBed.createComponent(TestApp);
+      testAppComponent = fixture.debugElement.componentInstance;
+      buttonDebugElement = fixture.debugElement.query(By.css("button"));
+      linkDebugElement = fixture.debugElement.query(By.css("a"));
     })
   );
 
   it("should apply classes based on type", () => {
-    const fixture = TestBed.createComponent(TestApp);
-
-    const testAppComponent: TestApp = fixture.debugElement.componentInstance;
-    const buttonDebugElement = fixture.debugElement.query(By.css("button"));
-    const linkDebugElement = fixture.debugElement.query(By.css("a"));
-
     testAppComponent.buttonType = "primary";
     fixture.detectChanges();
     expect(buttonDebugElement.nativeElement.classList.contains("tw-bg-primary-500")).toBe(true);
@@ -43,15 +46,32 @@ describe("Button", () => {
     expect(buttonDebugElement.nativeElement.classList.contains("tw-border-text-muted")).toBe(true);
     expect(linkDebugElement.nativeElement.classList.contains("tw-border-text-muted")).toBe(true);
   });
+
+  it("should apply block when true and inline-block when false", () => {
+    testAppComponent.block = true;
+    fixture.detectChanges();
+    expect(buttonDebugElement.nativeElement.classList.contains("tw-block")).toBe(true);
+    expect(linkDebugElement.nativeElement.classList.contains("tw-block")).toBe(true);
+    expect(buttonDebugElement.nativeElement.classList.contains("tw-inline-block")).toBe(false);
+    expect(linkDebugElement.nativeElement.classList.contains("tw-inline-block")).toBe(false);
+
+    testAppComponent.block = false;
+    fixture.detectChanges();
+    expect(buttonDebugElement.nativeElement.classList.contains("tw-inline-block")).toBe(true);
+    expect(linkDebugElement.nativeElement.classList.contains("tw-inline-block")).toBe(true);
+    expect(buttonDebugElement.nativeElement.classList.contains("tw-block")).toBe(false);
+    expect(linkDebugElement.nativeElement.classList.contains("tw-block")).toBe(false);
+  });
 });
 
 @Component({
   selector: "test-app",
   template: `
-    <button type="button" bit-button [buttonType]="buttonType">Button</button>
-    <a href="#" bit-button [buttonType]="buttonType"> Link </a>
+    <button type="button" bit-button [buttonType]="buttonType" [block]="block">Button</button>
+    <a href="#" bit-button [buttonType]="buttonType" [block]="block"> Link </a>
   `,
 })
 class TestApp {
   buttonType: string;
+  block: boolean;
 }

--- a/components/src/button/button.component.ts
+++ b/components/src/button/button.component.ts
@@ -74,7 +74,7 @@ export class ButtonComponent implements OnInit, OnChanges {
       "focus:tw-ring",
       "focus:tw-ring-offset-2",
       "focus:tw-ring-primary-700",
-      this.block ? "tw-w-full tw-block" : "",
+      this.block ? "tw-w-full tw-block" : "tw-inline-block",
       buttonStyles[this.buttonType ?? "secondary"],
     ];
   }

--- a/components/src/callout/callout.component.spec.ts
+++ b/components/src/callout/callout.component.spec.ts
@@ -33,6 +33,7 @@ describe("Callout", () => {
       fixture.detectChanges();
       expect(component.title).toBeUndefined();
       expect(component.icon).toBe("bwi-check");
+      expect(component.headerClass).toBe("!tw-text-success");
     });
 
     it("info", () => {
@@ -40,6 +41,7 @@ describe("Callout", () => {
       fixture.detectChanges();
       expect(component.title).toBeUndefined();
       expect(component.icon).toBe("bwi-info-circle");
+      expect(component.headerClass).toBe("!tw-text-info");
     });
 
     it("warning", () => {
@@ -47,6 +49,7 @@ describe("Callout", () => {
       fixture.detectChanges();
       expect(component.title).toBe("Warning");
       expect(component.icon).toBe("bwi-exclamation-triangle");
+      expect(component.headerClass).toBe("!tw-text-warning");
     });
 
     it("danger", () => {
@@ -54,6 +57,7 @@ describe("Callout", () => {
       fixture.detectChanges();
       expect(component.title).toBe("Error");
       expect(component.icon).toBe("bwi-error");
+      expect(component.headerClass).toBe("!tw-text-danger");
     });
   });
 });

--- a/components/src/callout/callout.component.ts
+++ b/components/src/callout/callout.component.ts
@@ -51,13 +51,13 @@ export class CalloutComponent implements OnInit {
   get headerClass() {
     switch (this.type) {
       case "danger":
-        return "tw-text-danger";
+        return "!tw-text-danger";
       case "info":
-        return "tw-text-info";
+        return "!tw-text-info";
       case "success":
-        return "tw-text-success";
+        return "!tw-text-success";
       case "warning":
-        return "tw-text-warning";
+        return "!tw-text-warning";
     }
   }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Callout `headerClass` color was being overridden via Bootstrap styling on the client level. Force the color to be `important!`
> Button `display` was not defaulting to `inline-block`

## Code changes
- **button.component.spec.ts**: Added tests for handling `block` vs `inline-block` display styling
- **button.component.ts**: Defaulted display styling to `inline-block` to match existing button pattern
- **callout.component.spec.ts**: Added additional context to existing tests regarding the `headerClass` color
- **callout.component.ts**: Forced `headerClass` to be `important!` in order to override bootstrap styling on the client

## Testing requirements
- Make sure Callout's `headerClass` matches the desired color scheme
- Make sure Button's default `display` styling is `inline-block`

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
