### PR TITLE
[fix] Move web's VaultFiltersComponent.reloadOrganizations() method to jslib

### DIFF
--- a/angular/src/modules/vault-filter/vault-filter.component.ts
+++ b/angular/src/modules/vault-filter/vault-filter.component.ts
@@ -79,6 +79,14 @@ export class VaultFilterComponent implements OnInit {
       : await this.vaultFilterService.buildCollections(filter.selectedOrganizationId);
   }
 
+  async reloadOrganizations() {
+    this.organizations = await this.vaultFilterService.buildOrganizations();
+    this.activePersonalOwnershipPolicy =
+      await this.vaultFilterService.checkForPersonalOwnershipPolicy();
+    this.activeSingleOrganizationPolicy =
+      await this.vaultFilterService.checkForSingleOrganizationPolicy();
+  }
+
   addFolder() {
     this.onAddFolder.emit();
   }


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-333
This will be cherry-picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
An issue that has been encountered in the web vault for the new organization filters in the filters bar is that they are sometimes hidden on initial login, because a sync didn't complete in time to create the filter component. 

This bug has also been found in desktop, and so the method that handles this in web's `VaultFiltersComponent` is being pulled back to jslib.
## Code changes
The ideal way to do this would be to be able to subscribe to organizations and have the object update on sync, but for now this is a manual process following a pattern set by collections.

The function has been moved to jslib as-is from web.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
