### PR TITLE
fix default forwardedService property name

### DIFF
--- a/common/src/services/usernameGeneration.service.ts
+++ b/common/src/services/usernameGeneration.service.ts
@@ -10,7 +10,7 @@ const DefaultOptions = {
   wordIncludeNumber: true,
   subaddressType: "random",
   catchallType: "random",
-  forwardedType: "simplelogin",
+  forwardedService: "simplelogin",
   forwardedAnonAddyDomain: "anonaddy.me",
 };
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix default username generation options so that simplelogin is the default selection when not having used the feature before.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **username generation service:** Change property name to what is actually used in implementation.

## Testing requirements

Make sure simplelogin is default selection for forwarded email service.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
