### PR TITLE
[PS-106] Stop clearing cipher list on every reload

### DIFF
--- a/angular/src/components/ciphers.component.ts
+++ b/angular/src/components/ciphers.component.ts
@@ -32,7 +32,6 @@ export class CiphersComponent {
 
   async reload(filter: (cipher: CipherView) => boolean = null, deleted = false) {
     this.loaded = false;
-    this.ciphers = [];
     await this.load(filter, deleted);
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Our list of ciphers in the vault is cleared and rebuilt after every save, delete, or refresh. Because of this, the desktop implementation isn't able to retain the scroll position after any change and will go back up to the top. This change stops us from pre-clearing the list. Instead we only reset it once.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
- **angular/src/components/ciphers.component.ts:** Stop from clearing the list of ciphers early

## Screenshots

https://user-images.githubusercontent.com/24985544/165768818-b8150504-ff46-4b7a-8ed1-1ed88ee4d121.mov


https://user-images.githubusercontent.com/24985544/165768843-e8753d2d-b86d-4381-ab54-34f3c28433c3.mov



## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Testing should be extensive over the desktop and web list of ciphers. I didn't find any side effects on web, but there's the possibility that the list was cleared early intentionally.
Make sure the list updates and retains scrolling information on desktop when:
- Saving an item
- Deleting an item
- Editing an item
Web should also have further testing for:
- bulk operations
Both platforms should also be tested for empty list appearance and operations

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
