### PR TITLE
[PS-136] stripped off accented characters from search field for browser client

### DIFF
--- a/angular/src/components/ciphers.component.ts
+++ b/angular/src/components/ciphers.component.ts
@@ -77,14 +77,19 @@ export class CiphersComponent {
   }
 
   isSearching() {
-    return !this.searchPending && this.searchService.isSearchable(this.searchText);
+    return (
+      !this.searchPending &&
+      this.searchService.isSearchable(
+        this.searchText?.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+      )
+    );
   }
 
   protected deletedFilter: (cipher: CipherView) => boolean = (c) => c.isDeleted === this.deleted;
 
   protected async doSearch(indexedCiphers?: CipherView[]) {
     this.ciphers = await this.searchService.searchCiphers(
-      this.searchText,
+      this.searchText?.normalize("NFD").replace(/[\u0300-\u036f]/g, ""),
       [this.filter, this.deletedFilter],
       indexedCiphers
     );

--- a/angular/src/components/ciphers.component.ts
+++ b/angular/src/components/ciphers.component.ts
@@ -77,19 +77,14 @@ export class CiphersComponent {
   }
 
   isSearching() {
-    return (
-      !this.searchPending &&
-      this.searchService.isSearchable(
-        this.searchText?.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
-      )
-    );
+    return !this.searchPending && this.searchService.isSearchable(this.searchText);
   }
 
   protected deletedFilter: (cipher: CipherView) => boolean = (c) => c.isDeleted === this.deleted;
 
   protected async doSearch(indexedCiphers?: CipherView[]) {
     this.ciphers = await this.searchService.searchCiphers(
-      this.searchText?.normalize("NFD").replace(/[\u0300-\u036f]/g, ""),
+      this.searchText,
       [this.filter, this.deletedFilter],
       indexedCiphers
     );

--- a/common/src/services/search.service.ts
+++ b/common/src/services/search.service.ts
@@ -34,6 +34,7 @@ export class SearchService implements SearchServiceAbstraction {
   }
 
   isSearchable(query: string): boolean {
+    query = this.normalizeSearchQuery(query);
     const notSearchable =
       query == null ||
       (this.index == null && query.length < this.searchableMinLength) ||
@@ -97,7 +98,7 @@ export class SearchService implements SearchServiceAbstraction {
   ): Promise<CipherView[]> {
     const results: CipherView[] = [];
     if (query != null) {
-      query = query.trim().toLowerCase();
+      query = this.normalizeSearchQuery(query.trim().toLowerCase());
     }
     if (query === "") {
       query = null;
@@ -165,7 +166,7 @@ export class SearchService implements SearchServiceAbstraction {
   }
 
   searchCiphersBasic(ciphers: CipherView[], query: string, deleted = false) {
-    query = query.trim().toLowerCase();
+    query = this.normalizeSearchQuery(query.trim().toLowerCase());
     return ciphers.filter((c) => {
       if (deleted !== c.isDeleted) {
         return false;
@@ -187,7 +188,7 @@ export class SearchService implements SearchServiceAbstraction {
   }
 
   searchSends(sends: SendView[], query: string) {
-    query = query.trim().toLocaleLowerCase();
+    query = this.normalizeSearchQuery(query.trim().toLocaleLowerCase());
 
     return sends.filter((s) => {
       if (s.name != null && s.name.toLowerCase().indexOf(query) > -1) {
@@ -293,12 +294,13 @@ export class SearchService implements SearchServiceAbstraction {
     const checkFields = fields.every((i: any) => searchableFields.includes(i));
 
     if (checkFields) {
-      return token
-        .toString()
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "");
+      return this.normalizeSearchQuery(token.toString());
     }
 
     return token;
+  }
+
+  private normalizeSearchQuery(query: string): string {
+    return query?.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   }
 }

--- a/common/src/services/search.service.ts
+++ b/common/src/services/search.service.ts
@@ -301,6 +301,7 @@ export class SearchService implements SearchServiceAbstraction {
     return token;
   }
 
+  //Normalize diacritics characters from text
   private normalizeSearchQuery(query: string): string {
     return query?.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   }

--- a/common/src/services/search.service.ts
+++ b/common/src/services/search.service.ts
@@ -301,7 +301,7 @@ export class SearchService implements SearchServiceAbstraction {
     return token;
   }
 
-  //Normalize diacritics characters from text
+  // Remove accents/diacritics characters from text. This regex is equivalent to the Diacritic unicode property escape, i.e. it will match all diacritic characters.
   private normalizeSearchQuery(query: string): string {
     return query?.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   }

--- a/common/src/services/search.service.ts
+++ b/common/src/services/search.service.ts
@@ -188,7 +188,7 @@ export class SearchService implements SearchServiceAbstraction {
   }
 
   searchSends(sends: SendView[], query: string) {
-    query = query.trim().toLocaleLowerCase();
+    query = this.normalizeSearchQuery(query.trim().toLocaleLowerCase());
     if (query === null) {
       return sends;
     }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
- Replicate same functionality of being able to search for texts with accented characters using normal texts. 

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes
- **angular/src/components/ciphers.component.ts:** Added `normalize("NFD").replace(/[\u0300-\u036f]/g, "")` to the `searchText` variable to strip off accent from a character. 

- This PR is related to https://github.com/bitwarden/web/pull/1690 and https://github.com/bitwarden/jslib/pull/804


<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
