### PR TITLE
[end user vault refresh] [bug] Add missing null check in vault filters

### DIFF
--- a/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -89,7 +89,7 @@ export class VaultFilterComponent implements OnInit {
   }
 
   protected pruneInvalidFolderSelection(filter: VaultFilter): VaultFilter {
-    if (filter.selectedFolder && !this.folders.hasId(filter.selectedFolderId)) {
+    if (filter.selectedFolder && !this.folders?.hasId(filter.selectedFolderId)) {
       filter.selectedFolder = false;
       filter.selectedFolderId = null;
     }
@@ -99,7 +99,7 @@ export class VaultFilterComponent implements OnInit {
   protected pruneInvalidCollectionSelection(filter: VaultFilter): VaultFilter {
     if (
       filter.selectedCollectionId != null &&
-      !this.collections.hasId(filter.selectedCollectionId)
+      !this.collections?.hasId(filter.selectedCollectionId)
     ) {
       filter.selectedCollectionId = null;
     }


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/SG-203?atlOrigin=eyJpIjoiYjAyM2NhODc2YWEyNDdhMjlmZTJjN2ExM2ZhNzE0ZGIiLCJwIjoiaiJ9

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Sometimes changing an organization filter involves resetting the filter modifier because the current one is not relevant to the new organization filter. One example of this is if a collection is selected, as changing an organization filter will always invalidate a selected collection. We are missing a null check when we check this to prune the filter, resulting in filter changes sometimes not being applied and console errors.

This commit adds a null check when correcting a requested filter change.