### PR TITLE
[EC-178] Logout on Key Connector error

### DIFF
--- a/angular/src/components/sso.component.ts
+++ b/angular/src/components/sso.component.ts
@@ -218,11 +218,13 @@ export class SsoComponent {
       }
     } catch (e) {
       this.logService.error(e);
-      if (e.message === "Unable to reach key connector") {
+
+      // TODO: Key Connector Service should pass this error message to the logout callback instead of displaying here
+      if (e.message === "Key Connector error") {
         this.platformUtilsService.showToast(
           "error",
           null,
-          this.i18nService.t("ssoKeyConnectorUnavailable")
+          this.i18nService.t("ssoKeyConnectorError")
         );
       }
     }

--- a/angular/src/services/jslib-services.module.ts
+++ b/angular/src/services/jslib-services.module.ts
@@ -399,6 +399,7 @@ export const SYSTEM_LANGUAGE = new InjectionToken<string>("SYSTEM_LANGUAGE");
         LogService,
         OrganizationServiceAbstraction,
         CryptoFunctionServiceAbstraction,
+        LOGOUT_CALLBACK
       ],
     },
     {

--- a/angular/src/services/jslib-services.module.ts
+++ b/angular/src/services/jslib-services.module.ts
@@ -399,7 +399,7 @@ export const SYSTEM_LANGUAGE = new InjectionToken<string>("SYSTEM_LANGUAGE");
         LogService,
         OrganizationServiceAbstraction,
         CryptoFunctionServiceAbstraction,
-        LOGOUT_CALLBACK
+        LOGOUT_CALLBACK,
       ],
     },
     {

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -22,7 +22,8 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     private tokenService: TokenService,
     private logService: LogService,
     private organizationService: OrganizationService,
-    private cryptoFunctionService: CryptoFunctionService
+    private cryptoFunctionService: CryptoFunctionService,
+    private logoutCallback: (expired: boolean, userId?: string) => void
   ) {}
 
   setUsesKeyConnector(usesKeyConnector: boolean) {
@@ -52,7 +53,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
         keyConnectorRequest
       );
     } catch (e) {
-      throw new Error("Unable to reach key connector");
+      this.handleKeyConnectorError(e);
     }
 
     await this.apiService.postConvertToKeyConnector();
@@ -65,8 +66,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
       const k = new SymmetricCryptoKey(keyArr);
       await this.cryptoService.setKey(k);
     } catch (e) {
-      this.logService.error(e);
-      throw new Error("Unable to reach key connector");
+      this.handleKeyConnectorError(e);
     }
   }
 
@@ -102,7 +102,7 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     try {
       await this.apiService.postUserKeyToKeyConnector(keyConnectorUrl, keyConnectorRequest);
     } catch (e) {
-      throw new Error("Unable to reach key connector");
+      this.handleKeyConnectorError(e);
     }
 
     const keys = new KeysRequest(pubKey, privKey.encryptedString);
@@ -130,5 +130,13 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
 
   async clear() {
     await this.removeConvertAccountRequired();
+  }
+
+  private handleKeyConnectorError(e: any) {
+    this.logService.error(e);
+    if (this.logoutCallback != null) {
+      this.logoutCallback(false);
+    }
+    throw new Error('Key Connector error');
   }
 }

--- a/common/src/services/keyConnector.service.ts
+++ b/common/src/services/keyConnector.service.ts
@@ -137,6 +137,6 @@ export class KeyConnectorService implements KeyConnectorServiceAbstraction {
     if (this.logoutCallback != null) {
       this.logoutCallback(false);
     }
-    throw new Error('Key Connector error');
+    throw new Error("Key Connector error");
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Related to https://github.com/bitwarden/key-connector/pull/16.

If there is any error with Key Connector (including contacting Key Connector or an unhandled server error), the user remains logged in. This presents them with a lock screen or their vault, depending on the flow. Because they have a token and a locally generated user key, they can even create new ciphers etc.

I propose that if there is any error with Key Connector onboarding or fetching user keys, this is most likely unrecoverable and we should just log the user out.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **common/src/services/keyConnector.service.ts** - add common error handling code - log the actual error to console, then log the user out and throw a custom error message for the toast.
- **angular/src/services/jslib-services.module.ts** - update dependencies
- **angular/src/components/sso.component.ts** - minor change to add TODO and update the error string. Instead of "Unable to reach Key Connector", we'll use a more generic "Key Connector error. Make sure Key Connector is available and working correctly." so that we're not misleading the user about the nature of the error.

Video of the error flow:

https://user-images.githubusercontent.com/31796059/170176356-ecb44e92-90c0-4d11-b591-6f181299ab2b.mov

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
