### PR TITLE
[fix] Expose collection filter init function for client override

### DIFF
--- a/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -46,8 +46,13 @@ export class VaultFilterComponent implements OnInit {
         await this.vaultFilterService.checkForSingleOrganizationPolicy();
     }
     this.folders = await this.vaultFilterService.buildFolders();
-    this.collections = await this.vaultFilterService.buildCollections();
+    this.collections = await this.initCollections();
     this.isLoaded = true;
+  }
+
+  // overwritten in web for organization vaults
+  async initCollections() {
+    return await this.vaultFilterService.buildCollections();
   }
 
   async toggleFilterNodeCollapseState(node: ITreeNodeObject) {


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-239

This will need to be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When loading the organization vault page initially all collections are displayed as filters instead of just the collections for the selected organization. This only happens on init, and toggling orgs creates the correct filters.

This is happening because the collection init logic is in jslib's `VaultFiltersComponent.ngOnInit()`, and the concept of an organization vault screen only exists in web. The collection init call needs to be exposed to web's `VaultFiltersComponent` to override it and pass in the organization for that condition. 

## Code changes
Extract the collection init logic into a function that can be overwritten in the web vault's organization vault

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
