### PR TITLE
CSA-2 SSO user interaction token

### DIFF
--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -86,10 +86,10 @@ export class SsoComponent {
 
   async submit(returnUri?: string, includeUserIdentifier?: boolean) {
     this.initiateSsoFormPromise = this.preValidate();
-    if (await this.initiateSsoFormPromise) {
-      const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier);
-      this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
-    }
+    const token = await this.initiateSsoFormPromise;
+
+    const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier, token);
+    this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
   }
 
   async preValidate(): Promise<boolean> {
@@ -106,7 +106,8 @@ export class SsoComponent {
 
   protected async buildAuthorizeUrl(
     returnUri?: string,
-    includeUserIdentifier?: boolean
+    includeUserIdentifier?: boolean,
+    token?: string
   ): Promise<string> {
     let codeChallenge = this.codeChallenge;
     let state = this.state;
@@ -156,7 +157,8 @@ export class SsoComponent {
       "&" +
       "code_challenge_method=S256&response_mode=query&" +
       "domain_hint=" +
-      encodeURIComponent(this.identifier);
+      encodeURIComponent(this.identifier) +
+      "&ssoToken=" + token;
 
     if (includeUserIdentifier) {
       const userIdentifier = await this.apiService.getSsoUserIdentifier();

--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -14,6 +14,7 @@ import { StateService } from "jslib-common/abstractions/state.service";
 import { Utils } from "jslib-common/misc/utils";
 import { AuthResult } from "jslib-common/models/domain/authResult";
 import { SsoLogInCredentials } from "jslib-common/models/domain/logInCredentials";
+import { SsoPreValidateResponse } from "jslib-common/models/response/ssoPreValidateResponse";
 
 @Directive()
 export class SsoComponent {
@@ -21,7 +22,7 @@ export class SsoComponent {
   loggingIn = false;
 
   formPromise: Promise<AuthResult>;
-  initiateSsoFormPromise: Promise<any>;
+  initiateSsoFormPromise: Promise<SsoPreValidateResponse>;
   onSuccessfulLogin: () => Promise<any>;
   onSuccessfulLoginNavigate: () => Promise<any>;
   onSuccessfulLoginTwoFactorNavigate: () => Promise<any>;
@@ -85,23 +86,24 @@ export class SsoComponent {
   }
 
   async submit(returnUri?: string, includeUserIdentifier?: boolean) {
-    this.initiateSsoFormPromise = this.preValidate();
-    const token = await this.initiateSsoFormPromise;
-
-    const authorizeUrl = await this.buildAuthorizeUrl(returnUri, includeUserIdentifier, token);
-    this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
-  }
-
-  async preValidate(): Promise<boolean> {
     if (this.identifier == null || this.identifier === "") {
       this.platformUtilsService.showToast(
         "error",
         this.i18nService.t("ssoValidationFailed"),
         this.i18nService.t("ssoIdentifierRequired")
       );
-      return false;
+      return;
     }
-    return await this.apiService.preValidateSso(this.identifier);
+
+    this.initiateSsoFormPromise = this.apiService.preValidateSso(this.identifier);
+    const response = await this.initiateSsoFormPromise;
+
+    const authorizeUrl = await this.buildAuthorizeUrl(
+      returnUri,
+      includeUserIdentifier,
+      response.token
+    );
+    this.platformUtilsService.launchUri(authorizeUrl, { sameWindow: true });
   }
 
   protected async buildAuthorizeUrl(
@@ -158,7 +160,8 @@ export class SsoComponent {
       "code_challenge_method=S256&response_mode=query&" +
       "domain_hint=" +
       encodeURIComponent(this.identifier) +
-      "&ssoToken=" + token;
+      "&ssoToken=" +
+      encodeURIComponent(token);
 
     if (includeUserIdentifier) {
       const userIdentifier = await this.apiService.getSsoUserIdentifier();

--- a/common/src/abstractions/api.service.ts
+++ b/common/src/abstractions/api.service.ts
@@ -6,6 +6,7 @@ import {
   OrganizationConnectionConfigApis,
   OrganizationConnectionResponse,
 } from "jslib-common/models/response/organizationConnectionResponse";
+import { SsoPreValidateResponse } from "jslib-common/models/response/ssoPreValidateResponse";
 
 import { PolicyType } from "../enums/policyType";
 import { SetKeyConnectorKeyRequest } from "../models/request/account/setKeyConnectorKeyRequest";
@@ -688,7 +689,7 @@ export abstract class ApiService {
   fetch: (request: Request) => Promise<Response>;
   nativeFetch: (request: Request) => Promise<Response>;
 
-  preValidateSso: (identifier: string) => Promise<boolean>;
+  preValidateSso: (identifier: string) => Promise<SsoPreValidateResponse>;
 
   postCreateSponsorship: (
     sponsorshipOrgId: string,

--- a/common/src/models/response/ssoPreValidateResponse.ts
+++ b/common/src/models/response/ssoPreValidateResponse.ts
@@ -1,0 +1,10 @@
+import { BaseResponse } from "./baseResponse";
+
+export class SsoPreValidateResponse extends BaseResponse {
+  token: string;
+
+  constructor(response: any) {
+    super(response);
+    this.token = this.getResponseProperty("Token");
+  }
+}

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -9,6 +9,7 @@ import {
   OrganizationConnectionConfigApis,
   OrganizationConnectionResponse,
 } from "jslib-common/models/response/organizationConnectionResponse";
+import { SsoPreValidateResponse } from "jslib-common/models/response/ssoPreValidateResponse";
 
 import { ApiService as ApiServiceAbstraction } from "../abstractions/api.service";
 import { EnvironmentService } from "../abstractions/environment.service";
@@ -2295,7 +2296,7 @@ export class ApiService implements ApiServiceAbstraction {
     return fetch(request);
   }
 
-  async preValidateSso(identifier: string): Promise<boolean> {
+  async preValidateSso(identifier: string): Promise<SsoPreValidateResponse> {
     if (identifier == null || identifier === "") {
       throw new Error("Organization Identifier was not provided.");
     }
@@ -2319,6 +2320,7 @@ export class ApiService implements ApiServiceAbstraction {
 
     if (response.status === 200) {
       const body = await response.json();
+      return new SsoPreValidateResponse(body);
       return body.token;
     } else {
       const error = await this.handleError(response, false, true);

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -2318,7 +2318,8 @@ export class ApiService implements ApiServiceAbstraction {
     );
 
     if (response.status === 200) {
-      return true;
+      const body = await response.json();
+      return body.token;
     } else {
       const error = await this.handleError(response, false, true);
       return Promise.reject(error);

--- a/common/src/services/api.service.ts
+++ b/common/src/services/api.service.ts
@@ -2321,7 +2321,6 @@ export class ApiService implements ApiServiceAbstraction {
     if (response.status === 200) {
       const body = await response.json();
       return new SsoPreValidateResponse(body);
-      return body.token;
     } else {
       const error = await this.handleError(response, false, true);
       return Promise.reject(error);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Handles token returned during `PreValidate()` call to pass back to `Login()` method on server - used to ensure the SSO redirect request was initiated by the user. Also handles adding user's hashed master password for validation during password reset enrollment (CSA-1 and CSA-2).

## Code changes

- **sso.component.ts:** Extract token from `PreValidate()` response and add to `Login()` request
- **organizationUserResetPasswordEnrollmentRequest.ts:** Extending password enrollment model to add hashed user master password.
- **api.service.ts:** Adding handling of returned token from `PreValidate()` call.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
