### PR TITLE
copy generator default options by value

### DIFF
--- a/common/src/services/passwordGeneration.service.ts
+++ b/common/src/services/passwordGeneration.service.ts
@@ -180,7 +180,7 @@ export class PasswordGenerationService implements PasswordGenerationServiceAbstr
   async getOptions(): Promise<[any, PasswordGeneratorPolicyOptions]> {
     let options = await this.stateService.getPasswordGenerationOptions();
     if (options == null) {
-      options = DefaultOptions;
+      options = Object.assign({}, DefaultOptions);
     } else {
       options = Object.assign({}, DefaultOptions, options);
     }

--- a/common/src/services/usernameGeneration.service.ts
+++ b/common/src/services/usernameGeneration.service.ts
@@ -97,7 +97,7 @@ export class UsernameGenerationService implements BaseUsernameGenerationService 
   async getOptions(): Promise<any> {
     let options = await this.stateService.getUsernameGenerationOptions();
     if (options == null) {
-      options = DefaultOptions;
+      options = Object.assign({}, DefaultOptions);
     } else {
       options = Object.assign({}, DefaultOptions, options);
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Generation services have a DefaultOptions object that was getting set by reference. This caused any changes made to the options later on to alter DefaultOptions itself. Future assignments of DefaultOptions would then have those values.

Resolve https://app.asana.com/0/1153292148278596/1202089012747649

## Code changes

Changed DefaultOptions assignment to copy by value in username and password generation services.

## Testing requirements

Re-test steps in https://app.asana.com/0/1153292148278596/1202089012747649

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
