### PR TITLE
[EC-142] Fix error during import of 1pux containing new email field format

### DIFF
--- a/common/spec/importers/onepassword1PuxImporter.spec.ts
+++ b/common/spec/importers/onepassword1PuxImporter.spec.ts
@@ -12,6 +12,8 @@ import { DatabaseData } from "./testData/onePassword1Pux/Database";
 import { DriversLicenseData } from "./testData/onePassword1Pux/DriversLicense";
 import { EmailAccountData } from "./testData/onePassword1Pux/EmailAccount";
 import { EmailFieldData } from "./testData/onePassword1Pux/Emailfield";
+import { EmailFieldOnIdentityData } from "./testData/onePassword1Pux/EmailfieldOnIdentity";
+import { EmailFieldOnIdentityPrefilledData } from "./testData/onePassword1Pux/EmailfieldOnIdentity_Prefilled";
 import { IdentityData } from "./testData/onePassword1Pux/IdentityData";
 import { LoginData } from "./testData/onePassword1Pux/LoginData";
 import { MedicalRecordData } from "./testData/onePassword1Pux/MedicalRecord";
@@ -223,6 +225,46 @@ describe("1Password 1Pux Importer", () => {
     validateCustomField(cipher.fields, "yahoo", "sk8rboi13@yah00.com");
     validateCustomField(cipher.fields, "msn", "msnothankyou@msn&m&m.com");
     validateCustomField(cipher.fields, "forumsig", "super cool guy");
+  });
+
+  it("emails fields on identity types should be added to the identity email field", async () => {
+    const importer = new Importer();
+    const EmailFieldOnIdentityDataJson = JSON.stringify(EmailFieldOnIdentityData);
+    const result = await importer.parse(EmailFieldOnIdentityDataJson);
+    expect(result != null).toBe(true);
+
+    const ciphers = result.ciphers;
+    expect(ciphers.length).toEqual(1);
+    const cipher = ciphers.shift();
+
+    const identity = cipher.identity;
+    expect(identity.email).toEqual("gengels@nullvalue.test");
+
+    expect(cipher.fields[0].name).toEqual("provider");
+    expect(cipher.fields[0].value).toEqual("myEmailProvider");
+    expect(cipher.fields[0].type).toBe(FieldType.Text);
+  });
+
+  it("emails fields on identity types should be added to custom fields if identity.email has been filled", async () => {
+    const importer = new Importer();
+    const EmailFieldOnIdentityPrefilledDataJson = JSON.stringify(EmailFieldOnIdentityPrefilledData);
+    const result = await importer.parse(EmailFieldOnIdentityPrefilledDataJson);
+    expect(result != null).toBe(true);
+
+    const ciphers = result.ciphers;
+    expect(ciphers.length).toEqual(1);
+    const cipher = ciphers.shift();
+
+    const identity = cipher.identity;
+    expect(identity.email).toEqual("gengels@nullvalue.test");
+
+    expect(cipher.fields[0].name).toEqual("2nd_email");
+    expect(cipher.fields[0].value).toEqual("kriddler@nullvalue.test");
+    expect(cipher.fields[0].type).toBe(FieldType.Text);
+
+    expect(cipher.fields[1].name).toEqual("provider");
+    expect(cipher.fields[1].value).toEqual("myEmailProvider");
+    expect(cipher.fields[1].type).toBe(FieldType.Text);
   });
 
   it("should parse category 005 - Password (Legacy)", async () => {

--- a/common/spec/importers/onepassword1PuxImporter.spec.ts
+++ b/common/spec/importers/onepassword1PuxImporter.spec.ts
@@ -11,6 +11,7 @@ import { CreditCardData } from "./testData/onePassword1Pux/CreditCard";
 import { DatabaseData } from "./testData/onePassword1Pux/Database";
 import { DriversLicenseData } from "./testData/onePassword1Pux/DriversLicense";
 import { EmailAccountData } from "./testData/onePassword1Pux/EmailAccount";
+import { EmailFieldData } from "./testData/onePassword1Pux/Emailfield";
 import { IdentityData } from "./testData/onePassword1Pux/IdentityData";
 import { LoginData } from "./testData/onePassword1Pux/LoginData";
 import { MedicalRecordData } from "./testData/onePassword1Pux/MedicalRecord";
@@ -100,6 +101,25 @@ describe("1Password 1Pux Importer", () => {
     expect(cipher.fields[1].name).toEqual("policies");
     expect(cipher.fields[1].value).toEqual("true");
     expect(cipher.fields[1].type).toBe(FieldType.Boolean);
+  });
+
+  it("should add fields of type email as custom fields", async () => {
+    const importer = new Importer();
+    const EmailFieldDataJson = JSON.stringify(EmailFieldData);
+    const result = await importer.parse(EmailFieldDataJson);
+    expect(result != null).toBe(true);
+
+    const ciphers = result.ciphers;
+    expect(ciphers.length).toEqual(1);
+    const cipher = ciphers.shift();
+
+    expect(cipher.fields[0].name).toEqual("reg_email");
+    expect(cipher.fields[0].value).toEqual("kriddler@nullvalue.test");
+    expect(cipher.fields[0].type).toBe(FieldType.Text);
+
+    expect(cipher.fields[1].name).toEqual("provider");
+    expect(cipher.fields[1].value).toEqual("myEmailProvider");
+    expect(cipher.fields[1].type).toBe(FieldType.Text);
   });
 
   it('should create concealed field as "hidden" type', async () => {

--- a/common/spec/importers/testData/onePassword1Pux/Emailfield.ts
+++ b/common/spec/importers/testData/onePassword1Pux/Emailfield.ts
@@ -1,0 +1,91 @@
+import { ExportData } from "jslib-common/importers/onepasswordImporters/types/onepassword1PuxImporterTypes";
+
+export const EmailFieldData: ExportData = {
+  accounts: [
+    {
+      attrs: {
+        accountName: "1Password Customer",
+        name: "1Password Customer",
+        avatar: "",
+        email: "username123123123@gmail.com",
+        uuid: "TRIZ3XV4JJFRXJ3BARILLTUA6E",
+        domain: "https://my.1password.com/",
+      },
+      vaults: [
+        {
+          attrs: {
+            uuid: "pqcgbqjxr4tng2hsqt5ffrgwju",
+            desc: "Just test entries",
+            avatar: "ke7i5rxnjrh3tj6uesstcosspu.png",
+            name: "T's Test Vault",
+            type: "U",
+          },
+          items: [
+            {
+              uuid: "47hvppiuwbanbza7bq6jpdjfxu",
+              favIndex: 1,
+              createdAt: 1619467985,
+              updatedAt: 1619468230,
+              trashed: false,
+              categoryUuid: "100",
+              details: {
+                loginFields: [],
+                notesPlain: "My Software License",
+                sections: [
+                  {
+                    title: "",
+                    fields: [],
+                  },
+                  {
+                    title: "Customer",
+                    name: "customer",
+                    fields: [
+                      {
+                        title: "registered email",
+                        id: "reg_email",
+                        value: {
+                          email: {
+                            email_address: "kriddler@nullvalue.test",
+                            provider: "myEmailProvider",
+                          },
+                        },
+                        indexAtSource: 1,
+                        guarded: false,
+                        multiline: false,
+                        dontGenerate: false,
+                        inputTraits: {
+                          keyboard: "emailAddress",
+                          correction: "default",
+                          capitalization: "default",
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    title: "Publisher",
+                    name: "publisher",
+                    fields: [],
+                  },
+                  {
+                    title: "Order",
+                    name: "order",
+                    fields: [],
+                  },
+                ],
+                passwordHistory: [],
+              },
+              overview: {
+                subtitle: "5.10.1000",
+                title: "Limux Product Key",
+                url: "",
+                ps: 0,
+                pbe: 0.0,
+                pgrng: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/common/spec/importers/testData/onePassword1Pux/EmailfieldOnIdentity.ts
+++ b/common/spec/importers/testData/onePassword1Pux/EmailfieldOnIdentity.ts
@@ -1,0 +1,87 @@
+import { ExportData } from "jslib-common/importers/onepasswordImporters/types/onepassword1PuxImporterTypes";
+
+export const EmailFieldOnIdentityData: ExportData = {
+  accounts: [
+    {
+      attrs: {
+        accountName: "1Password Customer",
+        name: "1Password Customer",
+        avatar: "",
+        email: "username123123123@gmail.com",
+        uuid: "TRIZ3XV4JJFRXJ3BARILLTUA6E",
+        domain: "https://my.1password.com/",
+      },
+      vaults: [
+        {
+          attrs: {
+            uuid: "pqcgbqjxr4tng2hsqt5ffrgwju",
+            desc: "Just test entries",
+            avatar: "ke7i5rxnjrh3tj6uesstcosspu.png",
+            name: "T's Test Vault",
+            type: "U",
+          },
+          items: [
+            {
+              uuid: "45mjttbbq3owgij2uis55pfrlq",
+              favIndex: 0,
+              createdAt: 1619465450,
+              updatedAt: 1619465789,
+              trashed: false,
+              categoryUuid: "004",
+              details: {
+                loginFields: [],
+                notesPlain: "",
+                sections: [
+                  {
+                    title: "Identification",
+                    name: "name",
+                    fields: [],
+                  },
+                  {
+                    title: "Address",
+                    name: "address",
+                    fields: [],
+                  },
+                  {
+                    title: "Internet Details",
+                    name: "internet",
+                    fields: [
+                      {
+                        title: "E-mail",
+                        id: "E-mail",
+                        value: {
+                          email: {
+                            email_address: "gengels@nullvalue.test",
+                            provider: "myEmailProvider",
+                          },
+                        },
+                        indexAtSource: 4,
+                        guarded: false,
+                        multiline: false,
+                        dontGenerate: false,
+                        inputTraits: {
+                          keyboard: "emailAddress",
+                          correction: "default",
+                          capitalization: "default",
+                        },
+                      },
+                    ],
+                  },
+                ],
+                passwordHistory: [],
+              },
+              overview: {
+                subtitle: "George Engels",
+                title: "George Engels",
+                url: "",
+                ps: 0,
+                pbe: 0.0,
+                pgrng: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/common/spec/importers/testData/onePassword1Pux/EmailfieldOnIdentity_Prefilled.ts
+++ b/common/spec/importers/testData/onePassword1Pux/EmailfieldOnIdentity_Prefilled.ts
@@ -1,0 +1,103 @@
+import { ExportData } from "jslib-common/importers/onepasswordImporters/types/onepassword1PuxImporterTypes";
+
+export const EmailFieldOnIdentityPrefilledData: ExportData = {
+  accounts: [
+    {
+      attrs: {
+        accountName: "1Password Customer",
+        name: "1Password Customer",
+        avatar: "",
+        email: "username123123123@gmail.com",
+        uuid: "TRIZ3XV4JJFRXJ3BARILLTUA6E",
+        domain: "https://my.1password.com/",
+      },
+      vaults: [
+        {
+          attrs: {
+            uuid: "pqcgbqjxr4tng2hsqt5ffrgwju",
+            desc: "Just test entries",
+            avatar: "ke7i5rxnjrh3tj6uesstcosspu.png",
+            name: "T's Test Vault",
+            type: "U",
+          },
+          items: [
+            {
+              uuid: "45mjttbbq3owgij2uis55pfrlq",
+              favIndex: 0,
+              createdAt: 1619465450,
+              updatedAt: 1619465789,
+              trashed: false,
+              categoryUuid: "004",
+              details: {
+                loginFields: [],
+                notesPlain: "",
+                sections: [
+                  {
+                    title: "Identification",
+                    name: "name",
+                    fields: [],
+                  },
+                  {
+                    title: "Address",
+                    name: "address",
+                    fields: [],
+                  },
+                  {
+                    title: "Internet Details",
+                    name: "internet",
+                    fields: [
+                      {
+                        title: "email",
+                        id: "email",
+                        value: {
+                          string: "gengels@nullvalue.test",
+                        },
+                        indexAtSource: 4,
+                        guarded: false,
+                        multiline: false,
+                        dontGenerate: false,
+                        inputTraits: {
+                          keyboard: "emailAddress",
+                          correction: "default",
+                          capitalization: "default",
+                        },
+                      },
+                      {
+                        title: "2nd email",
+                        id: "2nd_email",
+                        value: {
+                          email: {
+                            email_address: "kriddler@nullvalue.test",
+                            provider: "myEmailProvider",
+                          },
+                        },
+                        indexAtSource: 1,
+                        guarded: false,
+                        multiline: false,
+                        dontGenerate: false,
+                        inputTraits: {
+                          keyboard: "emailAddress",
+                          correction: "default",
+                          capitalization: "default",
+                        },
+                      },
+                    ],
+                  },
+                ],
+                passwordHistory: [],
+              },
+              overview: {
+                subtitle: "George Engels",
+                title: "George Engels",
+                url: "",
+                ps: 0,
+                pbe: 0.0,
+                pgrng: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/common/spec/importers/testData/onePassword1Pux/SanitizedExport.ts
+++ b/common/spec/importers/testData/onePassword1Pux/SanitizedExport.ts
@@ -344,7 +344,10 @@ export const SanitizedExport: ExportData = {
                         title: "",
                         id: "irpvnshg5kjpkmj5jwy4xxkfom",
                         value: {
-                          email: "plexuser@nullvalue.test",
+                          email: {
+                            email_address: "plexuser@nullvalue.test",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 0,
                         guarded: false,
@@ -1434,7 +1437,10 @@ export const SanitizedExport: ExportData = {
                         title: "registered email",
                         id: "reg_email",
                         value: {
-                          email: "kriddler@nullvalue.test",
+                          email: {
+                            email_address: "kriddler@nullvalue.test",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 1,
                         guarded: false,
@@ -1536,7 +1542,10 @@ export const SanitizedExport: ExportData = {
                         title: "support email",
                         id: "support_email",
                         value: {
-                          email: "support@nullvalue.test",
+                          email: {
+                            email_address: "support@nullvalue.test",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 4,
                         guarded: false,
@@ -4014,7 +4023,10 @@ export const SanitizedExport: ExportData = {
                         title: "registered email",
                         id: "reg_email",
                         value: {
-                          email: "",
+                          email: {
+                            email_address: "",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 1,
                         guarded: false,
@@ -4116,7 +4128,10 @@ export const SanitizedExport: ExportData = {
                         title: "support email",
                         id: "support_email",
                         value: {
-                          email: "",
+                          email: {
+                            email_address: "",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 4,
                         guarded: false,

--- a/common/spec/importers/testData/onePassword1Pux/SoftwareLicense.ts
+++ b/common/spec/importers/testData/onePassword1Pux/SoftwareLicense.ts
@@ -93,7 +93,10 @@ export const SoftwareLicenseData: ExportData = {
                         title: "registered email",
                         id: "reg_email",
                         value: {
-                          email: "kriddler@nullvalue.test",
+                          email: {
+                            email_address: "kriddler@nullvalue.test",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 1,
                         guarded: false,
@@ -195,7 +198,10 @@ export const SoftwareLicenseData: ExportData = {
                         title: "support email",
                         id: "support_email",
                         value: {
-                          email: "support@nullvalue.test",
+                          email: {
+                            email_address: "support@nullvalue.test",
+                            provider: null,
+                          },
                         },
                         indexAtSource: 4,
                         guarded: false,

--- a/common/src/importers/onepasswordImporters/onepassword1PuxImporter.ts
+++ b/common/src/importers/onepasswordImporters/onepassword1PuxImporter.ts
@@ -258,7 +258,7 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
           }
         }
       } else if (cipher.type === CipherType.Identity) {
-        if (this.fillIdentity(field, fieldValue, cipher)) {
+        if (this.fillIdentity(field, fieldValue, cipher, valueKey)) {
           return;
         }
         if (valueKey === "address") {
@@ -448,7 +448,12 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
     return false;
   }
 
-  private fillIdentity(field: FieldsEntity, fieldValue: string, cipher: CipherView): boolean {
+  private fillIdentity(
+    field: FieldsEntity,
+    fieldValue: string,
+    cipher: CipherView,
+    valueKey: string
+  ): boolean {
     if (this.isNullOrWhitespace(cipher.identity.firstName) && field.id === "firstname") {
       cipher.identity.firstName = fieldValue;
       return true;
@@ -474,9 +479,18 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
       return true;
     }
 
-    if (this.isNullOrWhitespace(cipher.identity.email) && field.id === "email") {
-      cipher.identity.email = fieldValue;
-      return true;
+    if (this.isNullOrWhitespace(cipher.identity.email)) {
+      if (valueKey === "email") {
+        const { email_address, provider } = field.value.email;
+        cipher.identity.email = this.getValueOrDefault(email_address);
+        this.processKvp(cipher, "provider", provider, FieldType.Text);
+        return true;
+      }
+
+      if (field.id === "email") {
+        cipher.identity.email = fieldValue;
+        return true;
+      }
     }
 
     if (this.isNullOrWhitespace(cipher.identity.username) && field.id === "username") {

--- a/common/src/importers/onepasswordImporters/onepassword1PuxImporter.ts
+++ b/common/src/importers/onepasswordImporters/onepassword1PuxImporter.ts
@@ -312,6 +312,14 @@ export class OnePassword1PuxImporter extends BaseImporter implements Importer {
         }
       }
 
+      if (valueKey === "email") {
+        // fieldValue is an object casted into a string, so access the plain value instead
+        const { email_address, provider } = field.value.email;
+        this.processKvp(cipher, fieldName, email_address, FieldType.Text);
+        this.processKvp(cipher, "provider", provider, FieldType.Text);
+        return;
+      }
+
       // Do not include a password field if it's already in the history
       if (
         field.title === "password" &&

--- a/common/src/importers/onepasswordImporters/types/onepassword1PuxImporterTypes.ts
+++ b/common/src/importers/onepasswordImporters/types/onepassword1PuxImporterTypes.ts
@@ -106,7 +106,7 @@ export interface Value {
   date?: number | null;
   string?: string | null;
   concealed?: string | null;
-  email?: string | null;
+  email?: Email | null;
   phone?: string | null;
   menu?: string | null;
   gender?: string | null;
@@ -117,6 +117,12 @@ export interface Value {
   creditCardNumber?: string | null;
   reference?: string | null;
 }
+
+export interface Email {
+  email_address: string;
+  provider: string;
+}
+
 export interface Address {
   street: string;
   city: string;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Some user where experiencing issues while importing a 1pux export into Bitwarden. The reason being, that a new email field type was introduced which got parsed incorrectly. This caused corruption while encrypting into a Bitwarden identity type and failed the import.

I also discovered that these email fields got falsely skipped and should have been imported as custom fields.

Old format
```
"value": {
    "string": "someuser@someprovider.com"
},
```

New format
```
"value": {
    "email": {
        "email_address": "someuser@someprovider.com",
        "provider": null
    }
},
```

Original report: https://github.com/bitwarden/web/issues/1548

## Code changes

- **common/src/importers/onepasswordImporters/types/onepassword1PuxImporterTypes.ts:** Change type of email field typefrom string to object
- **common/src/importers/onepasswordImporters/onepassword1PuxImporter.ts:** 
  - Import complex email field type as custom field
  - Import complex email field type as email field on identities
  - Only save in indentity.email if it is empty, if not save as custom field
  - If provider property of email field is filled, save it as custom field
 - **common/spec/importers/onepassword1PuxImporter.spec.ts:** Add additional test cases for complex email field
- **common/spec/importers/testData/onePassword1Pux/*.ts:** 
  - Files with testdata to support the test cases
  - Fixed formatting of existing test data files

## Testing requirements
Test cases will be described on the web PR following this, after merge.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
