### PR TITLE
Rename Export DTOs

### DIFF
--- a/common/spec/services/export.service.spec.ts
+++ b/common/spec/services/export.service.spec.ts
@@ -11,7 +11,7 @@ import { Utils } from "jslib-common/misc/utils";
 import { Cipher } from "jslib-common/models/domain/cipher";
 import { EncString } from "jslib-common/models/domain/encString";
 import { Login } from "jslib-common/models/domain/login";
-import { CipherWithIds as CipherExport } from "jslib-common/models/export/cipherWithIds";
+import { CipherWithIdExport as CipherExport } from "jslib-common/models/export/cipherWithIdsExport";
 import { CipherView } from "jslib-common/models/view/cipherView";
 import { LoginView } from "jslib-common/models/view/loginView";
 import { ExportService } from "jslib-common/services/export.service";

--- a/common/src/importers/bitwardenJsonImporter.ts
+++ b/common/src/importers/bitwardenJsonImporter.ts
@@ -2,9 +2,9 @@ import { CryptoService } from "../abstractions/crypto.service";
 import { I18nService } from "../abstractions/i18n.service";
 import { EncString } from "../models/domain/encString";
 import { ImportResult } from "../models/domain/importResult";
-import { CipherWithIds } from "../models/export/cipherWithIds";
-import { CollectionWithId } from "../models/export/collectionWithId";
-import { FolderWithId } from "../models/export/folderWithId";
+import { CipherWithIdExport } from "../models/export/cipherWithIdsExport";
+import { CollectionWithIdExport } from "../models/export/collectionWithIdExport";
+import { FolderWithIdExport } from "../models/export/folderWithIdExport";
 
 import { BaseImporter } from "./baseImporter";
 import { Importer } from "./importer";
@@ -59,8 +59,8 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
     const groupingsMap = new Map<string, number>();
 
     if (this.organization && this.results.collections != null) {
-      for (const c of this.results.collections as CollectionWithId[]) {
-        const collection = CollectionWithId.toDomain(c);
+      for (const c of this.results.collections as CollectionWithIdExport[]) {
+        const collection = CollectionWithIdExport.toDomain(c);
         if (collection != null) {
           collection.id = null;
           collection.organizationId = this.organizationId;
@@ -70,8 +70,8 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
         }
       }
     } else if (!this.organization && this.results.folders != null) {
-      for (const f of this.results.folders as FolderWithId[]) {
-        const folder = FolderWithId.toDomain(f);
+      for (const f of this.results.folders as FolderWithIdExport[]) {
+        const folder = FolderWithIdExport.toDomain(f);
         if (folder != null) {
           folder.id = null;
           const view = await folder.decrypt();
@@ -81,8 +81,8 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
       }
     }
 
-    for (const c of this.results.items as CipherWithIds[]) {
-      const cipher = CipherWithIds.toDomain(c);
+    for (const c of this.results.items as CipherWithIdExport[]) {
+      const cipher = CipherWithIdExport.toDomain(c);
       // reset ids incase they were set for some reason
       cipher.id = null;
       cipher.folderId = null;
@@ -121,8 +121,8 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
   private parseDecrypted() {
     const groupingsMap = new Map<string, number>();
     if (this.organization && this.results.collections != null) {
-      this.results.collections.forEach((c: CollectionWithId) => {
-        const collection = CollectionWithId.toView(c);
+      this.results.collections.forEach((c: CollectionWithIdExport) => {
+        const collection = CollectionWithIdExport.toView(c);
         if (collection != null) {
           collection.id = null;
           collection.organizationId = null;
@@ -131,8 +131,8 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
         }
       });
     } else if (!this.organization && this.results.folders != null) {
-      this.results.folders.forEach((f: FolderWithId) => {
-        const folder = FolderWithId.toView(f);
+      this.results.folders.forEach((f: FolderWithIdExport) => {
+        const folder = FolderWithIdExport.toView(f);
         if (folder != null) {
           folder.id = null;
           groupingsMap.set(f.id, this.result.folders.length);
@@ -141,8 +141,8 @@ export class BitwardenJsonImporter extends BaseImporter implements Importer {
       });
     }
 
-    this.results.items.forEach((c: CipherWithIds) => {
-      const cipher = CipherWithIds.toView(c);
+    this.results.items.forEach((c: CipherWithIdExport) => {
+      const cipher = CipherWithIdExport.toView(c);
       // reset ids incase they were set for some reason
       cipher.id = null;
       cipher.folderId = null;

--- a/common/src/models/export/cardExport.ts
+++ b/common/src/models/export/cardExport.ts
@@ -2,9 +2,9 @@ import { Card as CardDomain } from "../domain/card";
 import { EncString } from "../domain/encString";
 import { CardView } from "../view/cardView";
 
-export class Card {
-  static template(): Card {
-    const req = new Card();
+export class CardExport {
+  static template(): CardExport {
+    const req = new CardExport();
     req.cardholderName = "John Doe";
     req.brand = "visa";
     req.number = "4242424242424242";
@@ -14,7 +14,7 @@ export class Card {
     return req;
   }
 
-  static toView(req: Card, view = new CardView()) {
+  static toView(req: CardExport, view = new CardView()) {
     view.cardholderName = req.cardholderName;
     view.brand = req.brand;
     view.number = req.number;
@@ -24,7 +24,7 @@ export class Card {
     return view;
   }
 
-  static toDomain(req: Card, domain = new CardDomain()) {
+  static toDomain(req: CardExport, domain = new CardDomain()) {
     domain.cardholderName = req.cardholderName != null ? new EncString(req.cardholderName) : null;
     domain.brand = req.brand != null ? new EncString(req.brand) : null;
     domain.number = req.number != null ? new EncString(req.number) : null;

--- a/common/src/models/export/cipherExport.ts
+++ b/common/src/models/export/cipherExport.ts
@@ -4,15 +4,15 @@ import { Cipher as CipherDomain } from "../domain/cipher";
 import { EncString } from "../domain/encString";
 import { CipherView } from "../view/cipherView";
 
-import { Card } from "./card";
-import { Field } from "./field";
-import { Identity } from "./identity";
-import { Login } from "./login";
-import { SecureNote } from "./secureNote";
+import { CardExport } from "./cardExport";
+import { FieldExport } from "./fieldExport";
+import { IdentityExport } from "./identityExport";
+import { LoginExport } from "./loginExport";
+import { SecureNoteExport } from "./secureNoteExport";
 
-export class Cipher {
-  static template(): Cipher {
-    const req = new Cipher();
+export class CipherExport {
+  static template(): CipherExport {
+    const req = new CipherExport();
     req.organizationId = null;
     req.collectionIds = null;
     req.folderId = null;
@@ -29,7 +29,7 @@ export class Cipher {
     return req;
   }
 
-  static toView(req: Cipher, view = new CipherView()) {
+  static toView(req: CipherExport, view = new CipherView()) {
     view.type = req.type;
     view.folderId = req.folderId;
     if (view.organizationId == null) {
@@ -45,28 +45,28 @@ export class Cipher {
     view.reprompt = req.reprompt ?? CipherRepromptType.None;
 
     if (req.fields != null) {
-      view.fields = req.fields.map((f) => Field.toView(f));
+      view.fields = req.fields.map((f) => FieldExport.toView(f));
     }
 
     switch (req.type) {
       case CipherType.Login:
-        view.login = Login.toView(req.login);
+        view.login = LoginExport.toView(req.login);
         break;
       case CipherType.SecureNote:
-        view.secureNote = SecureNote.toView(req.secureNote);
+        view.secureNote = SecureNoteExport.toView(req.secureNote);
         break;
       case CipherType.Card:
-        view.card = Card.toView(req.card);
+        view.card = CardExport.toView(req.card);
         break;
       case CipherType.Identity:
-        view.identity = Identity.toView(req.identity);
+        view.identity = IdentityExport.toView(req.identity);
         break;
     }
 
     return view;
   }
 
-  static toDomain(req: Cipher, domain = new CipherDomain()) {
+  static toDomain(req: CipherExport, domain = new CipherDomain()) {
     domain.type = req.type;
     domain.folderId = req.folderId;
     if (domain.organizationId == null) {
@@ -78,21 +78,21 @@ export class Cipher {
     domain.reprompt = req.reprompt ?? CipherRepromptType.None;
 
     if (req.fields != null) {
-      domain.fields = req.fields.map((f) => Field.toDomain(f));
+      domain.fields = req.fields.map((f) => FieldExport.toDomain(f));
     }
 
     switch (req.type) {
       case CipherType.Login:
-        domain.login = Login.toDomain(req.login);
+        domain.login = LoginExport.toDomain(req.login);
         break;
       case CipherType.SecureNote:
-        domain.secureNote = SecureNote.toDomain(req.secureNote);
+        domain.secureNote = SecureNoteExport.toDomain(req.secureNote);
         break;
       case CipherType.Card:
-        domain.card = Card.toDomain(req.card);
+        domain.card = CardExport.toDomain(req.card);
         break;
       case CipherType.Identity:
-        domain.identity = Identity.toDomain(req.identity);
+        domain.identity = IdentityExport.toDomain(req.identity);
         break;
     }
 
@@ -106,11 +106,11 @@ export class Cipher {
   name: string;
   notes: string;
   favorite: boolean;
-  fields: Field[];
-  login: Login;
-  secureNote: SecureNote;
-  card: Card;
-  identity: Identity;
+  fields: FieldExport[];
+  login: LoginExport;
+  secureNote: SecureNoteExport;
+  card: CardExport;
+  identity: IdentityExport;
   reprompt: CipherRepromptType;
 
   // Use build method instead of ctor so that we can control order of JSON stringify for pretty print
@@ -132,24 +132,24 @@ export class Cipher {
 
     if (o.fields != null) {
       if (o instanceof CipherView) {
-        this.fields = o.fields.map((f) => new Field(f));
+        this.fields = o.fields.map((f) => new FieldExport(f));
       } else {
-        this.fields = o.fields.map((f) => new Field(f));
+        this.fields = o.fields.map((f) => new FieldExport(f));
       }
     }
 
     switch (o.type) {
       case CipherType.Login:
-        this.login = new Login(o.login);
+        this.login = new LoginExport(o.login);
         break;
       case CipherType.SecureNote:
-        this.secureNote = new SecureNote(o.secureNote);
+        this.secureNote = new SecureNoteExport(o.secureNote);
         break;
       case CipherType.Card:
-        this.card = new Card(o.card);
+        this.card = new CardExport(o.card);
         break;
       case CipherType.Identity:
-        this.identity = new Identity(o.identity);
+        this.identity = new IdentityExport(o.identity);
         break;
     }
   }

--- a/common/src/models/export/cipherWithIdsExport.ts
+++ b/common/src/models/export/cipherWithIdsExport.ts
@@ -1,9 +1,9 @@
 import { Cipher as CipherDomain } from "../domain/cipher";
 import { CipherView } from "../view/cipherView";
 
-import { Cipher } from "./cipher";
+import { CipherExport } from "./cipherExport";
 
-export class CipherWithIds extends Cipher {
+export class CipherWithIdExport extends CipherExport {
   id: string;
   collectionIds: string[];
 

--- a/common/src/models/export/collectionExport.ts
+++ b/common/src/models/export/collectionExport.ts
@@ -2,16 +2,16 @@ import { Collection as CollectionDomain } from "../domain/collection";
 import { EncString } from "../domain/encString";
 import { CollectionView } from "../view/collectionView";
 
-export class Collection {
-  static template(): Collection {
-    const req = new Collection();
+export class CollectionExport {
+  static template(): CollectionExport {
+    const req = new CollectionExport();
     req.organizationId = "00000000-0000-0000-0000-000000000000";
     req.name = "Collection name";
     req.externalId = null;
     return req;
   }
 
-  static toView(req: Collection, view = new CollectionView()) {
+  static toView(req: CollectionExport, view = new CollectionView()) {
     view.name = req.name;
     view.externalId = req.externalId;
     if (view.organizationId == null) {
@@ -20,7 +20,7 @@ export class Collection {
     return view;
   }
 
-  static toDomain(req: Collection, domain = new CollectionDomain()) {
+  static toDomain(req: CollectionExport, domain = new CollectionDomain()) {
     domain.name = req.name != null ? new EncString(req.name) : null;
     domain.externalId = req.externalId;
     if (domain.organizationId == null) {

--- a/common/src/models/export/collectionWithIdExport.ts
+++ b/common/src/models/export/collectionWithIdExport.ts
@@ -1,9 +1,9 @@
 import { Collection as CollectionDomain } from "../domain/collection";
 import { CollectionView } from "../view/collectionView";
 
-import { Collection } from "./collection";
+import { CollectionExport } from "./collectionExport";
 
-export class CollectionWithId extends Collection {
+export class CollectionWithIdExport extends CollectionExport {
   id: string;
 
   // Use build method instead of ctor so that we can control order of JSON stringify for pretty print

--- a/common/src/models/export/eventExport.ts
+++ b/common/src/models/export/eventExport.ts
@@ -1,7 +1,7 @@
 import { EventType } from "../../enums/eventType";
 import { EventView } from "../view/eventView";
 
-export class Event {
+export class EventExport {
   message: string;
   appIcon: string;
   appName: string;

--- a/common/src/models/export/fieldExport.ts
+++ b/common/src/models/export/fieldExport.ts
@@ -4,16 +4,16 @@ import { EncString } from "../domain/encString";
 import { Field as FieldDomain } from "../domain/field";
 import { FieldView } from "../view/fieldView";
 
-export class Field {
-  static template(): Field {
-    const req = new Field();
+export class FieldExport {
+  static template(): FieldExport {
+    const req = new FieldExport();
     req.name = "Field name";
     req.value = "Some value";
     req.type = FieldType.Text;
     return req;
   }
 
-  static toView(req: Field, view = new FieldView()) {
+  static toView(req: FieldExport, view = new FieldView()) {
     view.type = req.type;
     view.value = req.value;
     view.name = req.name;
@@ -21,7 +21,7 @@ export class Field {
     return view;
   }
 
-  static toDomain(req: Field, domain = new FieldDomain()) {
+  static toDomain(req: FieldExport, domain = new FieldDomain()) {
     domain.type = req.type;
     domain.value = req.value != null ? new EncString(req.value) : null;
     domain.name = req.name != null ? new EncString(req.name) : null;

--- a/common/src/models/export/folderExport.ts
+++ b/common/src/models/export/folderExport.ts
@@ -2,19 +2,19 @@ import { EncString } from "../domain/encString";
 import { Folder as FolderDomain } from "../domain/folder";
 import { FolderView } from "../view/folderView";
 
-export class Folder {
-  static template(): Folder {
-    const req = new Folder();
+export class FolderExport {
+  static template(): FolderExport {
+    const req = new FolderExport();
     req.name = "Folder name";
     return req;
   }
 
-  static toView(req: Folder, view = new FolderView()) {
+  static toView(req: FolderExport, view = new FolderView()) {
     view.name = req.name;
     return view;
   }
 
-  static toDomain(req: Folder, domain = new FolderDomain()) {
+  static toDomain(req: FolderExport, domain = new FolderDomain()) {
     domain.name = req.name != null ? new EncString(req.name) : null;
     return domain;
   }

--- a/common/src/models/export/folderWithIdExport.ts
+++ b/common/src/models/export/folderWithIdExport.ts
@@ -1,9 +1,9 @@
 import { Folder as FolderDomain } from "../domain/folder";
 import { FolderView } from "../view/folderView";
 
-import { Folder } from "./folder";
+import { FolderExport } from "./folderExport";
 
-export class FolderWithId extends Folder {
+export class FolderWithIdExport extends FolderExport {
   id: string;
 
   // Use build method instead of ctor so that we can control order of JSON stringify for pretty print

--- a/common/src/models/export/identityExport.ts
+++ b/common/src/models/export/identityExport.ts
@@ -2,9 +2,9 @@ import { EncString } from "../domain/encString";
 import { Identity as IdentityDomain } from "../domain/identity";
 import { IdentityView } from "../view/identityView";
 
-export class Identity {
-  static template(): Identity {
-    const req = new Identity();
+export class IdentityExport {
+  static template(): IdentityExport {
+    const req = new IdentityExport();
     req.title = "Mr";
     req.firstName = "John";
     req.middleName = "William";
@@ -26,7 +26,7 @@ export class Identity {
     return req;
   }
 
-  static toView(req: Identity, view = new IdentityView()) {
+  static toView(req: IdentityExport, view = new IdentityView()) {
     view.title = req.title;
     view.firstName = req.firstName;
     view.middleName = req.middleName;
@@ -48,7 +48,7 @@ export class Identity {
     return view;
   }
 
-  static toDomain(req: Identity, domain = new IdentityDomain()) {
+  static toDomain(req: IdentityExport, domain = new IdentityDomain()) {
     domain.title = req.title != null ? new EncString(req.title) : null;
     domain.firstName = req.firstName != null ? new EncString(req.firstName) : null;
     domain.middleName = req.middleName != null ? new EncString(req.middleName) : null;

--- a/common/src/models/export/loginExport.ts
+++ b/common/src/models/export/loginExport.ts
@@ -2,11 +2,11 @@ import { EncString } from "../domain/encString";
 import { Login as LoginDomain } from "../domain/login";
 import { LoginView } from "../view/loginView";
 
-import { LoginUri } from "./loginUri";
+import { LoginUriExport } from "./loginUriExport";
 
-export class Login {
-  static template(): Login {
-    const req = new Login();
+export class LoginExport {
+  static template(): LoginExport {
+    const req = new LoginExport();
     req.uris = [];
     req.username = "jdoe";
     req.password = "myp@ssword123";
@@ -14,9 +14,9 @@ export class Login {
     return req;
   }
 
-  static toView(req: Login, view = new LoginView()) {
+  static toView(req: LoginExport, view = new LoginView()) {
     if (req.uris != null) {
-      view.uris = req.uris.map((u) => LoginUri.toView(u));
+      view.uris = req.uris.map((u) => LoginUriExport.toView(u));
     }
     view.username = req.username;
     view.password = req.password;
@@ -24,9 +24,9 @@ export class Login {
     return view;
   }
 
-  static toDomain(req: Login, domain = new LoginDomain()) {
+  static toDomain(req: LoginExport, domain = new LoginDomain()) {
     if (req.uris != null) {
-      domain.uris = req.uris.map((u) => LoginUri.toDomain(u));
+      domain.uris = req.uris.map((u) => LoginUriExport.toDomain(u));
     }
     domain.username = req.username != null ? new EncString(req.username) : null;
     domain.password = req.password != null ? new EncString(req.password) : null;
@@ -34,7 +34,7 @@ export class Login {
     return domain;
   }
 
-  uris: LoginUri[];
+  uris: LoginUriExport[];
   username: string;
   password: string;
   totp: string;
@@ -46,9 +46,9 @@ export class Login {
 
     if (o.uris != null) {
       if (o instanceof LoginView) {
-        this.uris = o.uris.map((u) => new LoginUri(u));
+        this.uris = o.uris.map((u) => new LoginUriExport(u));
       } else {
-        this.uris = o.uris.map((u) => new LoginUri(u));
+        this.uris = o.uris.map((u) => new LoginUriExport(u));
       }
     }
 

--- a/common/src/models/export/loginUriExport.ts
+++ b/common/src/models/export/loginUriExport.ts
@@ -3,21 +3,21 @@ import { EncString } from "../domain/encString";
 import { LoginUri as LoginUriDomain } from "../domain/loginUri";
 import { LoginUriView } from "../view/loginUriView";
 
-export class LoginUri {
-  static template(): LoginUri {
-    const req = new LoginUri();
+export class LoginUriExport {
+  static template(): LoginUriExport {
+    const req = new LoginUriExport();
     req.uri = "https://google.com";
     req.match = null;
     return req;
   }
 
-  static toView(req: LoginUri, view = new LoginUriView()) {
+  static toView(req: LoginUriExport, view = new LoginUriView()) {
     view.uri = req.uri;
     view.match = req.match;
     return view;
   }
 
-  static toDomain(req: LoginUri, domain = new LoginUriDomain()) {
+  static toDomain(req: LoginUriExport, domain = new LoginUriDomain()) {
     domain.uri = req.uri != null ? new EncString(req.uri) : null;
     domain.match = req.match;
     return domain;

--- a/common/src/models/export/secureNoteExport.ts
+++ b/common/src/models/export/secureNoteExport.ts
@@ -2,19 +2,19 @@ import { SecureNoteType } from "../../enums/secureNoteType";
 import { SecureNote as SecureNoteDomain } from "../domain/secureNote";
 import { SecureNoteView } from "../view/secureNoteView";
 
-export class SecureNote {
-  static template(): SecureNote {
-    const req = new SecureNote();
+export class SecureNoteExport {
+  static template(): SecureNoteExport {
+    const req = new SecureNoteExport();
     req.type = SecureNoteType.Generic;
     return req;
   }
 
-  static toView(req: SecureNote, view = new SecureNoteView()) {
+  static toView(req: SecureNoteExport, view = new SecureNoteView()) {
     view.type = req.type;
     return view;
   }
 
-  static toDomain(req: SecureNote, view = new SecureNoteDomain()) {
+  static toDomain(req: SecureNoteExport, view = new SecureNoteDomain()) {
     view.type = req.type;
     return view;
   }

--- a/common/src/services/export.service.ts
+++ b/common/src/services/export.service.ts
@@ -17,10 +17,10 @@ import { CollectionData } from "../models/data/collectionData";
 import { Cipher } from "../models/domain/cipher";
 import { Collection } from "../models/domain/collection";
 import { Folder } from "../models/domain/folder";
-import { CipherWithIds as CipherExport } from "../models/export/cipherWithIds";
-import { CollectionWithId as CollectionExport } from "../models/export/collectionWithId";
-import { Event } from "../models/export/event";
-import { FolderWithId as FolderExport } from "../models/export/folderWithId";
+import { CipherWithIdExport as CipherExport } from "../models/export/cipherWithIdsExport";
+import { CollectionWithIdExport as CollectionExport } from "../models/export/collectionWithIdExport";
+import { EventExport } from "../models/export/eventExport";
+import { FolderWithIdExport as FolderExport } from "../models/export/folderWithIdExport";
 import { CollectionDetailsResponse } from "../models/response/collectionResponse";
 import { CipherView } from "../models/view/cipherView";
 import { CollectionView } from "../models/view/collectionView";
@@ -90,7 +90,7 @@ export class ExportService implements ExportServiceAbstraction {
   }
 
   async getEventExport(events: EventView[]): Promise<string> {
-    return papa.unparse(events.map((e) => new Event(e)));
+    return papa.unparse(events.map((e) => new EventExport(e)));
   }
 
   getFileName(prefix: string = null, extension = "csv"): string {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We currently have two sets of DTOs named identical, `domain` and `export`. To avoid confusion this PR adds a `Export` suffix to the export DTOs.

EC-147

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Verify the export and the bitwarden json importer still works.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
