### PR TITLE
[SG-245] “All Items” and “Trash” missing from Organization Vault

### DIFF
--- a/angular/src/modules/vault-filter/components/status-filter.component.ts
+++ b/angular/src/modules/vault-filter/components/status-filter.component.ts
@@ -11,7 +11,7 @@ export class StatusFilterComponent {
   @Input() activeFilter: VaultFilter;
 
   get show() {
-    return !this.hideFavorites && !this.hideTrash;
+    return !(this.hideFavorites && this.hideTrash);
   }
 
   applyFilter(cipherStatus: CipherStatus) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix condition to only hide status filters if both favorites and trash are hidden. 

## Code changes

- **angular/src/modules/vault-filter/components/status-filter.component.ts:** Fix show() condition

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
