### PR TITLE
[SG-234] Add alt2 text color

### DIFF
--- a/components/src/stories/colors.stories.mdx
+++ b/components/src/stories/colors.stories.mdx
@@ -53,6 +53,7 @@ export const Table = (args) => (
       {Row("text-main")}
       {Row("text-muted")}
       {Row("text-contrast")}
+      {Row("text-alt2")}
     </tbody>
   </table>
 );

--- a/components/src/tw-theme.css
+++ b/components/src/tw-theme.css
@@ -27,6 +27,7 @@
   --color-text-main: #212529;
   --color-text-muted: #6d757e;
   --color-text-contrast: #ffffff;
+  --color-text-alt2: #ffffff;
 
   --tw-ring-offset-color: #fff;
 }
@@ -64,6 +65,7 @@
   --color-text-main: #ffffff;
   --color-text-muted: #bac0ce;
   --color-text-contrast: #191e26;
+  --color-text-alt2: #ffffff;
 
   --tw-ring-offset-color: #1f242e;
 }

--- a/components/tailwind.config.base.js
+++ b/components/tailwind.config.base.js
@@ -41,6 +41,7 @@ module.exports = {
         main: "var(--color-text-main)",
         muted: "var(--color-text-muted)",
         contrast: "var(--color-text-contrast)",
+        alt2: "var(--color-text-alt2)",
       },
       background: {
         DEFAULT: "var(--color-background)",
@@ -52,6 +53,7 @@ module.exports = {
       main: "var(--color-text-main)",
       muted: "var(--color-text-muted)",
       contrast: "var(--color-text-contrast)",
+      alt2: "var(--color-text-alt2)",
       success: "var(--color-success-500)",
       danger: "var(--color-danger-500)",
       warning: "var(--color-warning-500)",


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add the text color alt2 as contrast option to background alt2.

Note: Will be cherry picked to `rc`.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
