### PR TITLE
[PS-153] upgrade premium on refresh

### DIFF
--- a/common/src/abstractions/state.service.ts
+++ b/common/src/abstractions/state.service.ts
@@ -58,6 +58,7 @@ export abstract class StateService<T extends Account = Account> {
   getBiometricUnlock: (options?: StorageOptions) => Promise<boolean>;
   setBiometricUnlock: (value: boolean, options?: StorageOptions) => Promise<void>;
   getCanAccessPremium: (options?: StorageOptions) => Promise<boolean>;
+  setCanAccessPremium: (value: boolean, options?: StorageOptions) => Promise<void>;
   getClearClipboard: (options?: StorageOptions) => Promise<number>;
   setClearClipboard: (value: number, options?: StorageOptions) => Promise<void>;
   getCollapsedGroupings: (options?: StorageOptions) => Promise<string[]>;

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -359,6 +359,17 @@ export class StateService<
     return false;
   }
 
+  async setCanAccessPremium(value: boolean, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    );
+    account.profile.hasPremiumPersonally = value;
+    await this.saveAccount(
+      account, 
+      this.reconcileOptions(options, await this.defaultOnDiskOptions())
+    )
+  }
+
   async getClearClipboard(options?: StorageOptions): Promise<number> {
     return (
       (

--- a/common/src/services/state.service.ts
+++ b/common/src/services/state.service.ts
@@ -365,9 +365,9 @@ export class StateService<
     );
     account.profile.hasPremiumPersonally = value;
     await this.saveAccount(
-      account, 
+      account,
       this.reconcileOptions(options, await this.defaultOnDiskOptions())
-    )
+    );
   }
 
   async getClearClipboard(options?: StorageOptions): Promise<number> {

--- a/common/src/services/sync.service.ts
+++ b/common/src/services/sync.service.ts
@@ -304,6 +304,7 @@ export class SyncService implements SyncServiceAbstraction {
     await this.cryptoService.setOrgKeys(response.organizations, response.providerOrganizations);
     await this.stateService.setSecurityStamp(response.securityStamp);
     await this.stateService.setEmailVerified(response.emailVerified);
+    await this.stateService.setCanAccessPremium(response.premium);
     await this.stateService.setForcePasswordReset(response.forcePasswordReset);
     await this.keyConnectorService.setUsesKeyConnector(response.usesKeyConnector);
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Grant access to premium features immediately after upgrade without having to log out.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes
- **common/src/abstractions/state.service.ts:** abstract method `setCanAccessPremium` added.
- **common/src/services/state.service.ts:** implementation of the abstract method `setCanAccessPremium` with sets the current state of `hasPremiumPersonally` property when premium has been activated.
- **common/src/services/sync.service.ts:** calls the `setCanAccessPremium` method which syncs and sets the current state of `hasPremiumPersonally` property.

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


https://user-images.githubusercontent.com/13024008/169881648-b03aa6c3-baab-4f58-a036-0973668e1fe0.mov



## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
